### PR TITLE
Fix missing eckit_mpi.so in ECKIT_LIBRARIES

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -205,7 +205,7 @@ endif()
 # export package info
 
 set( ECKIT_INCLUDE_DIRS   ${CMAKE_CURRENT_SOURCE_DIR}/src ${CMAKE_CURRENT_BINARY_DIR}/src )
-set( ECKIT_LIBRARIES      eckit eckit_geometry eckit_linalg eckit_maths eckit_web eckit_mpi )
+set( ECKIT_LIBRARIES      eckit eckit_geometry eckit_linalg eckit_maths eckit_mpi eckit_web )
 
 if( HAVE_ECKIT_CMD)
   list( APPEND ECKIT_LIBRARIES eckit_cmd )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -205,14 +205,10 @@ endif()
 # export package info
 
 set( ECKIT_INCLUDE_DIRS   ${CMAKE_CURRENT_SOURCE_DIR}/src ${CMAKE_CURRENT_BINARY_DIR}/src )
-set( ECKIT_LIBRARIES      eckit eckit_geometry eckit_linalg eckit_maths eckit_web )
+set( ECKIT_LIBRARIES      eckit eckit_geometry eckit_linalg eckit_maths eckit_web eckit_mpi )
 
 if( HAVE_ECKIT_CMD)
   list( APPEND ECKIT_LIBRARIES eckit_cmd )
-endif()
-
-if( HAVE_MPI )
-  list( APPEND ECKIT_LIBRARIES eckit_mpi )
 endif()
 
 if( HAVE_EXPERIMENTAL )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -211,7 +211,7 @@ if( HAVE_ECKIT_CMD)
   list( APPEND ECKIT_LIBRARIES eckit_cmd )
 endif()
 
-if( HAVE_ECKIT_MPI )
+if( HAVE_MPI )
   list( APPEND ECKIT_LIBRARIES eckit_mpi )
 endif()
 


### PR DESCRIPTION
`ecbuild_add_option(FEATURE MPI ...)` creates variable `HAVE_MPI` but this conditional checks `HAVE_ECKIT_MPI` which is never set.  With this patch, `${CMAKE_INSTALL_PREFIX}/lib/cmake/eckit/eckit-config.cmake` now correctly includes `eckit_mpi` in `ECKIT_LIBRARIES` when MPI is found.