### PR TITLE
Enable CI on self-hosted runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,31 +1,22 @@
 name: ci
 
-# Controls when the workflow will run
 on:
-
-  # Trigger the workflow on all pushes, except on tag creation
+  # Trigger the workflow on push to master or develop, except tag creation
   push:
     branches:
-    - '**'
+      - 'master'
+      - 'develop'
     tags-ignore:
-    - '**'
+      - '**'
 
-  # Trigger the workflow on all pull requests
+  # Trigger the workflow on pull request
   pull_request: ~
 
-  # Allow workflow to be dispatched on demand
-  workflow_dispatch: ~
-
 jobs:
-
   # Calls a reusable CI workflow to build & test the current repository.
-  #   It will pull in all needed dependencies and produce a code coverage report on success.
   ci:
     name: ci
-    uses: ecmwf-actions/reusable-workflows/.github/workflows/ci.yml@v1
+    uses: ./.github/workflows/reusable-ci.yml
     with:
-      codecov_upload: true
-      build_package_inputs: |
-        self_coverage: true
-        dependencies: ecmwf/ecbuild
-        dependency_branch: develop
+      eckit_sha: ${{ github.sha }}
+    secrets: inherit

--- a/.github/workflows/reusable-ci-hpc.yml
+++ b/.github/workflows/reusable-ci-hpc.yml
@@ -1,0 +1,22 @@
+name: reusable-ci-hpc
+
+on:
+  workflow_call:
+    inputs:
+      eckit:
+        required: false
+        type: string
+
+jobs:
+  ci-hpc:
+    name: ci-hpc
+    uses: ecmwf-actions/reusable-workflows/.github/workflows/ci-hpc.yml@main
+    with:
+      name-prefix: eckit-
+      build-inputs: |
+        --package: ${{ inputs.eckit || 'ecmwf/eckit@develop' }}
+        --modules: |
+          ecbuild
+          ninja
+        --parallel: 64
+    secrets: inherit

--- a/.github/workflows/reusable-ci.yml
+++ b/.github/workflows/reusable-ci.yml
@@ -1,0 +1,24 @@
+name: reusable-ci
+
+on:
+  workflow_call:
+    eckit_sha:
+      required: true
+      type: string
+
+jobs:
+  ci:
+    name: eckit-ci
+    uses: ecmwf-actions/reusable-workflows/.github/workflows/ci.yml@v2
+    with:
+      repository: ecmwf/eckit
+      ref: ${{ inputs.eckit_sha }}
+      name_prefix: eckit-
+      build_package_inputs: |
+        repository: ecmwf/eckit
+        sha: ${{ inputs.eckit_sha }}
+        self_coverage: true
+        dependencies: ecmwf/ecbuild
+        dependency_branch: develop
+        parallelism_factor: 8
+    secrets: inherit

--- a/.github/workflows/reusable-ci.yml
+++ b/.github/workflows/reusable-ci.yml
@@ -2,9 +2,10 @@ name: reusable-ci
 
 on:
   workflow_call:
-    eckit_sha:
-      required: true
-      type: string
+    inputs:
+      eckit_sha:
+        required: true
+        type: string
 
 jobs:
   ci:


### PR DESCRIPTION
CI is triggered by push event or pull request, builds and tests the current repository.