### PR TITLE
Maps with numeric keys in YAML files are not parsed correctly

### DIFF
--- a/tests/config/test_configuration.cc
+++ b/tests/config/test_configuration.cc
@@ -340,6 +340,57 @@ CASE("Hash a configuration") {
     EXPECT(h->digest() == "9f060b35735e98b0fdc0bf4c2d6d6d8d");
 }
 
+void testNumericKeys(const YAMLConfiguration &conf)
+{
+    LocalConfiguration discreteFunction;
+    EXPECT(conf.get("discrete_function", discreteFunction));
+
+    float valueAt1, valueAt2;
+    EXPECT(discreteFunction.get("1", valueAt1));
+    EXPECT(discreteFunction.get("2", valueAt2));
+    EXPECT(valueAt1 == 0.5f);
+    EXPECT(valueAt2 == 0.75f);
+}
+
+CASE("YAML-style map with unquoted numeric keys") {
+    std::string yaml(
+        "discrete_function:\n"
+        "  1: 0.5\n"
+        "  2: 0.75\n");
+    YAMLConfiguration conf(yaml);
+    testNumericKeys(conf);
+}
+
+CASE("YAML-style map with quoted numeric keys") {
+    std::string yaml(
+        "discrete_function:\n"
+        "  \"1\": 0.5\n"
+        "  \"2\": 0.75\n");
+    YAMLConfiguration conf(yaml);
+    testNumericKeys(conf);
+}
+
+CASE("YAML-style map with quoted textual keys") {
+    std::string yaml(
+        "discrete_function:\n"
+        "  \"abc\": 0.5\n"
+        "  \"def\": 0.75\n");
+    YAMLConfiguration conf(yaml);
+}
+
+CASE("JSON-style map with unquoted numeric keys") {
+    std::string yaml(
+        "discrete_function: { 1: 0.5, 2: 0.75 }\n");
+    YAMLConfiguration conf(yaml);
+    testNumericKeys(conf);
+}
+
+CASE("JSON-style map with quoted numeric keys") {
+    std::string yaml(
+        "discrete_function: { \"1\": 0.5, \"2\": 0.75 }\n");
+    YAMLConfiguration conf(yaml);
+    testNumericKeys(conf);
+}
 
 //----------------------------------------------------------------------------------------------------------------------
 


### PR DESCRIPTION
The ``YAMLConfiguration`` class does not handle correctly maps containing numeric keys. These keys are stored as ``Value`` objects storing an instance of ``NumberContent``; as a result, their values can't be accessed via the ``Configuration::get()`` function, since it expects the keys to be strings. Out of the four ways to write a map in a YAML file (in the block or flow style, with or without quoted keys), the only way that works is the JSON-like flow style with quoted keys.
```
my_map: { "1": 0.5, "2": 0.75 }
```
I'm not sure what the best way to fix this is; this pull request simply adds a few test cases demonstrating the problem.

The ``test_eckit_yaml_21`` test actually expects numeric keys to be treated as numbers, but I think this is undesirable, at least when YAML is parsed to build a ``Configuration`` object, since the latter requires keys to be strings.

