### PR TITLE
Get MPI_INFO_NULL from eckit

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -200,7 +200,7 @@ if( HAVE_ECKIT_CMD)
   list( APPEND ECKIT_LIBRARIES eckit_cmd )
 endif()
 
-if( HAVE_ECKIT_MPI )
+if( HAVE_MPI )
   list( APPEND ECKIT_LIBRARIES eckit_mpi )
 endif()
 

--- a/src/eckit/container/kdtree/KDNode.h
+++ b/src/eckit/container/kdtree/KDNode.h
@@ -45,6 +45,8 @@ public:
 
     static KDNode<Traits>* insert(Alloc& a, const Value& value, KDNode<Traits>* node, int depth = 0);
 
+    /// Return the axis along which this node is split.
+    size_t axis() const { return axis_; }
 
 public:
     void nearestNeighbourX(Alloc& a,const Point& p, Node*& best, double& max, int depth);

--- a/src/eckit/mpi/Comm.h
+++ b/src/eckit/mpi/Comm.h
@@ -110,6 +110,8 @@ public:  // methods
 
     virtual int anyTag() const = 0;
 
+    virtual int infoNull() const = 0;
+
     virtual Status status() const = 0;
 
     virtual Request request(int) const = 0;

--- a/src/eckit/mpi/Parallel.cc
+++ b/src/eckit/mpi/Parallel.cc
@@ -327,6 +327,10 @@ int Parallel::anyTag() const {
     return MPI_ANY_TAG;
 }
 
+int Parallel::infoNull() const {
+    return MPI_Info_c2f(MPI_INFO_NULL);
+}
+
 size_t Parallel::getCount(Status& st, Data::Code type) const {
     int count = 0;
 

--- a/src/eckit/mpi/Parallel.h
+++ b/src/eckit/mpi/Parallel.h
@@ -57,6 +57,8 @@ protected:  // methods
 
     virtual int anyTag() const;
 
+    virtual int infoNull() const;
+
     virtual size_t getCount(Status& st, Data::Code type) const;
 
     virtual void broadcast(void* buffer, size_t count, Data::Code type, size_t root) const;

--- a/src/eckit/mpi/Serial.cc
+++ b/src/eckit/mpi/Serial.cc
@@ -84,6 +84,8 @@ public:
 
     static int anyTag() { return std::numeric_limits<int>::max(); }
 
+    static int infoNull() { return std::numeric_limits<int>::max(); }
+
 private:
     Request registerRequest(SerialRequest* request) {
         ++n_;
@@ -203,6 +205,10 @@ int Serial::anySource() const {
 
 int Serial::anyTag() const {
     return SerialRequestPool::anyTag();
+}
+
+int Serial::infoNull() const {
+    return SerialRequestPool::infoNull();
 }
 
 size_t Serial::getCount(Status& st, Data::Code) const {

--- a/src/eckit/mpi/Serial.h
+++ b/src/eckit/mpi/Serial.h
@@ -51,6 +51,8 @@ protected:  // methods
 
     virtual int anyTag() const;
 
+    virtual int infoNull() const;
+
     virtual size_t getCount(Status& st, Data::Code type) const;
 
     virtual void broadcast(void* buffer, size_t count, Data::Code type, size_t root) const;

--- a/src/eckit/testing/Test.h
+++ b/src/eckit/testing/Test.h
@@ -390,6 +390,17 @@ void UNIQUE_NAME2(test_, __LINE__) (std::string& _test_subsection, int& _num_sub
         throw eckit::testing::TestException("Exception expected but was not thrown", Here()); \
     } while (false)
 
+// Consider using EXPECT_EQUAL instead of EXPECT when testing for equality of two expressions,
+// since this macro provides more informative output on failure.
+#define EXPECT_EQUAL(expr, expected) \
+    do { \
+        if (!((expr) == (expected))) { \
+            std::stringstream str; \
+            str << ("EXPECT condition '" #expr " == " #expected "' failed. ") \
+                << "(Received: " << expr << "; expected: " << expected << ")"; \
+            throw eckit::testing::TestException(str.str(), Here()); \
+        } \
+    } while (false)
 
 // Setup no longer does anything. Can be removed where it has been used
 #define SETUP(name)

--- a/tests/mpi/CMakeLists.txt
+++ b/tests/mpi/CMakeLists.txt
@@ -1,10 +1,14 @@
-ecbuild_add_test(
-    TARGET      eckit_test_mpi
-    SOURCES     eckit_test_mpi.cc
-    CONDITION   HAVE_MPI
-    LIBS eckit_mpi
-    MPI 4
-)
+#eckit_test_mpi is hanging for Intel 19.0.5. Disabling until a fix is proposed from upstream.
+if( NOT (CMAKE_CXX_COMPILER_ID STREQUAL Intel AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 19
+                                              AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 20) )
+    ecbuild_add_test(
+        TARGET      eckit_test_mpi
+        SOURCES     eckit_test_mpi.cc
+        CONDITION   HAVE_MPI
+        LIBS eckit_mpi
+        MPI 4
+    )
+endif()
 
  ecbuild_add_test(
     TARGET      eckit_test_mpi_addcomm

--- a/tests/testing/test_testing.cc
+++ b/tests/testing/test_testing.cc
@@ -52,6 +52,7 @@ EXPECT_NOT(false);
 EXPECT_NO_THROW({ bool b = true; });
 EXPECT_THROWS(throw std::exception());
 EXPECT_THROWS_AS(throw std::exception(), std::exception);
+EXPECT_EQUAL(3, 3);
 }  // namespace test
 }  // namespace eckit
 ,
@@ -108,6 +109,25 @@ EXPECT(1 == run(fail, TestVerbosity::Silent));
 }
 ,
 
+    {CASE("EXPECT_EQUAL causes an error to be reported on failure"){
+
+       Test fail = {CASE("F"){EXPECT_EQUAL(1, 2);
+}
+}
+;
+
+std::vector<std::string> f;
+bool ret = fail.run(TestVerbosity::Silent, f);
+if (ret || f.size() == 0) {
+  throw eckit::testing::TestException("No error reported when EXPECT_EQUAL failed", Here());
+}
+if (ret || f.size() > 1) {
+  throw eckit::testing::TestException("Too many errors reported when EXPECT_EQUAL failed", Here());
+}
+}
+}
+,
+
     {CASE("EXPECT succeeds for integer comparison"){EXPECT(7 == 7);
 EXPECT(7 != 8);
 EXPECT(7 >= 6);
@@ -120,6 +140,7 @@ EXPECT_NOT(7 <= 6);
 EXPECT_NOT(7 >= 8);
 EXPECT_NOT(7 < 6);
 EXPECT_NOT(7 > 8);
+EXPECT_EQUAL(7, 7);
 }
 }
 , {CASE("Expect succeeds for integer vs. real comparison"){EXPECT(7.0 == 7);
@@ -129,6 +150,8 @@ EXPECT(7 != 8.0);
 
 EXPECT_NOT(7.0 == 8);
 EXPECT_NOT(7 != 7.0);
+
+EXPECT_EQUAL(7, 7.0);
 }
 }
 ,
@@ -149,6 +172,8 @@ EXPECT_NOT(b <= a);
 EXPECT_NOT(a >= b);
 EXPECT_NOT(b < a);
 EXPECT_NOT(a > b);
+
+EXPECT_EQUAL(a, a);
 }
 }
 ,
@@ -268,6 +293,7 @@ SECTION("Compare Collections") {
     EXPECT_NOT(a != b);
     EXPECT_NOT(a > b);
     EXPECT_NOT(a < b);
+    EXPECT_EQUAL(a, b);
     a[0] = 0;
     EXPECT_NOT(a == b);
     EXPECT_NOT(a >= b);

--- a/tests/utils/hash-performance.cc
+++ b/tests/utils/hash-performance.cc
@@ -77,11 +77,11 @@ CASE("Test hash performance") {
 
         std::string name = hashes[i];
 
-        if (eckit::HashFactory::has(name)) {
+        if (eckit::HashFactory::instance().has(name)) {
 
             std::cout << name << std::endl;
 
-            std::unique_ptr<eckit::Hash> hash(eckit::HashFactory::build(name));
+            std::unique_ptr<eckit::Hash> hash(eckit::HashFactory::instance().build(name));
 
             timeAdd<20, 1>(*hash, buffer, timer);
             timeCompute<5>(*hash, buffer2, timer);


### PR DESCRIPTION
In this branch, I have added a method for the eckit communicator that provides the `MPI_INFO_NULL` value for Fortran applications. This method is then called in our fckit fork.

`MPI_INFO_NULL` value is required for parallel NetCDF calls (argument `info` in [nf90_create](https://www.unidata.ucar.edu/software/netcdf/fortran/docs/f90_datasets.html#f90-nf90_create)), and it is compiler-dependent.