### PR TITLE
Add MPI on/off to build matrix

### DIFF
--- a/.github/ci-hpc-config.yml
+++ b/.github/ci-hpc-config.yml
@@ -5,15 +5,18 @@ matrix:
 mpi_on:
   build:
     modules:
-      - ecbuild
       - ninja
-      - openmpi
+    modules_package:
+      - eckit:openmpi
+    dependencies:
+      - ecmwf/ecbuild@develop
     parallel: 64
     ntasks: 4
 
 mpi_off:
   build:
     modules:
-      - ecbuild
       - ninja
+    dependencies:
+      - ecmwf/ecbuild@develop
     parallel: 64

--- a/.github/ci-hpc-config.yml
+++ b/.github/ci-hpc-config.yml
@@ -1,5 +1,19 @@
-build:
-  modules:
-    - ecbuild
-    - ninja
-  parallel: 64
+matrix:
+  - mpi_on
+  - mpi_off
+
+mpi_on:
+  build:
+    modules:
+      - ecbuild
+      - ninja
+      - openmpi
+    parallel: 64
+    ntasks: 4
+
+mpi_off:
+  build:
+    modules:
+      - ecbuild
+      - ninja
+    parallel: 64


### PR DESCRIPTION
Adds build configurations to build with and without MPI on the HPC.