### PR TITLE
Add possibility to add plugin search paths

### DIFF
--- a/src/eckit/system/LibraryManager.h
+++ b/src/eckit/system/LibraryManager.h
@@ -82,6 +82,10 @@ public:  // class methods
     ///        To be called from the Plugin destructor
     /// @param [in] name Name of the library plugin to deregister
     static void deregisterPlugin(const std::string& name);
+
+    /// @brief Adds plugin search paths
+    /// @param [in] ":" separated list of search paths
+    static void addPluginSearchPath(const std::string& path);
 };
 
 //----------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
The development of plugins is designed with default following structure:
```
<plugin-path>/share/plugins/manifest.yml
<plugin-path>/lib/lib<plugin>.so
```
This PR creates a function `LibraryManager::addPluginSearchPath( path )`, where `path` is a colon-separated list.
The plugin search paths are then also used for the manifest-scan-path and the dynamic-library-path.
