### PR TITLE
Add an overload of Assert() taking a const char* rather than a const std::string&

### DIFF
--- a/src/eckit/exception/Exceptions.h
+++ b/src/eckit/exception/Exceptions.h
@@ -260,6 +260,12 @@ inline void ThrCall(int code, const char* msg, const char* file, int line, const
         handle_panic(msg, CodeLocation(file, line, func));
 }
 
+inline void Assert(int code, const char* msg, const char* file, int line, const char* func) {
+    if (code != 0) {
+        throw AssertionFailed(msg, CodeLocation(file, line, func));
+    }
+}
+
 inline void Assert(int code, const std::string& msg, const char* file, int line, const char* func) {
     if (code != 0) {
         throw AssertionFailed(msg, CodeLocation(file, line, func));


### PR DESCRIPTION
Currently `Assert()` takes the message to be displayed if the assertion fails by const reference to an `std::string`. This function is called by the `ASSERT()` macro, which converts its argument to a string literal and passes it to `Assert()`. As a result, a `std::string` object is created and destroyed in each call to `ASSERT()`. This can be quite costly if the macro is called from a tight loop and its argument is long enough to incur a heap allocation and deallocation in the constructor and destructor of `std::string`.

This PR adds an overload of `Assert()` taking a `const char*`; this makes the `ASSERT()` macro much cheaper to call. For example, this simple change reduces from 27 s to 10 s the time taken by
```
odc sql "select *" -i atms6K.odb -o /dev/null -f odb
```
where `atms6K.odb` is an ODB file with 1,292,800 rows and 212 columns. This is mainly because the call to `ASSERT()` from `odc::SQLSelectOutput::outputNumber()` becomes much cheaper.

(The original overload is still useful because it makes it possible to pass an `std::string` to the second argument of the `ASSERT_MSG` macro.)