### PR TITLE
ECKIT-600 Always define preprocessor definitions, with value 0 or 1

### DIFF
--- a/src/eckit/CMakeLists.txt
+++ b/src/eckit/CMakeLists.txt
@@ -3,15 +3,15 @@
 test_big_endian( _BIG_ENDIAN )
 
 if( _BIG_ENDIAN )
-        set( ECKIT_BIG_ENDIAN    1 )
-        set( ECKIT_LITTLE_ENDIAN 0 )
+        set( eckit_BIG_ENDIAN    1 )
+        set( eckit_LITTLE_ENDIAN 0 )
 else()
-        set( ECKIT_BIG_ENDIAN    0 )
-        set( ECKIT_LITTLE_ENDIAN 1 )
+        set( eckit_BIG_ENDIAN    0 )
+        set( eckit_LITTLE_ENDIAN 1 )
 endif()
 
-set( ECKIT_BIG_ENDIAN    ${ECKIT_BIG_ENDIAN}    )
-set( ECKIT_LITTLE_ENDIAN ${ECKIT_LITTLE_ENDIAN} )
+set( ECKIT_BIG_ENDIAN    ${eckit_BIG_ENDIAN}    )
+set( ECKIT_LITTLE_ENDIAN ${eckit_LITTLE_ENDIAN} )
 
 ### check support for DL library
 

--- a/src/eckit/eckit.h
+++ b/src/eckit/eckit.h
@@ -20,7 +20,7 @@
 
 //--------------------------------------------------------------------------------------------------
 
-#if (!defined eckit_HAVE_MAP_ANONYMOUS) && (defined eckit_HAVE_MAP_ANON)
+#if (!eckit_HAVE_MAP_ANONYMOUS) && eckit_HAVE_MAP_ANON
 #define MAP_ANONYMOUS MAP_ANON
 #endif
 

--- a/src/eckit/eckit_config.h.in
+++ b/src/eckit/eckit_config.h.in
@@ -7,60 +7,60 @@
 
 // endiness
 
-#define eckit_BIG_ENDIAN       @ECKIT_BIG_ENDIAN@
-#define ECKIT_BIG_ENDIAN       @ECKIT_BIG_ENDIAN@ /* backward compatibility */
-
-#define eckit_LITTLE_ENDIAN    @ECKIT_LITTLE_ENDIAN@
-#define ECKIT_LITTLE_ENDIAN    @ECKIT_LITTLE_ENDIAN@ /* backward compatibility */
+#cmakedefine01 eckit_BIG_ENDIAN
+#cmakedefine01 eckit_LITTLE_ENDIAN
 
 // system
 
 #define ECKIT_SIZEOF_TIME_T    @ECKIT_SIZEOF_TIME_T@
 
-#cmakedefine eckit_HAVE_DLFCN_H
-#cmakedefine eckit_HAVE_DLADDR
-#cmakedefine eckit_HAVE_MAP_ANONYMOUS
-#cmakedefine eckit_HAVE_MAP_ANON
-#cmakedefine eckit_HAVE_FUNOPEN
-#cmakedefine eckit_HAVE_FSYNC
-#cmakedefine eckit_HAVE_FDATASYNC
-#cmakedefine eckit_HAVE_F_FULLFSYNC
-#cmakedefine eckit_HAVE_FMEMOPEN
-#cmakedefine eckit_HAVE_DLINFO
-#cmakedefine eckit_HAVE_FOPENCOOKIE
-#cmakedefine eckit_HAVE_EXECINFO_BACKTRACE
-#cmakedefine eckit_HAVE_CXXABI_H
-#cmakedefine eckit_HAVE_GMTIME_R
-#cmakedefine eckit_HAVE_READDIR_R
-#cmakedefine eckit_HAVE_DIRFD
-#cmakedefine eckit_HAVE_DIRENT_D_TYPE
-#cmakedefine eckit_HAVE_CXX_INT_128
-#cmakedefine eckit_HAVE_AIO
-#cmakedefine eckit_HAVE_UNICODE
-#cmakedefine eckit_HAVE_XXHASH
+#cmakedefine01 eckit_HAVE_DLFCN_H
+#cmakedefine01 eckit_HAVE_DLADDR
+#cmakedefine01 eckit_HAVE_MAP_ANONYMOUS
+#cmakedefine01 eckit_HAVE_MAP_ANON
+#cmakedefine01 eckit_HAVE_FUNOPEN
+#cmakedefine01 eckit_HAVE_FSYNC
+#cmakedefine01 eckit_HAVE_FDATASYNC
+#cmakedefine01 eckit_HAVE_F_FULLFSYNC
+#cmakedefine01 eckit_HAVE_FMEMOPEN
+#cmakedefine01 eckit_HAVE_DLINFO
+#cmakedefine01 eckit_HAVE_FOPENCOOKIE
+#cmakedefine01 eckit_HAVE_EXECINFO_BACKTRACE
+#cmakedefine01 eckit_HAVE_CXXABI_H
+#cmakedefine01 eckit_HAVE_GMTIME_R
+#cmakedefine01 eckit_HAVE_READDIR_R
+#cmakedefine01 eckit_HAVE_DIRFD
+#cmakedefine01 eckit_HAVE_DIRENT_D_TYPE
+#cmakedefine01 eckit_HAVE_CXX_INT_128
+#cmakedefine01 eckit_HAVE_AIO
+#cmakedefine01 eckit_HAVE_UNICODE
+#cmakedefine01 eckit_HAVE_XXHASH
 
 // external packages
 
-#cmakedefine eckit_HAVE_ARMADILLO
-#cmakedefine eckit_HAVE_CUDA
-#cmakedefine eckit_HAVE_EIGEN
-#cmakedefine eckit_HAVE_LAPACK
-#cmakedefine eckit_HAVE_VIENNACL
-#cmakedefine eckit_HAVE_OMP
-#cmakedefine eckit_HAVE_SSL
-#cmakedefine eckit_HAVE_CURL
-#cmakedefine eckit_HAVE_JEMALLOC
-
-#define eckit_HAVE_MKL @eckit_HAVE_MKL@
-#define ECKIT_HAVE_MKL @eckit_HAVE_MKL@ /* backward compatibility */
-
-#define eckit_HAVE_MPI @eckit_HAVE_MPI@
-#define ECKIT_HAVE_MPI @eckit_HAVE_MPI@ /* backward compatibility */
+#cmakedefine01 eckit_HAVE_ARMADILLO
+#cmakedefine01 eckit_HAVE_CUDA
+#cmakedefine01 eckit_HAVE_EIGEN
+#cmakedefine01 eckit_HAVE_LAPACK
+#cmakedefine01 eckit_HAVE_VIENNACL
+#cmakedefine01 eckit_HAVE_OMP
+#cmakedefine01 eckit_HAVE_SSL
+#cmakedefine01 eckit_HAVE_CURL
+#cmakedefine01 eckit_HAVE_JEMALLOC
+#cmakedefine01 eckit_HAVE_MKL
+#cmakedefine01 eckit_HAVE_MPI
 
 // Have we built certain libraries
 
-#cmakedefine eckit_HAVE_ECKIT_CMD
-#cmakedefine eckit_HAVE_ECKIT_SQL
-#cmakedefine eckit_HAVE_ECKIT_MPI
+#cmakedefine01 eckit_HAVE_ECKIT_CMD
+#cmakedefine01 eckit_HAVE_ECKIT_SQL
+#cmakedefine01 eckit_HAVE_ECKIT_MPI
+
+// Backward compatibility with atlas < 0.30.0
+// Its use will be removed with ATLAS-367.
+#define ECKIT_HAVE_MKL         @eckit_HAVE_MKL@
+#define ECKIT_HAVE_MPI         @eckit_HAVE_MPI@
+#define ECKIT_BIG_ENDIAN       @eckit_BIG_ENDIAN@
+#define ECKIT_LITTLE_ENDIAN    @eckit_LITTLE_ENDIAN@
 
 #endif // eckit_config_h

--- a/src/eckit/filesystem/LocalPathName.cc
+++ b/src/eckit/filesystem/LocalPathName.cc
@@ -692,7 +692,7 @@ void LocalPathName::children(std::vector<LocalPathName>& files, std::vector<Loca
 
         bool do_stat = true;
 
-#if defined(eckit_HAVE_DIRENT_D_TYPE)
+#if eckit_HAVE_DIRENT_D_TYPE
         do_stat = false;
         if (e->d_type == DT_DIR) {
             dirs.push_back(full);
@@ -896,7 +896,7 @@ LocalPathName LocalPathName::mountPoint() const {
 
 void LocalPathName::syncParentDirectory() const {
     PathName directory = dirName();
-#ifdef eckit_HAVE_DIRFD
+#if eckit_HAVE_DIRFD
     //    Log::info() << "Syncing directory " << directory << std::endl;
     DIR* d = opendir(directory.localPath());
     if (!d)

--- a/src/eckit/filesystem/StdDir.cc
+++ b/src/eckit/filesystem/StdDir.cc
@@ -45,14 +45,14 @@ struct dirent* StdDir::dirent() {
     /// @todo Note that readdir_r() has been deprecated by POSIX standard
     ///       however readdir() isn't thread-safe yet, not even in glic implementation
     ///       until then we prefer to use readdir_r
-#ifdef eckit_HAVE_READDIR_R
+#if eckit_HAVE_READDIR_R
     ::readdir_r(d_, &buf, &e);
 #else
     e = ::readdir(d_);
 #endif
 
     if (e == nullptr && errno) {
-#ifdef eckit_HAVE_READDIR_R
+#if eckit_HAVE_READDIR_R
         const char* func = "readdir_r";
 #else
         const char* func = "readdir";

--- a/src/eckit/io/AIOHandle.cc
+++ b/src/eckit/io/AIOHandle.cc
@@ -24,7 +24,7 @@
 #include "eckit/os/Stat.h"
 #include "eckit/types/Types.h"
 
-#ifdef eckit_HAVE_AIO
+#if eckit_HAVE_AIO
 #include <aio.h>
 #endif
 
@@ -32,7 +32,7 @@ namespace eckit {
 
 //----------------------------------------------------------------------------------------------------------------------
 
-#ifdef eckit_HAVE_AIO
+#if eckit_HAVE_AIO
 
 struct AIOBuffer : private eckit::NonCopyable {
 

--- a/src/eckit/io/FDataSync.cc
+++ b/src/eckit/io/FDataSync.cc
@@ -28,18 +28,18 @@ int fsync(int fd) {
 
 int fdatasync(int fd) {
     int ret = 0;
-#if defined(eckit_HAVE_FDATASYNC)
+#if eckit_HAVE_FDATASYNC
     // usually available on Linux, but not Darwin (macosx) and xBSD
     // syncs all the data but avoids some of the metadata e.g. mtime
     ret = ::fdatasync(fd);
-#elif defined(eckit_HAVE_F_FULLSYNC)
+#elif eckit_HAVE_F_FULLSYNC
     // usually available on Darwin (macosx) and xBSD
     // provides stronger guarantees than fsync that data fully committed to persistent storage
     ret = ::fcntl(fd, F_FULLFSYNC);
     while (ret == -1 && errno == EINTR) {
         ret = ::fcntl(fd, F_FULLFSYNC);
     }
-#elif defined(eckit_HAVE_FSYNC)
+#elif eckit_HAVE_FSYNC
     // last resort, but note this is slower than ::fdatasync and less strong as F_FULLSYNC
     ret = eckit::fsync(fd);
 #else

--- a/src/eckit/io/FOpenDataHandle.cc
+++ b/src/eckit/io/FOpenDataHandle.cc
@@ -208,14 +208,14 @@ static int closefn(void* data) {
 }
 
 
-#if defined(eckit_HAVE_FOPENCOOKIE)
+#if eckit_HAVE_FOPENCOOKIE
 FILE* opencookie(FOpenDataHandle* h, const char* mode) {
     ASSERT(sizeof(long) >= sizeof(size_t));
     ASSERT(sizeof(long) >= sizeof(ssize_t));
     cookie_io_functions_t func = {&readfn, &writefn, &seekfn, &closefn};
     return ::fopencookie(h, mode, func);
 }
-#elif defined(eckit_HAVE_FUNOPEN)
+#elif eckit_HAVE_FUNOPEN
 
 static int _read(void* data, char* buffer, int length) {
     return readfn(data, buffer, length);

--- a/src/eckit/linalg/LinearAlgebraDense.cc
+++ b/src/eckit/linalg/LinearAlgebraDense.cc
@@ -30,11 +30,11 @@ static BackendRegistry<LinearAlgebraDense>* backends = nullptr;
 
 static void init() {
     backends = new BackendRegistry<LinearAlgebraDense>(
-#if eckit_HAVE_MKL  // always defined: 0 or 1
+#if eckit_HAVE_MKL
         "mkl"
-#elif defined(eckit_HAVE_LAPACK)
+#elif eckit_HAVE_LAPACK
         "lapack"
-#elif defined(eckit_HAVE_EIGEN)
+#elif eckit_HAVE_EIGEN
         "eigen"
 #else
         "generic"

--- a/src/eckit/linalg/LinearAlgebraSparse.cc
+++ b/src/eckit/linalg/LinearAlgebraSparse.cc
@@ -30,7 +30,7 @@ static BackendRegistry<LinearAlgebraSparse>* backends = nullptr;
 
 static void init() {
     backends = new BackendRegistry<LinearAlgebraSparse>(
-#ifdef eckit_HAVE_EIGEN
+#if eckit_HAVE_EIGEN
         "eigen"
 #else
         "generic"

--- a/src/eckit/linalg/SparseMatrix.cc
+++ b/src/eckit/linalg/SparseMatrix.cc
@@ -33,7 +33,7 @@
 namespace eckit {
 namespace linalg {
 
-#ifdef ECKIT_LITTLE_ENDIAN
+#if eckit_LITTLE_ENDIAN
 static const bool littleEndian = true;
 #else
 static const bool littleEndian = false;

--- a/src/eckit/linalg/dense/LinearAlgebraGeneric.cc
+++ b/src/eckit/linalg/dense/LinearAlgebraGeneric.cc
@@ -26,7 +26,7 @@ namespace dense {
 
 
 static const LinearAlgebraGeneric __la_generic("generic");
-#ifdef eckit_HAVE_OMP
+#if eckit_HAVE_OMP
 static const LinearAlgebraGeneric __la_openmp("openmp");
 #endif
 
@@ -42,7 +42,7 @@ Scalar LinearAlgebraGeneric::dot(const Vector& x, const Vector& y) const {
 
     Scalar sum = 0.;
 
-#ifdef eckit_HAVE_OMP
+#if eckit_HAVE_OMP
 #pragma omp parallel for reduction(+ \
                                    : sum)
 #endif
@@ -62,7 +62,7 @@ void LinearAlgebraGeneric::gemv(const Matrix& A, const Vector& x, Vector& y) con
     ASSERT(y.rows() == Ni);
     ASSERT(x.rows() == Nj);
 
-#ifdef eckit_HAVE_OMP
+#if eckit_HAVE_OMP
 #pragma omp parallel for
 #endif
     for (Size i = 0; i < Ni; ++i) {
@@ -86,7 +86,7 @@ void LinearAlgebraGeneric::gemm(const Matrix& A, const Matrix& B, Matrix& C) con
     ASSERT(C.cols() == Nj);
     ASSERT(B.rows() == Nk);
 
-#ifdef eckit_HAVE_OMP
+#if eckit_HAVE_OMP
 #pragma omp parallel for collapse(2)
 #endif
     for (Size j = 0; j < Nj; ++j) {

--- a/src/eckit/linalg/sparse/LinearAlgebraGeneric.cc
+++ b/src/eckit/linalg/sparse/LinearAlgebraGeneric.cc
@@ -27,7 +27,7 @@ namespace sparse {
 
 
 static const LinearAlgebraGeneric __la_generic("generic");
-#ifdef eckit_HAVE_OMP
+#if eckit_HAVE_OMP
 static const LinearAlgebraGeneric __la_openmp("openmp");
 #endif
 
@@ -54,7 +54,7 @@ void LinearAlgebraGeneric::spmv(const SparseMatrix& A, const Vector& x, Vector& 
 
     ASSERT(outer[0] == 0);  // expect indices to be 0-based
 
-#ifdef eckit_HAVE_OMP
+#if eckit_HAVE_OMP
 #pragma omp parallel for
 #endif
     for (Size i = 0; i < Ni; ++i) {
@@ -90,13 +90,13 @@ void LinearAlgebraGeneric::spmm(const SparseMatrix& A, const Matrix& B, Matrix& 
 
     std::vector<Scalar> sum;
 
-#ifdef eckit_HAVE_OMP
+#if eckit_HAVE_OMP
 #pragma omp parallel
 #endif
     {
         std::vector<Scalar> sum(Nk);
 
-#ifdef eckit_HAVE_OMP
+#if eckit_HAVE_OMP
 #pragma omp for
 #endif
         for (Size i = 0; i < Ni; ++i) {
@@ -136,7 +136,7 @@ void LinearAlgebraGeneric::dsptd(const Vector& x, const SparseMatrix& A, const V
 
     ASSERT(outer[0] == 0);  // expect indices to be 0-based
 
-#ifdef eckit_HAVE_OMP
+#if eckit_HAVE_OMP
 #pragma omp parallel for
 #endif
     for (Size i = 0; i < Ni; ++i) {

--- a/src/eckit/log/TimeStamp.cc
+++ b/src/eckit/log/TimeStamp.cc
@@ -28,7 +28,7 @@ TimeStamp::TimeStamp(time_t t, const std::string& format) :
 
 std::ostream& operator<<(std::ostream& s, const TimeStamp& x) {
     char buf[80];
-#ifdef eckit_HAVE_GMTIME_R
+#if eckit_HAVE_GMTIME_R
     struct tm t;
     ::strftime(buf, sizeof(buf), x.format_.c_str(), gmtime_r(&x.time_, &t));
 #else

--- a/src/eckit/maths/Eigen.h
+++ b/src/eckit/maths/Eigen.h
@@ -19,7 +19,7 @@
 
 //--------------------------------------------------------------------------------------------
 
-#ifdef eckit_HAVE_EIGEN
+#if eckit_HAVE_EIGEN
 
 #define EIGEN_NO_AUTOMATIC_RESIZING
 #define EIGEN_DONT_ALIGN

--- a/src/eckit/maths/Lapack.cc
+++ b/src/eckit/maths/Lapack.cc
@@ -6,7 +6,7 @@ namespace eckit {
 namespace maths {
 namespace lapack {
 
-#ifdef eckit_HAVE_LAPACK
+#if eckit_HAVE_LAPACK
 
 extern "C" {
 void dgetrf_(int* M, int* N, double* A, int* lda, int* ipiv, int* info);

--- a/src/eckit/maths/Matrix.h
+++ b/src/eckit/maths/Matrix.h
@@ -46,7 +46,7 @@ class Matrix;
 
 }  // namespace eckit
 
-#ifdef eckit_HAVE_EIGEN
+#if eckit_HAVE_EIGEN
 
 // Implementation using Eigen
 #include "eckit/maths/MatrixEigen.h"

--- a/src/eckit/maths/MatrixLapack.h
+++ b/src/eckit/maths/MatrixLapack.h
@@ -249,7 +249,7 @@ public:
                 break;
             }
             default: {  // invert with LU-factorization
-#ifdef eckit_HAVE_LAPACK
+#if eckit_HAVE_LAPACK
                 inv     = *this;
                 int M   = nr_;
                 int N   = nc_;

--- a/src/eckit/os/BackTrace.cc
+++ b/src/eckit/os/BackTrace.cc
@@ -14,11 +14,11 @@
 
 #include "eckit/eckit.h"
 
-#if defined(eckit_HAVE_EXECINFO_BACKTRACE) || defined(__FreeBSD__)
+#if eckit_HAVE_EXECINFO_BACKTRACE || defined(__FreeBSD__)
 #include <execinfo.h>  // for backtrace
 #endif
 
-#ifdef eckit_HAVE_CXXABI_H
+#if eckit_HAVE_CXXABI_H
 #include <cxxabi.h>
 #endif
 
@@ -36,7 +36,7 @@ std::string BackTrace::dump() {
 
     std::ostringstream oss;
 
-#if (defined(eckit_HAVE_EXECINFO_BACKTRACE) || defined(__FreeBSD__)) && !defined(_AIX)
+#if (eckit_HAVE_EXECINFO_BACKTRACE || defined(__FreeBSD__)) && !defined(_AIX)
 
     static Ordinal count = 0;
     ++count;
@@ -54,7 +54,7 @@ std::string BackTrace::dump() {
     if (strings == nullptr)
         oss << " --- no backtrace_symbols found ---\n";
 
-#ifndef eckit_HAVE_CXXABI_H
+#if !eckit_HAVE_CXXABI_H
     for (int s = 0; s < addsize; ++s)
         oss << strings[s] << std::endl;
 #else

--- a/src/eckit/os/System.cc
+++ b/src/eckit/os/System.cc
@@ -14,7 +14,7 @@
 #include "eckit/os/System.h"
 #include "eckit/types/Types.h"
 
-#if defined(eckit_HAVE_DLADDR)
+#if eckit_HAVE_DLADDR
 
 #ifndef _GNU_SOURCE
 #define _GNU_SOURCE

--- a/src/eckit/parser/ObjectParser.cc
+++ b/src/eckit/parser/ObjectParser.cc
@@ -15,7 +15,7 @@
 
 #include "eckit/eckit_config.h"
 
-#ifdef eckit_HAVE_UNICODE
+#if eckit_HAVE_UNICODE
 #include <codecvt>
 #endif /* eckit_HAVE_UNICODE */
 
@@ -124,7 +124,7 @@ Value ObjectParser::parseNumber() {
     }
 }
 
-#ifdef eckit_HAVE_UNICODE
+#if eckit_HAVE_UNICODE
 static std::string utf8(uint32_t code) {
     std::wstring_convert<std::codecvt_utf8<char32_t>, char32_t> conv;
     return conv.to_bytes(char32_t(code));
@@ -198,7 +198,7 @@ Value ObjectParser::parseString(char quote) {
                     s += '\t';
                     break;
 
-#ifdef eckit_HAVE_UNICODE
+#if eckit_HAVE_UNICODE
                 case 'u':
                     s += unicode();
                     break;

--- a/src/eckit/persist/Exporter.cc
+++ b/src/eckit/persist/Exporter.cc
@@ -122,7 +122,7 @@ const int Swap<T>::last = sizeof(T) - 1;
 
 class Endian {
 public:
-#ifdef ECKIT_LITTLE_ENDIAN
+#if eckit_LITTLE_ENDIAN
     template <class T>
     static T transform(T x) {
         return Swap<T>()(x);

--- a/src/eckit/serialisation/FileStream.cc
+++ b/src/eckit/serialisation/FileStream.cc
@@ -50,7 +50,7 @@ void FileStream::close() {
 
         // On Linux, you must also flush the directory
 
-#ifdef eckit_HAVE_DIRFD
+#if eckit_HAVE_DIRFD
         PathName directory = PathName(name_).dirName();
         DIR* d             = ::opendir(directory.localPath());
         if (!d)

--- a/src/eckit/system/LibraryManager.cc
+++ b/src/eckit/system/LibraryManager.cc
@@ -46,7 +46,7 @@ namespace system {
 //----------------------------------------------------------------------------------------------------------------------
 
 static std::string path_from_libhandle(const std::string& libname, void* handle) {
-#ifdef eckit_HAVE_DLINFO
+#if eckit_HAVE_DLINFO
     char path[PATH_MAX];
     if (::dlinfo(handle, RTLD_DI_ORIGIN, path) < 0) {
         std::ostringstream ss;

--- a/src/eckit/system/SystemInfo.cc
+++ b/src/eckit/system/SystemInfo.cc
@@ -119,9 +119,9 @@ void SystemInfo::print(std::ostream& out) const {
 //----------------------------------------------------------------------------------------------------------------------
 
 bool SystemInfo::isBigEndian() {
-#if ECKIT_BIG_ENDIAN
+#if eckit_BIG_ENDIAN
     return true;
-#elif ECKIT_LITTLE_ENDIAN
+#elif eckit_LITTLE_ENDIAN
     return false;
 #else
     throw SeriousBug("Unsupported endianess -- neither BIG or LITTLE detected");
@@ -129,9 +129,9 @@ bool SystemInfo::isBigEndian() {
 }
 
 bool SystemInfo::isLittleEndian() {
-#if ECKIT_BIG_ENDIAN
+#if eckit_BIG_ENDIAN
     return false;
-#elif ECKIT_LITTLE_ENDIAN
+#elif eckit_LITTLE_ENDIAN
     return true;
 #else
     throw SeriousBug("Unsupported endianess -- neither BIG or LITTLE detected");

--- a/src/eckit/types/Date.cc
+++ b/src/eckit/types/Date.cc
@@ -208,7 +208,7 @@ long Date::today(void) {
     time_t now;
     time(&now);
 
-#ifdef eckit_HAVE_GMTIME_R
+#if eckit_HAVE_GMTIME_R
     struct tm t;
     gmtime_r(&now, &t);
     long td = (1900 + t.tm_year) * 10000 + (t.tm_mon + 1) * 100 + t.tm_mday;

--- a/src/eckit/types/DateTime.cc
+++ b/src/eckit/types/DateTime.cc
@@ -84,7 +84,7 @@ DateTime::DateTime(time_t thetime) {
 
     // prefer reentrant version ( gmtime_r )
 
-#ifdef eckit_HAVE_GMTIME_R
+#if eckit_HAVE_GMTIME_R
     struct tm t;
     gmtime_r(&thetime, &t);
     long td   = (1900 + t.tm_year) * 10000 + (t.tm_mon + 1) * 100 + t.tm_mday;

--- a/src/eckit/types/Time.cc
+++ b/src/eckit/types/Time.cc
@@ -182,7 +182,7 @@ Time Time::now() {
     time(&now);
     struct tm* pt;
 
-#ifdef eckit_HAVE_GMTIME_R
+#if eckit_HAVE_GMTIME_R
     struct tm t;
     gmtime_r(&now, &t);
     pt = &t;

--- a/src/eckit/utils/MD4.h
+++ b/src/eckit/utils/MD4.h
@@ -13,7 +13,7 @@
 
 #include "eckit/eckit.h"
 
-#ifdef eckit_HAVE_SSL
+#if eckit_HAVE_SSL
 #include <openssl/md4.h>
 #else
 #error "eckit was not configured with OpenSSL, SHA1 is disabled. Use conditional eckit_HAVE_SSL from eckit/eckit.h"

--- a/src/eckit/utils/SHA1.h
+++ b/src/eckit/utils/SHA1.h
@@ -13,7 +13,7 @@
 
 #include "eckit/eckit.h"
 
-#ifdef eckit_HAVE_SSL
+#if eckit_HAVE_SSL
 #include <openssl/sha.h>
 #else
 #error "eckit was not configured with OpenSSL, SHA1 is disabled. Use conditional eckit_HAVE_SSL from eckit/eckit.h"

--- a/tests/filesystem/test_localpathname.cc
+++ b/tests/filesystem/test_localpathname.cc
@@ -410,7 +410,7 @@ CASE("Test PathName hashing") {
     // Create and hash some random data. Note that the buffer is bigger than and a non-integer
     // multiple of the buffer size used in hash generation
 
-#ifdef eckit_HAVE_XXHASH
+#if eckit_HAVE_XXHASH
     const char* hash_method = "xxh64";
 #else
     const char* hash_method = "MD5";

--- a/tests/linalg/test_la_factory.cc
+++ b/tests/linalg/test_la_factory.cc
@@ -25,48 +25,46 @@ CASE("list") {
 
     auto dense_backends = {
         "generic",
-#ifdef eckit_HAVE_ARMADILLO
+#if eckit_HAVE_ARMADILLO
         "armadillo",
 #endif
-#ifdef eckit_HAVE_CUDA
+#if eckit_HAVE_CUDA
         "cuda",
 #endif
-#ifdef eckit_HAVE_EIGEN
+#if eckit_HAVE_EIGEN
         "eigen",
 #endif
-#ifdef eckit_HAVE_LAPACK
+#if eckit_HAVE_LAPACK
         "lapack",
 #endif
-#ifdef eckit_HAVE_MKL
 #if eckit_HAVE_MKL
         "mkl",
 #endif
-#endif
-#ifdef eckit_HAVE_VIENNACL
+#if eckit_HAVE_VIENNACL
         "viennacl",
 #endif
-#ifdef eckit_HAVE_OMP
+#if eckit_HAVE_OMP
         "openmp",
 #endif
     };
 
     auto sparse_backends = {
         "generic",
-#ifdef eckit_HAVE_CUDA
+#if eckit_HAVE_CUDA
         "cuda",
 #endif
-#ifdef eckit_HAVE_EIGEN
+#if eckit_HAVE_EIGEN
         "eigen",
 #endif
-#ifdef eckit_HAVE_MKL
+#if eckit_HAVE_MKL
 #if eckit_HAVE_MKL
         "mkl",
 #endif
 #endif
-#ifdef eckit_HAVE_VIENNACL
+#if eckit_HAVE_VIENNACL
         "viennacl",
 #endif
-#ifdef eckit_HAVE_OMP
+#if eckit_HAVE_OMP
         "openmp",
 #endif
     };

--- a/tests/parser/test_json.cc
+++ b/tests/parser/test_json.cc
@@ -144,7 +144,7 @@ CASE("test_eckit_parser_comment_in_string") {
     EXPECT(v["test"] == "#fff");
 }
 
-#ifdef eckit_HAVE_UNICODE
+#if eckit_HAVE_UNICODE
 CASE("test_eckit_parser_unicode") {
     istringstream in("{\"test\": \"\\u0061\"}");
     JSONParser p(in);

--- a/tests/parser/test_yaml.cc
+++ b/tests/parser/test_yaml.cc
@@ -515,7 +515,7 @@ CASE("test_eckit_yaml_cfg_1") {
     std::cout << toJSON(v) << std::endl;
 }
 
-#ifdef eckit_HAVE_UNICODE
+#if eckit_HAVE_UNICODE
 CASE("test_eckit_yaml_unicode") {
     Value v = YAMLParser::decodeFile("unicode.yaml");
     v.dump(std::cout) << std::endl;

--- a/tests/system/test_system_library.cc
+++ b/tests/system/test_system_library.cc
@@ -114,7 +114,7 @@ CASE("test_libeckit") {
     EXPECT_NO_THROW(LibEcKit::instance().configuration());  // tests an empty configuration
 }
 
-#ifdef eckit_HAVE_ECKIT_CMD
+#if eckit_HAVE_ECKIT_CMD
 CASE("test dynamic load") {
     EXPECT(!LibraryManager::exists("eckit_cmd"));
     EXPECT(LibraryManager::loadLibrary("eckit_cmd") != nullptr);
@@ -127,14 +127,14 @@ CASE("test fail dynamic load") {
     EXPECT(LibraryManager::loadLibrary("fake-library") == nullptr);
 }
 
-#ifdef eckit_HAVE_ECKIT_SQL
+#if eckit_HAVE_ECKIT_SQL
 CASE("Can load library without a eckit::Library object") {
     EXPECT(!LibraryManager::exists("eckit_sql"));
     EXPECT(LibraryManager::loadLibrary("eckit_sql") != nullptr);
 }
 #endif
 
-#ifdef eckit_HAVE_ECKIT_MPI
+#if eckit_HAVE_ECKIT_MPI
 CASE("Fails to load a plugin without a eckit::Plugin object") {
     EXPECT(!LibraryManager::exists("eckit_mpi"));
     EXPECT_THROW_AS(LibraryManager::loadPlugin("eckit_mpi"), UnexpectedState);

--- a/tests/utils/test_byteswap.cc
+++ b/tests/utils/test_byteswap.cc
@@ -67,7 +67,7 @@ CASE("Low-level roundtrip 64 bits") {
 
 //----------------------------------------------------------------------------------------------------------------------
 
-#if ECKIT_LITTLE_ENDIAN  // use htons and htonl as correctness tests, and test against specifc bit patterns
+#if eckit_LITTLE_ENDIAN  // use htons and htonl as correctness tests, and test against specifc bit patterns
 
 CASE("Check correctness 16 bit swap") {
 
@@ -238,7 +238,7 @@ CASE("ByteSwap double") {
     }
 }
 
-#endif  // ECKIT_LITTLE_ENDIAN
+#endif  // eckit_LITTLE_ENDIAN
 
 //----------------------------------------------------------------------------------------------------------------------
 


### PR DESCRIPTION
Copy of [ECKIT-600](https://jira.ecmwf.int/browse/ECKIT-600)

Change preprocessor definitions like `'eckit_HAVE_'` to be always defined with value 0 or 1 is safer and more convenient.
Always being defined means that we use `#if` instead of `#ifdef`. That allows compiler to detect typo in the variable name.
The variable can also be used as boolean.
This is a followup of PR associated with [ECKIT-599](https://jira.ecmwf.int/browse/ECKIT-599)

This had already been discussed in above mentioned PR and agreed by @tlmquintino 
See here https://git.ecmwf.int/projects/ECSDK/repos/eckit/pull-requests/320/diff?commentId=27609#src/eckit/linalg/LinearAlgebraDense.cc?t=33