### PR TITLE
Made Test take and store std::function objects instead of function pointers

### DIFF
--- a/src/eckit/testing/Test.h
+++ b/src/eckit/testing/Test.h
@@ -14,6 +14,7 @@
 #ifndef eckit_testing_Test_h
 #define eckit_testing_Test_h
 
+#include <functional>
 #include <vector>
 #include <sstream>
 #include <string>
@@ -46,9 +47,9 @@ class Test {
 
 public:  // methods
 
-    Test(const std::string& description, void (*testFn)(std::string&, int&, int)) :
+    Test(const std::string& description, std::function<void(std::string&, int&, int)> testFn) :
         description_(description),
-        testFn_(testFn) {}
+        testFn_(std::move(testFn)) {}
 
     bool run(TestVerbosity v, std::vector<std::string>& failures) {
 
@@ -117,7 +118,7 @@ private:  // members
     std::string description_;
     std::string subsection_;
 
-    void (* testFn_)(std::string&, int&, int);
+    std::function<void(std::string&, int&, int)> testFn_;
 };
 
 std::vector<Test>& specification() {


### PR DESCRIPTION
The ``CASE`` macro returns an anonymous function, and it is possible to make it capture arbitrary variables by passing it to the macro's variable argument. However, the returned function cannot be passed to the constructor of ``eckit::Test`` because the latter takes a function pointer, and only non-capturing lambdas can be converted into function pointers.

This change replaces the function pointer parameter of ``eckit::Test::Test()`` by a ``std::function<...>`` parameter. This makes it possible, for example, to conveniently register multiple tests executing the same code, but operating on different data (e.g. different sections in a YAML file). Example:

```
void testMyFilter(const eckit::LocalConfiguration &conf) {
  // Test filter configured using the parameters in 'conf'...
}

void register_tests(const eckit::LocalConfiguration &topLevelConf) {
  std::vector<eckit::testing::Test> &tests = eckit::testing::specification();
  for (const std::string &section : topLevelConf.keys()) {
    const eckit::LocalConfiguration testConf(topLevelConf, section);
    // The CASE macro creates an anonymous function capturing 'testConf' by value
    tests.emplace_back(CASE("ufo/MyFilter/" + section, testConf)
                       {
                         testMyFilter(testConf);
                       });
  }
}
```

This change has been accepted into the JCSDA fork of ``eckit`` (https://github.com/JCSDA/eckit/pull/4).