### PR TITLE
Remove duplicate keys from .clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -34,7 +34,7 @@ BraceWrapping:
   SplitEmptyFunction: true
   SplitEmptyRecord: true
   SplitEmptyNamespace: true
-BreakBeforeBinaryOperators: None
+BreakBeforeBinaryOperators: All
 BreakBeforeBraces: Custom
 BreakBeforeInheritanceComma: false
 BreakBeforeTernaryOperators: true
@@ -103,6 +103,4 @@ SpacesInSquareBrackets: false
 Standard:        Auto
 TabWidth:        4
 UseTab:          Never
-BreakBeforeBinaryOperators: All
-ColumnLimit: 0
 ...


### PR DESCRIPTION
This pull requests removes problematic duplicate keys from clang-format configuration.

The issue was detected because some IDEs (e.g. CLion) check the .clang-format content, and highlight duplicate keys as an error.