### PR TITLE
Add trigger condition for all CI jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
   private-downstream-ci:
     name: private-downstream-ci
     needs: [downstream-ci]
-    if: success() || failure()
+    if: (success() || failure()) && ${{ !github.event.pull_request.head.repo.fork && github.event.action != 'labeled' || github.event.label.name == 'approved-for-ci' }}
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
@@ -50,6 +50,7 @@ jobs:
   # Build downstream packages on HPC
   downstream-ci-hpc:
     name: downstream-ci-hpc
+    if: ${{ !github.event.pull_request.head.repo.fork && github.event.action != 'labeled' || github.event.label.name == 'approved-for-ci' }}
     uses: ecmwf-actions/downstream-ci/.github/workflows/downstream-ci-hpc.yml@main
     with:
       eckit: ecmwf/eckit@${{ github.event.pull_request.head.sha || github.sha }}
@@ -59,7 +60,7 @@ jobs:
   private-downstream-ci-hpc:
     name: private-downstream-ci-hpc
     needs: [downstream-ci-hpc]
-    if: success() || failure()
+    if: (success() || failure()) && ${{ !github.event.pull_request.head.repo.fork && github.event.action != 'labeled' || github.event.label.name == 'approved-for-ci' }}
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write


### PR DESCRIPTION
`success() || failure()` is not enough, it would trigger even if previous job is skipped, i.e. unlabeled PRs.