### PR TITLE
Enable convertSphericalToCartesian to handle latitudes across poles

### DIFF
--- a/src/eckit/geometry/CMakeLists.txt
+++ b/src/eckit/geometry/CMakeLists.txt
@@ -1,4 +1,6 @@
 list( APPEND eckit_geometry_srcs
+CoordinateHelpers.cc
+CoordinateHelpers.h
 EllipsoidOfRevolution.cc
 EllipsoidOfRevolution.h
 GreatCircle.cc

--- a/src/eckit/geometry/CoordinateHelpers.cc
+++ b/src/eckit/geometry/CoordinateHelpers.cc
@@ -5,11 +5,14 @@
  * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
+#include <limits>
+#include <sstream>
+
+#include "eckit/exception/Exceptions.h"
 #include "eckit/geometry/CoordinateHelpers.h"
 #include "eckit/geometry/Point2.h"
 
-namespace eckit {
-namespace geometry {
+namespace eckit::geometry {
 
 //----------------------------------------------------------------------------------------------------------------------
 
@@ -26,17 +29,27 @@ double normalise_angle(double a, const double minimum) {
 //----------------------------------------------------------------------------------------------------------------------
 
 Point2 canonicaliseOnSphere(const Point2& lonlat, const double minimum_lon) {
-    const double lat = normalise_angle(lonlat[1], -90.);
+    const double lat       = normalise_angle(lonlat[1], -90.);
     const bool across_pole = (lat > 90.);
 
     if (!across_pole) {
-        return Point2(normalise_angle(lonlat[0], minimum_lon), lat);
-    } else {
-        return Point2(normalise_angle(lonlat[0] + 180., minimum_lon), 180. - lat);
+        return {normalise_angle(lonlat[0], minimum_lon), lat};
+    }
+
+    return {normalise_angle(lonlat[0] + 180., minimum_lon), 180. - lat};
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+
+void assert_latitude_range(double lat) {
+    if (!(-90. <= lat && lat <= 90.)) {
+        std::ostringstream oss;
+        oss.precision(std::numeric_limits<double>::max_digits10);
+        oss << "Invalid latitude " << lat;
+        throw BadValue(oss.str(), Here());
     }
 }
 
 //----------------------------------------------------------------------------------------------------------------------
 
-}  // namespace geometry
-}  // namespace eckit
+}  // namespace eckit::geometry

--- a/src/eckit/geometry/CoordinateHelpers.cc
+++ b/src/eckit/geometry/CoordinateHelpers.cc
@@ -1,0 +1,42 @@
+/*
+ * (C) Copyright 2023 UCAR
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+#include "eckit/geometry/CoordinateHelpers.h"
+#include "eckit/geometry/Point2.h"
+
+namespace eckit {
+namespace geometry {
+
+//----------------------------------------------------------------------------------------------------------------------
+
+double normalise_angle(double a, const double minimum) {
+    while (a < minimum) {
+        a += 360.;
+    }
+    while (a >= minimum + 360.) {
+        a -= 360.;
+    }
+    return a;
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+
+Point2 canonicaliseOnSphere(const Point2& lonlat, const double minimum_lon) {
+    const double lat = normalise_angle(lonlat[1], -90.);
+    const bool across_pole = (lat > 90.);
+
+    if (!across_pole) {
+        return Point2(normalise_angle(lonlat[0], minimum_lon), lat);
+    } else {
+        return Point2(normalise_angle(lonlat[0] + 180., minimum_lon), 180. - lat);
+    }
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+
+}  // namespace geometry
+}  // namespace eckit

--- a/src/eckit/geometry/CoordinateHelpers.h
+++ b/src/eckit/geometry/CoordinateHelpers.h
@@ -1,0 +1,43 @@
+/*
+ * (C) Copyright 2023 UCAR.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+#ifndef CoordinateHelpers_H
+#define CoordinateHelpers_H
+
+namespace eckit {
+namespace geometry {
+
+class Point2;
+
+//------------------------------------------------------------------------------------------------------
+
+/// Shift angle in increments of 360° until it lies in [minimum, minimum+360°).
+///
+/// Inputs angle and minimum are in degrees, returned angle is in degrees.
+double normalise_angle(double angle, double minimum);
+
+//------------------------------------------------------------------------------------------------------
+
+/// Shift input point on sphere so its longitude lies in [minimum_lon, minimum_lon+360°)
+/// and its latitude lies in [-90°, 90°].
+///
+/// Latitudes outside the canonical interval [-90°,90°] are first shifted into the interval
+/// [-90°,270°], then any points with latitudes in [90°,270°] are flagged as "across the pole".
+/// Such points are re-labeled with equivalent coordinates that lie within the canonical coordinate
+/// patch by the transformation: (λ, ϕ) -> (λ+180°, 180°-ϕ).
+///
+/// Finally, the longitude is shifted into [minimum_lon, minimum_lon+360°).
+///
+/// Inputs lonlat and minimum_lon are in degrees, returned angles are in degrees.
+Point2 canonicaliseOnSphere(const Point2& lonlat, double minimum_lon = 0.);
+
+//------------------------------------------------------------------------------------------------------
+
+}  // namespace geometry
+}  // namespace eckit
+
+#endif  // CoordinateHelpers_H

--- a/src/eckit/geometry/CoordinateHelpers.h
+++ b/src/eckit/geometry/CoordinateHelpers.h
@@ -8,19 +8,18 @@
 #ifndef CoordinateHelpers_H
 #define CoordinateHelpers_H
 
-namespace eckit {
-namespace geometry {
+namespace eckit::geometry {
 
 class Point2;
 
-//------------------------------------------------------------------------------------------------------
+//----------------------------------------------------------------------------------------------------------------------
 
 /// Shift angle in increments of 360° until it lies in [minimum, minimum+360°).
 ///
 /// Inputs angle and minimum are in degrees, returned angle is in degrees.
 double normalise_angle(double angle, double minimum);
 
-//------------------------------------------------------------------------------------------------------
+//----------------------------------------------------------------------------------------------------------------------
 
 /// Shift input point on sphere so its longitude lies in [minimum_lon, minimum_lon+360°)
 /// and its latitude lies in [-90°, 90°].
@@ -35,9 +34,14 @@ double normalise_angle(double angle, double minimum);
 /// Inputs lonlat and minimum_lon are in degrees, returned angles are in degrees.
 Point2 canonicaliseOnSphere(const Point2& lonlat, double minimum_lon = 0.);
 
-//------------------------------------------------------------------------------------------------------
+//----------------------------------------------------------------------------------------------------------------------
 
-}  // namespace geometry
-}  // namespace eckit
+/// Assert latitude lies in [-90°, 90°].
+void assert_latitude_range(double lat);
+
+
+//----------------------------------------------------------------------------------------------------------------------
+
+}  // namespace eckit::geometry
 
 #endif  // CoordinateHelpers_H

--- a/src/eckit/geometry/EllipsoidOfRevolution.cc
+++ b/src/eckit/geometry/EllipsoidOfRevolution.cc
@@ -11,9 +11,6 @@
 #include "eckit/geometry/EllipsoidOfRevolution.h"
 
 #include <cmath>
-#include <ios>
-// #include <limits>  // for std::numeric_limits
-#include <sstream>
 
 #include "eckit/exception/Exceptions.h"
 #include "eckit/geometry/CoordinateHelpers.h"
@@ -30,21 +27,25 @@ namespace {
 
 static const double degrees_to_radians = M_PI / 180.;
 
-static std::streamsize max_digits10 = 15 + 3;
-
-// C++-11: std::numeric_limits<double>::max_digits10;
-
 }  // namespace
 
 //----------------------------------------------------------------------------------------------------------------------
 
-void EllipsoidOfRevolution::convertSphericalToCartesian(const double& a, const double& b, const Point2& Alonlat,
-                                                        Point3& B, double height) {
+void EllipsoidOfRevolution::convertSphericalToCartesian(const double& a,
+                                                        const double& b,
+                                                        const Point2& Alonlat,
+                                                        Point3& B,
+                                                        double height,
+                                                        bool normalise_angle) {
     ASSERT(a > 0.);
     ASSERT(b > 0.);
 
     // See https://en.wikipedia.org/wiki/Reference_ellipsoid#Coordinates
     // numerical conditioning for both ϕ (poles) and λ (Greenwich/Date Line)
+
+    if (!normalise_angle) {
+        assert_latitude_range(Alonlat[1]);
+    }
 
     const Point2 alonlat = canonicaliseOnSphere(Alonlat, -180.);
 

--- a/src/eckit/geometry/EllipsoidOfRevolution.cc
+++ b/src/eckit/geometry/EllipsoidOfRevolution.cc
@@ -27,7 +27,8 @@ namespace eckit::geometry {
 
 namespace {
 
-static double normalise_longitude(double a, const double& minimum) {
+// Shift the angle a by increments of 360 until it lies in [minimum, minimum+360)
+static double normalise_angle(double a, const double& minimum) {
     while (a < minimum) {
         a += 360;
     }
@@ -52,17 +53,15 @@ void EllipsoidOfRevolution::convertSphericalToCartesian(const double& a, const d
     ASSERT(a > 0.);
     ASSERT(b > 0.);
 
-    if (!(-90. <= Alonlat[1] && Alonlat[1] <= 90.)) {
-        std::ostringstream oss;
-        oss.precision(max_digits10);
-        oss << "Invalid latitude " << Alonlat[1];
-        throw BadValue(oss.str(), Here());
-    }
-
     // See https://en.wikipedia.org/wiki/Reference_ellipsoid#Coordinates
     // numerical conditioning for both ϕ (poles) and λ (Greenwich/Date Line)
+    //
+    // See Sphere::convertSphericalToCartesian for a description of how
+    // points with latitudes outside [-90°,90°] are handled.
 
-    const double lambda_deg = normalise_longitude(Alonlat[0], -180.);
+    const bool A_across_pole = (normalise_angle(Alonlat[1], -90.) > 90.);
+
+    const double lambda_deg = normalise_angle(Alonlat[0] + (A_across_pole ? 180. : 0.), -180.);
     const double lambda     = degrees_to_radians * lambda_deg;
     const double phi        = degrees_to_radians * Alonlat[1];
 

--- a/src/eckit/geometry/EllipsoidOfRevolution.cc
+++ b/src/eckit/geometry/EllipsoidOfRevolution.cc
@@ -16,6 +16,7 @@
 #include <sstream>
 
 #include "eckit/exception/Exceptions.h"
+#include "eckit/geometry/CoordinateHelpers.h"
 #include "eckit/geometry/Point2.h"
 #include "eckit/geometry/Point3.h"
 
@@ -26,17 +27,6 @@ namespace eckit::geometry {
 //----------------------------------------------------------------------------------------------------------------------
 
 namespace {
-
-// Shift the angle a by increments of 360 until it lies in [minimum, minimum+360)
-static double normalise_angle(double a, const double& minimum) {
-    while (a < minimum) {
-        a += 360;
-    }
-    while (a >= minimum + 360) {
-        a -= 360;
-    }
-    return a;
-}
 
 static const double degrees_to_radians = M_PI / 180.;
 
@@ -55,15 +45,12 @@ void EllipsoidOfRevolution::convertSphericalToCartesian(const double& a, const d
 
     // See https://en.wikipedia.org/wiki/Reference_ellipsoid#Coordinates
     // numerical conditioning for both ϕ (poles) and λ (Greenwich/Date Line)
-    //
-    // See Sphere::convertSphericalToCartesian for a description of how
-    // points with latitudes outside [-90°,90°] are handled.
 
-    const bool A_across_pole = (normalise_angle(Alonlat[1], -90.) > 90.);
+    const Point2 alonlat = canonicaliseOnSphere(Alonlat, -180.);
 
-    const double lambda_deg = normalise_angle(Alonlat[0] + (A_across_pole ? 180. : 0.), -180.);
+    const double lambda_deg = alonlat[0];
     const double lambda     = degrees_to_radians * lambda_deg;
-    const double phi        = degrees_to_radians * Alonlat[1];
+    const double phi        = degrees_to_radians * alonlat[1];
 
     const double sin_phi    = std::sin(phi);
     const double cos_phi    = std::sqrt(1. - sin_phi * sin_phi);

--- a/src/eckit/geometry/EllipsoidOfRevolution.h
+++ b/src/eckit/geometry/EllipsoidOfRevolution.h
@@ -11,24 +11,28 @@
 #ifndef EllipsoidOfRevolution_H
 #define EllipsoidOfRevolution_H
 
-//------------------------------------------------------------------------------------------------------
+//----------------------------------------------------------------------------------------------------------------------
 
 namespace eckit::geometry {
 
-//------------------------------------------------------------------------------------------------------
+//----------------------------------------------------------------------------------------------------------------------
 
 class Point2;
 class Point3;
 
-//------------------------------------------------------------------------------------------------------
+//----------------------------------------------------------------------------------------------------------------------
 
 struct EllipsoidOfRevolution {
     // Convert elliptic coordinates to Cartesian
-    static void convertSphericalToCartesian(const double& radiusA, const double& radiusB, const Point2& Alonlat,
-                                            Point3& B, double height = 0.);
+    static void convertSphericalToCartesian(const double& radiusA,
+                                            const double& radiusB,
+                                            const Point2& Alonlat,
+                                            Point3& B,
+                                            double height        = 0.,
+                                            bool normalise_angle = false);
 };
 
-//------------------------------------------------------------------------------------------------------
+//----------------------------------------------------------------------------------------------------------------------
 
 }  // namespace eckit::geometry
 

--- a/src/eckit/geometry/Sphere.cc
+++ b/src/eckit/geometry/Sphere.cc
@@ -190,14 +190,20 @@ void Sphere::convertSphericalToCartesian(const double& radius, const Point2& Alo
      * These three conditionings combined project very accurately to the sphere
      * poles and quadrants.
      *
-     * Latitudes outside [-90,90] are normalised back into the interval by the transformation:
-     *   (λ, ϕ) -> (λ+180, 180-ϕ) if ϕ > 90
-     *          -> (λ+180, -180-ϕ) if ϕ < -90
-     * As the convertSphericalToCartesian algorithm depends on sin(ϕ) which is invariant
-     * under this transformation, the normalisation affects only the longitude phase-shift.
+     * Latitudes outside the standard interval [-90°,90°] are first normalised
+     * into the interval [-90°,270°], then any points with latitudes in
+     * [90°,270°] are flagged as "across the pole". Such points are re-labeled
+     * with equivalent coordinates that lie within the standard coordinate patch
+     * by the transformation
+     *   (λ, ϕ) -> (λ+180°, 180°-ϕ)
+     * As the convertSphericalToCartesian algorithm depends on sin(ϕ) which is
+     * invariant under this transformation, the normalisation procedure is
+     * simplified to only perform the longitude phase shift.
      */
 
-    const bool lat_across_pole = (Alonlat[1] < -90. || Alonlat[1] > 90.);
+    // We normalise the latitude by calling the logically-identical normalise_longitude.
+    const auto& normalise_latitude = normalise_longitude;
+    const bool lat_across_pole = (normalise_latitude(Alonlat[1], -90.) > 90.);
 
     const double lambda_deg = normalise_longitude(Alonlat[0] + (lat_across_pole ? 180. : 0.), -180.);
     const double lambda     = degrees_to_radians * lambda_deg;

--- a/src/eckit/geometry/Sphere.cc
+++ b/src/eckit/geometry/Sphere.cc
@@ -175,17 +175,8 @@ void Sphere::greatCircleLongitudeGivenLatitude(const Point2& Alonlat, const Poin
     Clon2 = lon.size() > 1 ? lon[1] : std::numeric_limits<double>::signaling_NaN();
 }
 
-void Sphere::convertSphericalToCartesian(const double& radius, const Point2& Alonlat, Point3& B, double height,
-                                         const bool normalise_lats_across_poles) {
+void Sphere::convertSphericalToCartesian(const double& radius, const Point2& Alonlat, Point3& B, double height) {
     ASSERT(radius > 0.);
-
-    const bool lat_across_pole = (Alonlat[1] < -90. || Alonlat[1] > 90.);
-    if (!normalise_lats_across_poles && lat_across_pole) {
-        std::ostringstream oss;
-        oss.precision(max_digits10);
-        oss << "Invalid latitude " << Alonlat[1];
-        throw BadValue(oss.str(), Here());
-    }
 
     /*
      * See https://en.wikipedia.org/wiki/Reference_ellipsoid#Coordinates
@@ -199,13 +190,14 @@ void Sphere::convertSphericalToCartesian(const double& radius, const Point2& Alo
      * These three conditionings combined project very accurately to the sphere
      * poles and quadrants.
      *
-     * Note the option `normalise_lats_across_poles` enables normalising latitudes
-     * outside [-90,90] back into the interval according to the transformation:
+     * Latitudes outside [-90,90] are normalised back into the interval by the transformation:
      *   (λ, ϕ) -> (λ+180, 180-ϕ) if ϕ > 90
      *          -> (λ+180, -180-ϕ) if ϕ < -90
-     * As the SphericalToCartesian algorithm depends on sin(ϕ) which is invariant
-     * under this renormalisation, this option controls only the longitude phase-shift.
+     * As the convertSphericalToCartesian algorithm depends on sin(ϕ) which is invariant
+     * under this transformation, the normalisation affects only the longitude phase-shift.
      */
+
+    const bool lat_across_pole = (Alonlat[1] < -90. || Alonlat[1] > 90.);
 
     const double lambda_deg = normalise_longitude(Alonlat[0] + (lat_across_pole ? 180. : 0.), -180.);
     const double lambda     = degrees_to_radians * lambda_deg;

--- a/src/eckit/geometry/Sphere.h
+++ b/src/eckit/geometry/Sphere.h
@@ -52,7 +52,8 @@ struct Sphere {
                                                   double& Clon1, double& Clon2);
 
     // Convert spherical coordinates to Cartesian
-    static void convertSphericalToCartesian(const double& radius, const Point2& Alonlat, Point3& B, double height = 0.);
+    static void convertSphericalToCartesian(const double& radius, const Point2& Alonlat, Point3& B, double height = 0.,
+                                            bool normalise_lats_across_poles = false);
 
     // Convert Cartesian coordinates to spherical
     static void convertCartesianToSpherical(const double& radius, const Point3& A, Point2& Blonlat);

--- a/src/eckit/geometry/Sphere.h
+++ b/src/eckit/geometry/Sphere.h
@@ -52,8 +52,7 @@ struct Sphere {
                                                   double& Clon1, double& Clon2);
 
     // Convert spherical coordinates to Cartesian
-    static void convertSphericalToCartesian(const double& radius, const Point2& Alonlat, Point3& B, double height = 0.,
-                                            bool normalise_lats_across_poles = false);
+    static void convertSphericalToCartesian(const double& radius, const Point2& Alonlat, Point3& B, double height = 0.);
 
     // Convert Cartesian coordinates to spherical
     static void convertCartesianToSpherical(const double& radius, const Point3& A, Point2& Blonlat);

--- a/src/eckit/geometry/Sphere.h
+++ b/src/eckit/geometry/Sphere.h
@@ -11,20 +11,22 @@
 #ifndef Sphere_H
 #define Sphere_H
 
-//------------------------------------------------------------------------------------------------------
+//----------------------------------------------------------------------------------------------------------------------
 
 namespace eckit::geometry {
 
-//------------------------------------------------------------------------------------------------------
+//----------------------------------------------------------------------------------------------------------------------
 
 class Point2;
 class Point3;
 
-//------------------------------------------------------------------------------------------------------
+//----------------------------------------------------------------------------------------------------------------------
 
 struct Sphere {
     /// Great-circle central angle between two points (latitude/longitude coordinates) in radians
-    static double centralAngle(const Point2& Alonlat, const Point2& Blonlat);
+    static double centralAngle(const Point2& Alonlat,
+                               const Point2& Blonlat,
+                               bool normalise_angle = false);
 
     /// Great-circle central angle between two points (Cartesian coordinates) in radians
     static double centralAngle(const double& radius, const Point3& A, const Point3& B);
@@ -52,13 +54,17 @@ struct Sphere {
                                                   double& Clon1, double& Clon2);
 
     // Convert spherical coordinates to Cartesian
-    static void convertSphericalToCartesian(const double& radius, const Point2& Alonlat, Point3& B, double height = 0.);
+    static void convertSphericalToCartesian(const double& radius,
+                                            const Point2& Alonlat,
+                                            Point3& B,
+                                            double height        = 0.,
+                                            bool normalise_angle = false);
 
     // Convert Cartesian coordinates to spherical
     static void convertCartesianToSpherical(const double& radius, const Point3& A, Point2& Blonlat);
 };
 
-//------------------------------------------------------------------------------------------------------
+//----------------------------------------------------------------------------------------------------------------------
 
 }  // namespace eckit::geometry
 

--- a/src/eckit/geometry/SphereT.h
+++ b/src/eckit/geometry/SphereT.h
@@ -13,11 +13,11 @@
 
 #include "eckit/geometry/Sphere.h"
 
-//------------------------------------------------------------------------------------------------------
+//----------------------------------------------------------------------------------------------------------------------
 
 namespace eckit::geometry {
 
-//------------------------------------------------------------------------------------------------------
+//----------------------------------------------------------------------------------------------------------------------
 
 /// Definition of a sphere parametrised with a geodetic datum
 template <class DATUM>
@@ -27,8 +27,10 @@ struct SphereT {
     inline static double radius() { return DATUM::radius(); }
 
     /// Great-circle central angle between two points (longitude/latitude coordinates) in radians
-    inline static double centralAngle(const Point2& Alonlat, const Point2& Blonlat) {
-        return Sphere::centralAngle(Alonlat, Blonlat);
+    inline static double centralAngle(const Point2& Alonlat,
+                                      const Point2& Blonlat,
+                                      bool normalise_angle = false) {
+        return Sphere::centralAngle(Alonlat, Blonlat, normalise_angle);
     }
 
     /// Great-circle central angle between two points (Cartesian coordinates) in radians
@@ -66,8 +68,11 @@ struct SphereT {
     }
 
     // Convert spherical coordinates to Cartesian
-    inline static void convertSphericalToCartesian(const Point2& Alonlat, Point3& B, double height = 0.) {
-        Sphere::convertSphericalToCartesian(DATUM::radius(), Alonlat, B, height);
+    inline static void convertSphericalToCartesian(const Point2& Alonlat,
+                                                   Point3& B,
+                                                   double height        = 0.,
+                                                   bool normalise_angle = false) {
+        Sphere::convertSphericalToCartesian(DATUM::radius(), Alonlat, B, height, normalise_angle);
     }
 
     // Convert Cartesian coordinates to spherical
@@ -76,7 +81,7 @@ struct SphereT {
     }
 };
 
-//------------------------------------------------------------------------------------------------------
+//----------------------------------------------------------------------------------------------------------------------
 
 }  // namespace eckit::geometry
 

--- a/src/eckit/geometry/SphereT.h
+++ b/src/eckit/geometry/SphereT.h
@@ -66,9 +66,8 @@ struct SphereT {
     }
 
     // Convert spherical coordinates to Cartesian
-    inline static void convertSphericalToCartesian(const Point2& Alonlat, Point3& B, double height = 0.,
-                                                   bool normalise_lats_across_poles = false) {
-        Sphere::convertSphericalToCartesian(DATUM::radius(), Alonlat, B, height, normalise_lats_across_poles);
+    inline static void convertSphericalToCartesian(const Point2& Alonlat, Point3& B, double height = 0.) {
+        Sphere::convertSphericalToCartesian(DATUM::radius(), Alonlat, B, height);
     }
 
     // Convert Cartesian coordinates to spherical

--- a/src/eckit/geometry/SphereT.h
+++ b/src/eckit/geometry/SphereT.h
@@ -66,8 +66,9 @@ struct SphereT {
     }
 
     // Convert spherical coordinates to Cartesian
-    inline static void convertSphericalToCartesian(const Point2& Alonlat, Point3& B, double height = 0.) {
-        Sphere::convertSphericalToCartesian(DATUM::radius(), Alonlat, B, height);
+    inline static void convertSphericalToCartesian(const Point2& Alonlat, Point3& B, double height = 0.,
+                                                   bool normalise_lats_across_poles = false) {
+        Sphere::convertSphericalToCartesian(DATUM::radius(), Alonlat, B, height, normalise_lats_across_poles);
     }
 
     // Convert Cartesian coordinates to spherical

--- a/src/eckit/geometry/polygon/LonLatPolygon.cc
+++ b/src/eckit/geometry/polygon/LonLatPolygon.cc
@@ -14,6 +14,7 @@
 #include <ostream>
 
 #include "eckit/exception/Exceptions.h"
+#include "eckit/geometry/CoordinateHelpers.h"
 #include "eckit/types/FloatCompare.h"
 
 //----------------------------------------------------------------------------------------------------------------------
@@ -106,30 +107,10 @@ std::ostream& operator<<(std::ostream& out, const LonLatPolygon& pc) {
 }
 
 bool LonLatPolygon::contains(const Point2& P) const {
-    // Shift the angle a by increments of 360 until it lies in [minimum, minimum+360)
-    auto normalise_angle = [](double a, const double minimum) {
-        while (a < minimum) {
-            a += 360;
-        }
-        while (a >= minimum + 360) {
-            a -= 360;
-        }
-        return a;
-    };
 
-    // Latitudes outside the canonical interval [-90°,90°] are first shifted
-    // into the interval [-90°,270°], then any points with latitudes in
-    // [90°,270°] are flagged as "across the pole". Such points are re-labeled
-    // with equivalent coordinates that lie within the canonical coordinate patch
-    // by the transformation
-    //   (λ, ϕ) -> (λ+180°, 180°-ϕ)
-    auto lat = normalise_angle(P[LAT], -90.);
-    const bool P_across_pole = (lat > 90.);
-    if (P_across_pole) {
-        lat = 180. - lat;
-    }
-
-    auto lon = normalise_angle(P[LON] + (P_across_pole ? 180. : 0.), min_[LON]);
+    const Point2 p = canonicaliseOnSphere(P, min_[LON]);
+    auto lat = p[LAT];
+    auto lon = p[LON];
 
     // check poles
     if (includeNorthPole_ && is_approximately_equal(lat, 90)) {

--- a/src/eckit/geometry/polygon/LonLatPolygon.cc
+++ b/src/eckit/geometry/polygon/LonLatPolygon.cc
@@ -106,11 +106,14 @@ std::ostream& operator<<(std::ostream& out, const LonLatPolygon& pc) {
     return out;
 }
 
-bool LonLatPolygon::contains(const Point2& P) const {
+bool LonLatPolygon::contains(const Point2& Plonlat, bool normalise_angle) const {
+    if (!normalise_angle) {
+        assert_latitude_range(Plonlat[LAT]);
+    }
 
-    const Point2 p = canonicaliseOnSphere(P, min_[LON]);
-    auto lat = p[LAT];
-    auto lon = p[LON];
+    const Point2 p = canonicaliseOnSphere(Plonlat, min_[LON]);
+    auto lat       = p[LAT];
+    auto lon       = p[LON];
 
     // check poles
     if (includeNorthPole_ && is_approximately_equal(lat, 90)) {

--- a/src/eckit/geometry/polygon/LonLatPolygon.h
+++ b/src/eckit/geometry/polygon/LonLatPolygon.h
@@ -58,8 +58,9 @@ public:
     /// @brief Point-in-polygon test based on winding number
     /// @note reference <a href="http://geomalgorithms.com/a03-_inclusion.html">Inclusion of a Point in a Polygon</a>
     /// @param[in] P given point
+    /// @param[in] normalise_angle normalise point angles
     /// @return if point (lon,lat) is in polygon
-    bool contains(const Point2& Plonlat) const;
+    bool contains(const Point2& Plonlat, bool normalise_angle = false) const;
 
 private:
     // -- Methods

--- a/tests/geometry/CMakeLists.txt
+++ b/tests/geometry/CMakeLists.txt
@@ -1,4 +1,4 @@
-foreach( _test great_circle kdtree sphere kpoint points polygon )
+foreach( _test coordinate_helpers great_circle kdtree sphere kpoint points polygon )
     ecbuild_add_test( TARGET  eckit_test_geometry_${_test}
                       SOURCES test_${_test}.cc
                       LIBS    eckit_geometry )

--- a/tests/geometry/test_coordinate_helpers.cc
+++ b/tests/geometry/test_coordinate_helpers.cc
@@ -1,0 +1,70 @@
+/*
+ * (C) Copyright 2023 UCAR
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+#include "eckit/geometry/CoordinateHelpers.h"
+#include "eckit/geometry/Point2.h"
+#include "eckit/testing/Test.h"
+
+
+namespace eckit {
+namespace test {
+
+using namespace geometry;
+
+// -----------------------------------------------------------------------------
+
+CASE("normalise angles") {
+    EXPECT(0. == normalise_angle(360., 0.));
+    EXPECT(14. == normalise_angle(374., 0.));
+    EXPECT(14. == normalise_angle(374., -90.));
+    EXPECT(374. == normalise_angle(374., 90.));
+}
+
+CASE("canonicalise on sphere") {
+    using types::is_approximately_equal;
+
+    const Point2 p1(108., 32.);
+
+    // Worse coordinates for the same point:
+    const Point2 p2(-252., 32.);
+    const Point2 p3(288., 148.);
+    const Point2 p4(108., -328.);
+
+    // Check each of these is correctly shifted back to original point:
+    const Point2 q2 = canonicaliseOnSphere(p2);
+    const Point2 q3 = canonicaliseOnSphere(p3);
+    const Point2 q4 = canonicaliseOnSphere(p4);
+
+    EXPECT(p1.x() == q2.x());
+    EXPECT(p1.y() == q2.y());
+    EXPECT(p1.x() == q3.x());
+    EXPECT(p1.y() == q3.y());
+    EXPECT(p1.x() == q4.x());
+    EXPECT(p1.y() == q4.y());
+
+    // Check with longitude offset
+    const Point2 q2b = canonicaliseOnSphere(p2, -90.);
+    EXPECT(q2b.x() == 108.);
+    EXPECT(q2b.y() == 32.);
+
+    const Point2 q2c = canonicaliseOnSphere(p2, 90.);
+    EXPECT(q2c.x() == 108.);
+    EXPECT(q2c.y() == 32.);
+
+    const Point2 q2d = canonicaliseOnSphere(p2, 180.);
+    EXPECT(q2d.x() == 468.);
+    EXPECT(q2d.y() == 32.);
+}
+
+// -----------------------------------------------------------------------------
+
+}  // namespace test
+}  // namespace eckit
+
+int main(int argc, char** argv) {
+    return eckit::testing::run_tests(argc, argv);
+}

--- a/tests/geometry/test_coordinate_helpers.cc
+++ b/tests/geometry/test_coordinate_helpers.cc
@@ -10,8 +10,7 @@
 #include "eckit/testing/Test.h"
 
 
-namespace eckit {
-namespace test {
+namespace eckit::test {
 
 using namespace geometry;
 
@@ -62,8 +61,7 @@ CASE("canonicalise on sphere") {
 
 // -----------------------------------------------------------------------------
 
-}  // namespace test
-}  // namespace eckit
+}  // namespace eckit::test
 
 int main(int argc, char** argv) {
     return eckit::testing::run_tests(argc, argv);

--- a/tests/geometry/test_polygon.cc
+++ b/tests/geometry/test_polygon.cc
@@ -266,8 +266,8 @@ CASE("LonLatPolygon") {
         }
 
         // Test points at non-canonical coordinates
-        EXPECT(poly.contains({lonmid + 360., latmid}));
-        EXPECT(poly.contains({lonmid, 180. - latmid}));
+        EXPECT(poly.contains({lonmid + 360., latmid}, true));
+        EXPECT(poly.contains({lonmid, 180. - latmid}, true));
     }
 
     SECTION("Parallelogram") {

--- a/tests/geometry/test_polygon.cc
+++ b/tests/geometry/test_polygon.cc
@@ -267,7 +267,7 @@ CASE("LonLatPolygon") {
 
         // Test points at non-canonical coordinates
         // Default behavior throws
-        EXPECT_THROWS_AS(poly.contains({lonmid, 180. - latmid}, eckit::BadValue);
+        EXPECT_THROWS_AS(poly.contains({lonmid, 180. - latmid}), eckit::BadValue);
 
         EXPECT(poly.contains({lonmid + 360., latmid}, true));
         EXPECT(poly.contains({lonmid, 180. - latmid}, true));

--- a/tests/geometry/test_polygon.cc
+++ b/tests/geometry/test_polygon.cc
@@ -264,6 +264,10 @@ CASE("LonLatPolygon") {
                 EXPECT_NOT(poly.contains({lonmax + eps, lat}));
             }
         }
+
+        // Test points at non-canonical coordinates
+        EXPECT(poly.contains({lonmid + 360., latmid}));
+        EXPECT(poly.contains({lonmid, 180. - latmid}));
     }
 
     SECTION("Parallelogram") {

--- a/tests/geometry/test_polygon.cc
+++ b/tests/geometry/test_polygon.cc
@@ -266,6 +266,9 @@ CASE("LonLatPolygon") {
         }
 
         // Test points at non-canonical coordinates
+        // Default behavior throws
+        EXPECT_THROWS_AS(poly.contains({lonmid, 180. - latmid}, eckit::BadValue);
+
         EXPECT(poly.contains({lonmid + 360., latmid}, true));
         EXPECT(poly.contains({lonmid, 180. - latmid}, true));
     }

--- a/tests/geometry/test_sphere.cc
+++ b/tests/geometry/test_sphere.cc
@@ -212,6 +212,20 @@ CASE("test unit sphere lat 100") {
     EXPECT(eckit::types::is_approximately_equal(p.z(), q.z()));
 }
 
+CASE("test unit sphere lat 290") {
+    const PointLonLat ll1(15., 290.);
+    const PointLonLat ll2(15., -70.);
+    PointXYZ p, q;
+
+    UnitSphere::convertSphericalToCartesian(ll1, p);
+    UnitSphere::convertSphericalToCartesian(ll2, q);
+
+    // sin(x) and sin(pi-x) are not bitwise identical
+    EXPECT(eckit::types::is_approximately_equal(p.x(), q.x()));
+    EXPECT(eckit::types::is_approximately_equal(p.y(), q.y()));
+    EXPECT(eckit::types::is_approximately_equal(p.z(), q.z()));
+}
+
 CASE("test unit sphere lat -120") {
     const PointLonLat ll1(45., -120.);
     const PointLonLat ll2(225., -60.);

--- a/tests/geometry/test_sphere.cc
+++ b/tests/geometry/test_sphere.cc
@@ -196,6 +196,49 @@ CASE("test unit sphere lon 315") {
 }
 
 // -----------------------------------------------------------------------------
+// test unit sphere latitudes outside [-90, 90]
+
+CASE("test unit sphere lat 100") {
+    const PointLonLat ll1(0., 100.);
+    const PointLonLat ll2(180., 80.);
+    PointXYZ p, q;
+
+    // Default behavior throws
+    EXPECT_THROWS_AS(UnitSphere::convertSphericalToCartesian(ll1, p), eckit::Exception);
+
+    // Optional behavior normalises coordinates
+    const double height = 0.;
+    const bool normalise_lats_across_poles = true;
+    UnitSphere::convertSphericalToCartesian(ll1, p, height, normalise_lats_across_poles);
+    UnitSphere::convertSphericalToCartesian(ll2, q);
+
+    // sin(x) and sin(pi-x) are not bitwise identical
+    EXPECT(eckit::types::is_approximately_equal(p.x(), q.x()));
+    EXPECT(eckit::types::is_approximately_equal(p.y(), q.y()));
+    EXPECT(eckit::types::is_approximately_equal(p.z(), q.z()));
+}
+
+CASE("test unit sphere lat -120") {
+    const PointLonLat ll1(45., -120.);
+    const PointLonLat ll2(225., -60.);
+    PointXYZ p, q;
+
+    // Default behavior throws
+    EXPECT_THROWS_AS(UnitSphere::convertSphericalToCartesian(ll1, p), eckit::Exception);
+
+    // Optional behavior normalises coordinates
+    const double height = 0.;
+    const bool normalise_lats_across_poles = true;
+    UnitSphere::convertSphericalToCartesian(ll1, p, height, normalise_lats_across_poles);
+    UnitSphere::convertSphericalToCartesian(ll2, q);
+
+    // sin(x) and sin(pi-x) are not bitwise identical
+    EXPECT(eckit::types::is_approximately_equal(p.x(), q.x()));
+    EXPECT(eckit::types::is_approximately_equal(p.y(), q.y()));
+    EXPECT(eckit::types::is_approximately_equal(p.z(), q.z()));
+}
+
+// -----------------------------------------------------------------------------
 // test unit sphere area
 
 CASE("test unit sphere area globe") {

--- a/tests/geometry/test_sphere.cc
+++ b/tests/geometry/test_sphere.cc
@@ -203,8 +203,8 @@ CASE("test unit sphere lat 100") {
     const PointLonLat ll2(180., 80.);
     PointXYZ p, q;
 
-    UnitSphere::convertSphericalToCartesian(ll1, p);
-    UnitSphere::convertSphericalToCartesian(ll2, q);
+    UnitSphere::convertSphericalToCartesian(ll1, p, 0., true);
+    UnitSphere::convertSphericalToCartesian(ll2, q, 0., true);
 
     // sin(x) and sin(pi-x) are not bitwise identical
     EXPECT(eckit::types::is_approximately_equal(p.x(), q.x()));
@@ -217,8 +217,8 @@ CASE("test unit sphere lat 290") {
     const PointLonLat ll2(15., -70.);
     PointXYZ p, q;
 
-    UnitSphere::convertSphericalToCartesian(ll1, p);
-    UnitSphere::convertSphericalToCartesian(ll2, q);
+    UnitSphere::convertSphericalToCartesian(ll1, p, 0., true);
+    UnitSphere::convertSphericalToCartesian(ll2, q, 0., true);
 
     // sin(x) and sin(pi-x) are not bitwise identical
     EXPECT(eckit::types::is_approximately_equal(p.x(), q.x()));
@@ -231,8 +231,8 @@ CASE("test unit sphere lat -120") {
     const PointLonLat ll2(225., -60.);
     PointXYZ p, q;
 
-    UnitSphere::convertSphericalToCartesian(ll1, p);
-    UnitSphere::convertSphericalToCartesian(ll2, q);
+    UnitSphere::convertSphericalToCartesian(ll1, p, 0., true);
+    UnitSphere::convertSphericalToCartesian(ll2, q, 0., true);
 
     // sin(x) and sin(pi-x) are not bitwise identical
     EXPECT(eckit::types::is_approximately_equal(p.x(), q.x()));

--- a/tests/geometry/test_sphere.cc
+++ b/tests/geometry/test_sphere.cc
@@ -203,6 +203,9 @@ CASE("test unit sphere lat 100") {
     const PointLonLat ll2(180., 80.);
     PointXYZ p, q;
 
+    // Default behavior throws
+    EXPECT_THROWS_AS(UnitSphere::convertSphericalToCartesian(ll1, p), eckit::BadValue);
+
     UnitSphere::convertSphericalToCartesian(ll1, p, 0., true);
     UnitSphere::convertSphericalToCartesian(ll2, q, 0., true);
 
@@ -217,6 +220,9 @@ CASE("test unit sphere lat 290") {
     const PointLonLat ll2(15., -70.);
     PointXYZ p, q;
 
+    // Default behavior throws
+    EXPECT_THROWS_AS(UnitSphere::convertSphericalToCartesian(ll1, p), eckit::BadValue);
+
     UnitSphere::convertSphericalToCartesian(ll1, p, 0., true);
     UnitSphere::convertSphericalToCartesian(ll2, q, 0., true);
 
@@ -230,6 +236,9 @@ CASE("test unit sphere lat -120") {
     const PointLonLat ll1(45., -120.);
     const PointLonLat ll2(225., -60.);
     PointXYZ p, q;
+
+    // Default behavior throws
+    EXPECT_THROWS_AS(UnitSphere::convertSphericalToCartesian(ll1, p), eckit::BadValue);
 
     UnitSphere::convertSphericalToCartesian(ll1, p, 0., true);
     UnitSphere::convertSphericalToCartesian(ll2, q, 0., true);

--- a/tests/geometry/test_sphere.cc
+++ b/tests/geometry/test_sphere.cc
@@ -196,7 +196,7 @@ CASE("test unit sphere lon 315") {
 }
 
 // -----------------------------------------------------------------------------
-// test unit sphere latitudes outside [-90, 90]
+// test unit sphere with non-canonical latitudes outside [-90, 90]
 
 CASE("test unit sphere lat 100") {
     const PointLonLat ll1(0., 100.);
@@ -238,6 +238,28 @@ CASE("test unit sphere lat -120") {
     EXPECT(eckit::types::is_approximately_equal(p.x(), q.x()));
     EXPECT(eckit::types::is_approximately_equal(p.y(), q.y()));
     EXPECT(eckit::types::is_approximately_equal(p.z(), q.z()));
+}
+
+// -----------------------------------------------------------------------------
+// test unit sphere distances with non-canonical coordinates
+
+CASE("test unit sphere distances") {
+    const PointLonLat P1(-71.6, -33.);  // Valparaíso
+    const PointLonLat P2(121.8, 31.4);  // Shanghai
+
+    // Same points with added shifts
+    const PointLonLat P1b(288.4, -33.);    // Valparaíso + longitude shift
+    const PointLonLat P2b(301.8, 148.6);   // Shanghai + latitude/longitude shift
+    const PointLonLat P2c(-58.2, -211.4);  // Shanghai + latitude/longitude shift
+
+    const double d0 = UnitSphere::distance(P1, P2);
+    const double d1 = UnitSphere::distance(P1b, P2);
+    const double d2 = UnitSphere::distance(P1, P2b);
+    const double d3 = UnitSphere::distance(P1, P2c);
+
+    EXPECT(eckit::types::is_approximately_equal(d0, d1));
+    EXPECT(eckit::types::is_approximately_equal(d0, d2));
+    EXPECT(eckit::types::is_approximately_equal(d0, d3));
 }
 
 // -----------------------------------------------------------------------------

--- a/tests/geometry/test_sphere.cc
+++ b/tests/geometry/test_sphere.cc
@@ -203,13 +203,7 @@ CASE("test unit sphere lat 100") {
     const PointLonLat ll2(180., 80.);
     PointXYZ p, q;
 
-    // Default behavior throws
-    EXPECT_THROWS_AS(UnitSphere::convertSphericalToCartesian(ll1, p), eckit::Exception);
-
-    // Optional behavior normalises coordinates
-    const double height = 0.;
-    const bool normalise_lats_across_poles = true;
-    UnitSphere::convertSphericalToCartesian(ll1, p, height, normalise_lats_across_poles);
+    UnitSphere::convertSphericalToCartesian(ll1, p);
     UnitSphere::convertSphericalToCartesian(ll2, q);
 
     // sin(x) and sin(pi-x) are not bitwise identical
@@ -223,13 +217,7 @@ CASE("test unit sphere lat -120") {
     const PointLonLat ll2(225., -60.);
     PointXYZ p, q;
 
-    // Default behavior throws
-    EXPECT_THROWS_AS(UnitSphere::convertSphericalToCartesian(ll1, p), eckit::Exception);
-
-    // Optional behavior normalises coordinates
-    const double height = 0.;
-    const bool normalise_lats_across_poles = true;
-    UnitSphere::convertSphericalToCartesian(ll1, p, height, normalise_lats_across_poles);
+    UnitSphere::convertSphericalToCartesian(ll1, p);
     UnitSphere::convertSphericalToCartesian(ll2, q);
 
     // sin(x) and sin(pi-x) are not bitwise identical


### PR DESCRIPTION
The atlas library generates points with latitudes outside the usual [-90°, 90°] interval, for example halo points on a regular Gaussian grid. Passing these points through eckit's `convertSphericalToCartesian` throws an exception because the code expects latitudes within the usual interval.

This PR preserves the current default behavior, but adds the option to renormalise points with latitudes "across the pole".

(I'd be happy to update the PR to remove the bool and always apply the renormalisation, if that is the preferred behavior. This would enable the change to propagate transparently to atlas without adding the bool, but would affect users who relied on the exception for points outside [-90,90]).