### PR TITLE
Fix CI for public pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,10 +12,15 @@ on:
   # Trigger the workflow on pull request
   pull_request: ~
 
+  # Trigger on public pull request approval
+  pull_request_target:
+    types: [labeled]
+
 jobs:
   # Calls a reusable CI workflow to build & test the current repository.
   ci:
     name: ci
+    if: ${{ !github.event.pull_request.head.repo.fork && github.event.action != 'labeled' || github.event.label.name == 'approved-for-ci' }}
     uses: ./.github/workflows/reusable-ci.yml
     with:
       eckit_sha: ${{ github.sha }}

--- a/.github/workflows/label-public-pr.yml
+++ b/.github/workflows/label-public-pr.yml
@@ -7,21 +7,4 @@ on:
 
 jobs:
   label:
-    runs-on: ubuntu-latest
-    if: ${{ github.event.pull_request.head.repo.fork }}
-    steps:
-      - name: Add label `contributor`
-        if: ${{ github.event.action == 'opened' }}
-        uses: ecmwf-actions/labeler@v1
-        with:
-          issue: ${{ github.event.number }}
-          label: contributor
-          action: add
-
-      - name: Remove label `approved-for-ci`
-        if: ${{ github.event.action == 'synchronize' && contains(github.event.pull_request.labels.*.name, 'approved-for-ci') }}
-        uses: ecmwf-actions/labeler@v1
-        with:
-          issue: ${{ github.event.number }}
-          label: approved-for-ci
-          action: remove
+    uses: ecmwf-actions/reusable-workflows/.github/workflows/label-pr.yml@v2

--- a/.github/workflows/label-public-pr.yml
+++ b/.github/workflows/label-public-pr.yml
@@ -1,0 +1,27 @@
+# Manage labels of pull requests that originate from forks
+name: label-public-pr
+
+on:
+  pull_request_target:
+    types: [opened, synchronize]
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.pull_request.head.repo.fork }}
+    steps:
+      - name: Add label `contributor`
+        if: ${{ github.event.action == 'opened' }}
+        uses: ecmwf-actions/labeler@v1
+        with:
+          issue: ${{ github.event.number }}
+          label: contributor
+          action: add
+
+      - name: Remove label `approved-for-ci`
+        if: ${{ github.event.action == 'synchronize' && contains(github.event.pull_request.labels.*.name, 'approved-for-ci') }}
+        uses: ecmwf-actions/labeler@v1
+        with:
+          issue: ${{ github.event.number }}
+          label: approved-for-ci
+          action: remove


### PR DESCRIPTION
CI for pull requests originating from forks will run only when labeled with `approved-for-ci` label. Label `contributor` will be added to such PRs. Label `approved-for-ci` will be removed whenever contents of the PR change. 

CI for pull requests from internal branches will run the same way as before.

 