### PR TITLE
Switch Eckit to downstream CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,3 +28,47 @@ jobs:
     with:
       eckit: ecmwf/eckit@${{ github.event.pull_request.head.sha || github.sha }}
     secrets: inherit
+
+  # Run CI of private downstream packages on self-hosted runners
+  private-downstream-ci:
+    name: private-downstream-ci
+    needs: [downstream-ci]
+    if: success() || failure()
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Dispatch private downstream CI
+        uses: ecmwf-actions/dispatch-private-downstream-ci@v1
+        with:
+          token: ${{ secrets.GH_REPO_READ_TOKEN }}
+          owner: ecmwf-actions
+          repository: private-downstream-ci
+          event_type: downstream-ci
+          payload: '{"eckit": "ecmwf/eckit@${{ github.event.pull_request.head.sha || github.sha }}"}'
+
+  # Build downstream packages on HPC
+  downstream-ci-hpc:
+    name: downstream-ci-hpc
+    uses: ecmwf-actions/downstream-ci/.github/workflows/downstream-ci-hpc.yml@main
+    with:
+      eckit: ecmwf/eckit@${{ github.event.pull_request.head.sha || github.sha }}
+    secrets: inherit
+
+  # Run CI of private downstream packages on HPC
+  private-downstream-ci-hpc:
+    name: private-downstream-ci-hpc
+    needs: [downstream-ci-hpc]
+    if: success() || failure()
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Dispatch private downstream CI
+        uses: ecmwf-actions/dispatch-private-downstream-ci@v1
+        with:
+          token: ${{ secrets.GH_REPO_READ_TOKEN }}
+          owner: ecmwf-actions
+          repository: private-downstream-ci
+          event_type: downstream-ci-hpc
+          payload: '{"eckit": "ecmwf/eckit@${{ github.event.pull_request.head.sha || github.sha }}"}'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,10 +4,10 @@ on:
   # Trigger the workflow on push to master or develop, except tag creation
   push:
     branches:
-      - 'master'
-      - 'develop'
+      - "master"
+      - "develop"
     tags-ignore:
-      - '**'
+      - "**"
 
   # Trigger the workflow on pull request
   pull_request: ~
@@ -17,11 +17,11 @@ on:
     types: [labeled]
 
 jobs:
-  # Calls a reusable CI workflow to build & test the current repository.
-  ci:
-    name: ci
+  # Run CI including downstream packages on self-hosted runners
+  downstream-ci:
+    name: downstream-ci
     if: ${{ !github.event.pull_request.head.repo.fork && github.event.action != 'labeled' || github.event.label.name == 'approved-for-ci' }}
-    uses: ./.github/workflows/reusable-ci.yml
+    uses: ecmwf-actions/downstream-ci/.github/workflows/downstream-ci.yml@main
     with:
-      eckit_sha: ${{ github.sha }}
+      eckit: ecmwf/eckit@${{ github.event.pull_request.head.sha || github.sha }}
     secrets: inherit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,9 @@ on:
   pull_request_target:
     types: [labeled]
 
+  # Trigger the workflow manually
+  workflow_dispatch: ~
+
 jobs:
   # Run CI including downstream packages on self-hosted runners
   downstream-ci:

--- a/.github/workflows/reusable-ci-hpc.yml
+++ b/.github/workflows/reusable-ci-hpc.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   ci-hpc:
     name: ci-hpc
-    uses: ecmwf-actions/reusable-workflows/.github/workflows/ci-hpc.yml@main
+    uses: ecmwf-actions/reusable-workflows/.github/workflows/ci-hpc.yml@v2
     with:
       name-prefix: eckit-
       build-inputs: |

--- a/.github/workflows/reusable-ci.yml
+++ b/.github/workflows/reusable-ci.yml
@@ -4,7 +4,7 @@ on:
   workflow_call:
     inputs:
       eckit:
-        default: 'ecmwf/eckit@develop'
+        required: false
         type: string
 
 jobs:
@@ -12,10 +12,10 @@ jobs:
     name: eckit-ci
     uses: ecmwf-actions/reusable-workflows/.github/workflows/ci.yml@v2
     with:
-      repository: ${{ inputs.eckit }}
+      repository: ${{ inputs.eckit || 'ecmwf/eckit@develop' }}
       name_prefix: eckit-
       build_package_inputs: |
-        repository: ${{ inputs.eckit }}
+        repository: ${{ inputs.eckit || 'ecmwf/eckit@develop' }}
         self_coverage: true
         dependencies: ecmwf/ecbuild
         dependency_branch: develop

--- a/.github/workflows/reusable-ci.yml
+++ b/.github/workflows/reusable-ci.yml
@@ -4,7 +4,7 @@ on:
   workflow_call:
     inputs:
       eckit:
-        required: true
+        default: 'ecmwf/eckit@develop'
         type: string
 
 jobs:

--- a/.github/workflows/reusable-ci.yml
+++ b/.github/workflows/reusable-ci.yml
@@ -3,7 +3,7 @@ name: reusable-ci
 on:
   workflow_call:
     inputs:
-      eckit_sha:
+      eckit:
         required: true
         type: string
 
@@ -12,12 +12,10 @@ jobs:
     name: eckit-ci
     uses: ecmwf-actions/reusable-workflows/.github/workflows/ci.yml@v2
     with:
-      repository: ecmwf/eckit
-      ref: ${{ inputs.eckit_sha }}
+      repository: ${{ inputs.eckit }}
       name_prefix: eckit-
       build_package_inputs: |
-        repository: ecmwf/eckit
-        sha: ${{ inputs.eckit_sha }}
+        repository: ${{ inputs.eckit }}
         self_coverage: true
         dependencies: ecmwf/ecbuild
         dependency_branch: develop


### PR DESCRIPTION
Run CI including public and private downstream packages on self-hosted runners and HPC.