### PR TITLE
Update sqly.y for modern GNU bison-3.7.1 support

### DIFF
--- a/src/eckit/sql/sqly.y
+++ b/src/eckit/sql/sqly.y
@@ -1,4 +1,4 @@
-%define api.pure
+%pure-parser
 %lex-param {void * scanner}
 %lex-param {eckit::sql::SQLSession* session}
 %parse-param {void * scanner}

--- a/src/eckit/sql/sqly.y
+++ b/src/eckit/sql/sqly.y
@@ -1,7 +1,7 @@
-%pure-parser
-%lex-param {yyscan_t scanner}
+%define api.pure
+%lex-param {void * scanner}
 %lex-param {eckit::sql::SQLSession* session}
-%parse-param {yyscan_t scanner}
+%parse-param {void * scanner}
 %parse-param {eckit::sql::SQLSession* session}
 
 %{


### PR DESCRIPTION
With `/usr/bin/yacc` provided by the newest GNU bison/3.7.1, the `src/eckit/sql/sqly.y` yacc file is not compatible and is generating yacc warnings and a compilation failure for a missing symbol `yyscan_t`:
```
/usr/bin/x86_64-pc-linux-gnu-g++ -Deckit_sql_EXPORTS -I/var/tmp/portage/sci-libs/eckit-1.10.1.2/work/eckit-1.10.1.2/src -Isrc -I/var/tmp/portage/sci-libs/eckit-1.10.1.2/work/eckit-1.10.1.2/src/eckit/sql -I/var/tmp/portage/sci-libs/eckit-1.10.1.2/work/eckit-1.10.1.2/src/eckit -I/usr/include/eigen3  -O2 -pipe -pipe -O3 -DNDEBUG -fPIC -std=gnu++11 -Wno-unused-function -Wno-sign-compare -MD -MT src/eckit/sql/CMakeFiles/eckit_sql.dir/SQLParser.cc.o -MF src/eckit/sql/CMakeFiles/eckit_sql.dir/SQLParser.cc.o.d -o src/eckit/sql/CMakeFiles/eckit_sql.dir/SQLParser.cc.o -c /var/tmp/portage/sci-libs/eckit-1.10.1.2/work/eckit-1.10.1.2/src/eckit/sql/SQLParser.cc
In file included from /var/tmp/portage/sci-libs/eckit-1.10.1.2/work/eckit-1.10.1.2_build/src/eckit/sql/sqly.c:147,
                 from /var/tmp/portage/sci-libs/eckit-1.10.1.2/work/eckit-1.10.1.2/src/eckit/sql/SQLParser.cc:47:
src/eckit/sql/sqly.tmp.h:131:14: error: ‘yyscan_t’ was not declared in this scope
  131 | int yyparse (yyscan_t scanner, eckit::sql::SQLSession* session);
      |              ^~~~~~~~
src/eckit/sql/sqly.tmp.h:131:54: error: expected primary-expression before ‘*’ token
  131 | int yyparse (yyscan_t scanner, eckit::sql::SQLSession* session);
      |                                                      ^
src/eckit/sql/sqly.tmp.h:131:56: error: ‘session’ was not declared in this scope
  131 | int yyparse (yyscan_t scanner, eckit::sql::SQLSession* session);
      |                                                        ^~~~~~~
src/eckit/sql/sqly.tmp.h:131:63: error: expression list treated as compound expression in initializer [-fpermissive]
  131 | int yyparse (yyscan_t scanner, eckit::sql::SQLSession* session);
      |                                                               ^

```

These were fixed by replacing `sscant_t` with `void *`.

Also there are several `yacc` warnings, of which one was easily fixable.  The others indicate potential logic issues, but I have not investigated, as they don't prevent compilation:
```
cd /var/tmp/portage/sci-libs/eckit-1.10.1.2/work/eckit-1.10.1.2/src/eckit/sql && /usr/bin/bison -t -d -o /var/tmp/portage/sci-libs/eckit-1.10.1.2/work/eckit-1.10.1.2_build/src/eckit/sql/sqly.tmp.c /var/tmp/portage/sci-libs/eckit-1.10.1.2/work/eckit-1.10.1.2/src/eckit/sql/sqly.y
/var/tmp/portage/sci-libs/eckit-1.10.1.2/work/eckit-1.10.1.2/src/eckit/sql/sqly.y:1.1-12: warning: deprecated directive: ‘%pure-parser’, use ‘%define api.pure’ [-Wdeprecated]
    1 | %pure-parser
      | ^~~~~~~~~~~~
      | %define api.pure
/var/tmp/portage/sci-libs/eckit-1.10.1.2/work/eckit-1.10.1.2/src/eckit/sql/sqly.y: warning: 57 shift/reduce conflicts [-Wconflicts-sr]
/var/tmp/portage/sci-libs/eckit-1.10.1.2/work/eckit-1.10.1.2/src/eckit/sql/sqly.y: warning: 91 reduce/reduce conflicts [-Wconflicts-rr]
/var/tmp/portage/sci-libs/eckit-1.10.1.2/work/eckit-1.10.1.2/src/eckit/sql/sqly.y: note: rerun with option '-Wcounterexamples' to generate conflict counterexamples
/var/tmp/portage/sci-libs/eckit-1.10.1.2/work/eckit-1.10.1.2/src/eckit/sql/sqly.y: warning: fix-its can be applied.  Rerun with option '--update'. [-Wother]
```

Note the same errors show with the develop version, I just have them reproduced here with this older un-patched build.  You will need bison/3.7.1 to see the yacc warnings.
