### PR TITLE
ECKIT-620 Enable multi-value options in CmdArgs

### DIFF
--- a/src/eckit/option/CMakeLists.txt
+++ b/src/eckit/option/CMakeLists.txt
@@ -7,6 +7,8 @@ ecbuild_add_library( TARGET eckit_option TYPE SHARED
 	SOURCES
         FactoryOption.cc
         FactoryOption.h
+        MultiValueOption.cc
+        MultiValueOption.h
         Option.cc
         Option.h
         Separator.cc

--- a/src/eckit/option/CmdArgs.cc
+++ b/src/eckit/option/CmdArgs.cc
@@ -46,57 +46,70 @@ CmdArgs::CmdArgs(std::function<void(const std::string&)> usage, std::vector<Opti
 
 void CmdArgs::init(std::function<void(const std::string&)> usage, int args_count, int minimum_args,
                    bool throw_on_error) {
-    Main& ctx  = Main::instance();
-    tool_      = ctx.name();
-    int argc   = ctx.argc();
-    bool error = false;
+    const Main& ctx = Main::instance();
+    tool_           = ctx.name();
+    int argc        = ctx.argc();
+    bool error      = false;
 
-    std::map<std::string, const option::Option*> opts;
+    using options_map_t = std::map<std::string, const option::Option*>;
 
-    for (std::vector<option::Option*>::const_iterator j = options_.begin(); j != options_.end(); ++j) {
-        if ((*j)->active()) {
-            ASSERT(opts.find((*j)->name()) == opts.end());
-            opts[(*j)->name()] = *j;
-            keys_.insert((*j)->name());
-            (*j)->setDefault(*this);
+    options_map_t opts;
+
+    // Fill in 'keys_' and prepare options map
+    for (Option* j : options_) {
+        if (j->active()) {
+            ASSERT(opts.find(j->name()) == opts.end());
+            keys_.insert(j->name());
+            opts[j->name()] = j;
+            j->setDefault(*this);
         }
     }
 
+    const static std::string prefix = "--";
     Tokenizer parse("=");
+    // Process all options/values in argv, letting each Option collect the necessary entries
     for (int i = 1; i < argc; ++i) {
         std::string a = ctx.argv(i);
-        if (a.size() > 2 && a[0] == '-' && a[1] == '-') {
-            std::vector<std::string> v;
-            parse(a.substr(2), v);
+        if (a.substr(0, prefix.size()) == prefix) { // An Option 'a' is found (starts with '--')!
 
-            std::map<std::string, const option::Option*>::const_iterator j = opts.find(v[0]);
-            if (j != opts.end()) {
+            // The Option might be formatted as --<name>=<value>, so we tokenize and take the <name>
+            std::vector<std::string> tokens;
+            parse(a.substr(2), tokens);
+
+            std::string name = tokens[0];
+            tokens.erase(tokens.begin());
+
+            if (auto found = opts.find(name); found != opts.end()) {
                 try {
-                    if (v.size() == 1) {
-                        (*j).second->set(*this);
+                    const Option* option = found->second;
+                    // Given the applicable Option, we prepare the argv tokens (including the <value>)
+                    std::vector<std::string> remaining;
+                    remaining.reserve(tokens.size() + argc);
+                    for (const auto& token : tokens) {
+                        remaining.push_back(token);
                     }
-                    else {
-                        std::vector<std::string>::const_iterator b = v.begin();
-                        ++b;
-                        std::vector<std::string>::const_iterator e = v.end();
-                        (*j).second->set(StringTools::join("=", b, e), *this);
+                    for (int j = i + 1; j < argc; ++j) {
+                        remaining.push_back(ctx.argv(j));
                     }
+                    // ... allow the Option to set itself based on all remaining argv tokens
+                    size_t consumed = option->set(*this, std::begin(remaining), std::end(remaining));
+                    // ... and, disregard the number of consumed tokens.
+                    i += static_cast<int>(consumed - tokens.size());
                 }
                 catch (UserError&) {
-                    Log::info() << "Invalid value for option --" << v[0] << std::endl;
+                    Log::info() << "Invalid value for option --" << tokens[0] << std::endl;
                     error = true;
                 }
             }
             else {
-                Log::info() << "Invalid option --" << v[0] << std::endl;
+                Log::info() << "Invalid option --" << name << std::endl;
                 error = true;
             }
         }
-        else {
+        else { // Position argument 'a' is found!
             args_.push_back(a);
         }
     }
-
 
     if (args_count >= 0) {
         if (args_.size() != size_t(args_count)) {
@@ -121,16 +134,16 @@ void CmdArgs::init(std::function<void(const std::string&)> usage, int args_count
             Log::info() << "Options are:" << std::endl;
             Log::info() << "===========:" << std::endl
                         << std::endl;
-            for (std::vector<option::Option*>::const_iterator j = options_.begin(); j != options_.end(); ++j) {
-                Log::info() << *(*j) << std::endl
+            for (const Option* j : options_) {
+                Log::info() << *j << std::endl
                             << std::endl;
             }
             Log::info() << std::endl;
         }
 
         if (throw_on_error) {
-            for (std::vector<option::Option*>::iterator j = options_.begin(); j != options_.end(); ++j) {
-                delete (*j);
+            for (const Option* j : options_) {
+                delete j;
             }
             throw UserError("An error occurred in argument parsing", Here());
         }
@@ -140,15 +153,15 @@ void CmdArgs::init(std::function<void(const std::string&)> usage, int args_count
 
 
 CmdArgs::~CmdArgs() {
-    for (std::vector<option::Option*>::iterator j = options_.begin(); j != options_.end(); ++j) {
-        delete (*j);
+    for (const Option* j : options_) {
+        delete j;
     }
 }
 
 
 void CmdArgs::configure(Configured& c) const {
-    for (std::vector<option::Option*>::const_iterator j = options_.begin(); j != options_.end(); ++j) {
-        (*j)->copy(*this, c);
+    for (const Option* j : options_) {
+        j->copy(*this, c);
     }
 }
 
@@ -158,14 +171,6 @@ void CmdArgs::print(std::ostream& out) const {
     LocalConfiguration::print(out);
     out << "]";
 }
-
-// const std::set<std::string>& CmdArgs::keys() const {
-//     return keys_;
-// }
-
-// const std::vector<std::string>& CmdArgs::args() const {
-//     return args_;
-// }
 
 const std::string& CmdArgs::operator()(size_t i) const {
     ASSERT(i < args_.size());
@@ -179,6 +184,7 @@ size_t CmdArgs::count() const {
 const std::string& CmdArgs::tool() const {
     return tool_;
 }
+
 //----------------------------------------------------------------------------------------------------------------------
 
 }  // namespace eckit::option

--- a/src/eckit/option/CmdArgs.cc
+++ b/src/eckit/option/CmdArgs.cc
@@ -22,6 +22,7 @@
 #include "eckit/exception/Exceptions.h"
 #include "eckit/option/Option.h"
 #include "eckit/runtime/Main.h"
+#include "eckit/utils/Tokenizer.h"
 
 namespace eckit::option {
 
@@ -85,7 +86,7 @@ void CmdArgs::init(std::function<void(const std::string&)> usage, int args_count
             // ... so we remove the '--' prefix
             a = a.substr(2);
             // ... and tokenize [<name>(,<tail>)]
-            std::vector<std::string> tokens = split_at(a, '=');
+            std::vector<std::string> tokens = Tokenizer::split_at(a, '=');
 
             const std::string name = tokens[0];
             tokens.erase(tokens.begin());

--- a/src/eckit/option/FactoryOption.cc
+++ b/src/eckit/option/FactoryOption.cc
@@ -26,15 +26,15 @@ namespace option {
 
 
 template <class T>
-FactoryOption<T>::FactoryOption(const std::string& name, const std::string& description) :
-    base_t(name, description) {}
+FactoryOption<T>::FactoryOption(const std::string& name, const std::string& description) : base_t(name, description) {}
 
 template <class T>
 FactoryOption<T>::FactoryOption(const std::string& name, const std::string& description, std::string default_value) :
     base_t(name, description, std::move(default_value)) {}
 
 template <class T>
-size_t FactoryOption<T>::set(Configured& parametrisation, args_t::const_iterator begin, args_t::const_iterator end) const {
+size_t FactoryOption<T>::set(Configured& parametrisation, [[maybe_unused]] size_t values, args_t::const_iterator begin,
+                             args_t::const_iterator end) const {
     if (begin == end) {
         throw UserError("No option value found for FactoryOption, where 1 was expected");
     }
@@ -61,8 +61,7 @@ template <class T>
 void FactoryOption<T>::print(std::ostream& out) const {
     out << "   --" << name_ << "=name"
         << " (" << description_ << ")";
-    out << std::endl
-        << "     Values are: ";
+    out << std::endl << "     Values are: ";
     T::list(out);
 }
 

--- a/src/eckit/option/FactoryOption.cc
+++ b/src/eckit/option/FactoryOption.cc
@@ -27,22 +27,34 @@ namespace option {
 
 template <class T>
 FactoryOption<T>::FactoryOption(const std::string& name, const std::string& description) :
-    Option(name, description) {}
+    base_t(name, description) {}
 
 template <class T>
-FactoryOption<T>::~FactoryOption() {}
+FactoryOption<T>::FactoryOption(const std::string& name, const std::string& description, std::string default_value) :
+    base_t(name, description, std::move(default_value)) {}
+
+template <class T>
+size_t FactoryOption<T>::set(Configured& parametrisation, args_t::const_iterator begin, args_t::const_iterator end) const {
+    if (begin == end) {
+        throw UserError("No option value found for FactoryOption, where 1 was expected");
+    }
+    set(*begin, parametrisation);
+    return 1;
+}
 
 template <class T>
 void FactoryOption<T>::set(const std::string& value, Configured& parametrisation) const {
+    set_value(value, parametrisation);
+}
+
+template <class T>
+void FactoryOption<T>::set_value(const std::string& value, Configured& parametrisation) const {
     parametrisation.set(name_, value);
 }
 
 template <class T>
 void FactoryOption<T>::copy(const Configuration& from, Configured& to) const {
-    std::string v;
-    if (from.get(name_, v)) {
-        to.set(name_, v);
-    }
+    Option::copy<std::string>(name_, from, to);
 }
 
 template <class T>

--- a/src/eckit/option/FactoryOption.cc
+++ b/src/eckit/option/FactoryOption.cc
@@ -38,18 +38,19 @@ size_t FactoryOption<T>::set(Configured& parametrisation, [[maybe_unused]] size_
     if (begin == end) {
         throw UserError("No option value found for FactoryOption, where 1 was expected");
     }
-    set(*begin, parametrisation);
-    return 1;
-}
-
-template <class T>
-void FactoryOption<T>::set(const std::string& value, Configured& parametrisation) const {
+    auto value = translate(*begin);
     set_value(value, parametrisation);
+    return 1;
 }
 
 template <class T>
 void FactoryOption<T>::set_value(const std::string& value, Configured& parametrisation) const {
     parametrisation.set(name_, value);
+}
+
+template <class T>
+std::string FactoryOption<T>::translate(const std::string& value) const {
+    return value;
 }
 
 template <class T>

--- a/src/eckit/option/FactoryOption.h
+++ b/src/eckit/option/FactoryOption.h
@@ -27,19 +27,25 @@ namespace eckit::option {
 ///       the validity of input received, and just returns the appropriate string
 
 template <class T>
-class FactoryOption : public Option {
+class FactoryOption : public BaseOption<std::string> {
 public:
-    FactoryOption(const std::string& name, const std::string& description);
+    using base_t = BaseOption<std::string>;
 
-    ~FactoryOption() override;  // Change to virtual if base class
+    FactoryOption(const std::string& name, const std::string& description);
+    FactoryOption(const std::string& name, const std::string& description, std::string default_value);
+
+    ~FactoryOption() override = default;
 
 protected:
-    void print(std::ostream&) const override;  // Change to virtual if base class
+    void print(std::ostream&) const override;
 
 private:
     using Option::set;
 
-    void set(const std::string& value, Configured&) const override;
+    size_t set(Configured&, args_t::const_iterator begin, args_t::const_iterator end) const override;
+    void set(const std::string& value, Configured&) const;
+    void set_value(const std::string& value, Configured&) const override;
+
     void copy(const Configuration& from, Configured& to) const override;
 };
 

--- a/src/eckit/option/FactoryOption.h
+++ b/src/eckit/option/FactoryOption.h
@@ -36,15 +36,15 @@ public:
 
     ~FactoryOption() override = default;
 
+    size_t set(Configured&, size_t values, args_t::const_iterator begin, args_t::const_iterator end) const override;
+
 protected:
     void print(std::ostream&) const override;
 
 private:
-    using Option::set;
-
-    size_t set(Configured&, size_t values, args_t::const_iterator begin, args_t::const_iterator end) const override;
-    void set(const std::string& value, Configured&) const;
     void set_value(const std::string& value, Configured&) const override;
+
+    [[nodiscard]] std::string translate(const std::string& value) const override;
 
     void copy(const Configuration& from, Configured& to) const override;
 };

--- a/src/eckit/option/FactoryOption.h
+++ b/src/eckit/option/FactoryOption.h
@@ -42,7 +42,7 @@ protected:
 private:
     using Option::set;
 
-    size_t set(Configured&, args_t::const_iterator begin, args_t::const_iterator end) const override;
+    size_t set(Configured&, size_t values, args_t::const_iterator begin, args_t::const_iterator end) const override;
     void set(const std::string& value, Configured&) const;
     void set_value(const std::string& value, Configured&) const override;
 

--- a/src/eckit/option/MultiValueOption.cc
+++ b/src/eckit/option/MultiValueOption.cc
@@ -1,0 +1,89 @@
+/*
+ * (C) Copyright 1996- ECMWF.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation nor
+ * does it submit to any jurisdiction.
+ */
+
+#include "eckit/option/MultiValueOption.h"
+
+#include <algorithm>
+#include <iostream>
+
+#include "eckit/config/Configuration.h"
+#include "eckit/config/Configured.h"
+
+#include "eckit/exception/Exceptions.h"
+
+namespace eckit::option {
+
+MultiValueOption::MultiValueOption(const std::string& name, const std::string& description, size_t n_mandatory_values) :
+    MultiValueOption(name, description, n_mandatory_values, 0) {}
+
+MultiValueOption::MultiValueOption(const std::string& name, const std::string& description, size_t n_mandatory_values,
+                                   size_t n_optional_values) :
+    base_t(name, description),
+    n_mandatory_values_{n_mandatory_values},
+    n_optional_values_{n_optional_values},
+    values_{} {
+    ASSERT_MSG(n_mandatory_values >= 1, "At least 1 mandatory value is expected.");
+}
+
+MultiValueOption::MultiValueOption(const std::string& name, const std::string& description, size_t n_mandatory_values,
+                                   const values_t& default_values) :
+    MultiValueOption(name, description, n_mandatory_values, 0, default_values) {}
+
+MultiValueOption::MultiValueOption(const std::string& name, const std::string& description, size_t n_mandatory_values,
+                                   size_t n_maximum_values, const values_t& default_values) :
+    base_t(name, description, default_values),
+    n_mandatory_values_{n_mandatory_values},
+    n_optional_values_{n_maximum_values},
+    values_{} {
+    ASSERT_MSG(n_mandatory_values >= 1, "At least 1 mandatory value is expected.");
+}
+
+size_t MultiValueOption::set(Configured& parametrisation, args_t::const_iterator begin,
+                             args_t::const_iterator end) const {
+    if (std::distance(begin, end) < n_mandatory_values_) {
+        throw UserError("Not enough option values found for MultiValueOption, where at least "
+                        + std::to_string(n_mandatory_values_) + " were expected");
+    }
+
+    // Collect n_mandatory_values_ mandatory values from the range [begin, end)
+    values_t values;
+    std::copy_n(begin, n_mandatory_values_, std::back_inserter(values));
+    begin = begin + n_mandatory_values_;
+
+    // Collect up to n_optional_values from the range [(updated-)begin, end)
+    // - n.b. collection must stop when either end is reached or when an option (i.e. "--*") is found
+    for (size_t i = 0; i < n_optional_values_; ++i) {
+        if ((begin == end) || (begin->substr(0, 2) == "--")) {
+            break;
+        }
+
+        values.push_back(*begin);
+        ++begin;
+    }
+
+    // Store the collected values
+    set_value(values, parametrisation);
+    return values.size();
+}
+
+void MultiValueOption::set_value(const values_t& values, Configured& parametrisation) const {
+    parametrisation.set(this->name(), values);
+}
+
+void MultiValueOption::copy(const Configuration& from, Configured& to) const {
+    Option::copy<values_t>(this->name(), from, to);
+}
+
+void MultiValueOption::print(std::ostream& out) const {
+    out << "   --" << this->name() << "[=] [" << n_mandatory_values_ << " * values]([" << n_optional_values_
+        << " * values]) (" << this->description() << ")";
+}
+
+}  // namespace eckit::option

--- a/src/eckit/option/MultiValueOption.cc
+++ b/src/eckit/option/MultiValueOption.cc
@@ -77,6 +77,10 @@ void MultiValueOption::set_value(const values_t& values, Configured& parametrisa
     parametrisation.set(this->name(), values);
 }
 
+MultiValueOption::values_t MultiValueOption::translate(const std::string& value) const {
+    NOTIMP;
+}
+
 void MultiValueOption::copy(const Configuration& from, Configured& to) const {
     Option::copy<values_t>(this->name(), from, to);
 }

--- a/src/eckit/option/MultiValueOption.cc
+++ b/src/eckit/option/MultiValueOption.cc
@@ -45,7 +45,7 @@ MultiValueOption::MultiValueOption(const std::string& name, const std::string& d
     ASSERT_MSG(n_mandatory_values >= 1, "At least 1 mandatory value is expected.");
 }
 
-size_t MultiValueOption::set(Configured& parametrisation, args_t::const_iterator begin,
+size_t MultiValueOption::set(Configured& parametrisation, [[maybe_unused]] size_t values, args_t::const_iterator begin,
                              args_t::const_iterator end) const {
     if (std::distance(begin, end) < n_mandatory_values_) {
         throw UserError("Not enough option values found for MultiValueOption, where at least "
@@ -53,8 +53,8 @@ size_t MultiValueOption::set(Configured& parametrisation, args_t::const_iterator
     }
 
     // Collect n_mandatory_values_ mandatory values from the range [begin, end)
-    values_t values;
-    std::copy_n(begin, n_mandatory_values_, std::back_inserter(values));
+    values_t collected;
+    std::copy_n(begin, n_mandatory_values_, std::back_inserter(collected));
     begin = begin + n_mandatory_values_;
 
     // Collect up to n_optional_values from the range [(updated-)begin, end)
@@ -64,13 +64,13 @@ size_t MultiValueOption::set(Configured& parametrisation, args_t::const_iterator
             break;
         }
 
-        values.push_back(*begin);
+        collected.push_back(*begin);
         ++begin;
     }
 
     // Store the collected values
-    set_value(values, parametrisation);
-    return values.size();
+    set_value(collected, parametrisation);
+    return collected.size();
 }
 
 void MultiValueOption::set_value(const values_t& values, Configured& parametrisation) const {

--- a/src/eckit/option/MultiValueOption.cc
+++ b/src/eckit/option/MultiValueOption.cc
@@ -25,22 +25,21 @@ MultiValueOption::MultiValueOption(const std::string& name, const std::string& d
 
 MultiValueOption::MultiValueOption(const std::string& name, const std::string& description, size_t n_mandatory_values,
                                    size_t n_optional_values) :
-    base_t(name, description),
-    n_mandatory_values_{n_mandatory_values},
-    n_optional_values_{n_optional_values},
-    values_{} {
-    ASSERT_MSG(n_mandatory_values >= 1, "At least 1 mandatory value is expected.");
-}
+    MultiValueOption(name, description, n_mandatory_values, n_optional_values, std::nullopt) {}
 
 MultiValueOption::MultiValueOption(const std::string& name, const std::string& description, size_t n_mandatory_values,
                                    const values_t& default_values) :
     MultiValueOption(name, description, n_mandatory_values, 0, default_values) {}
 
 MultiValueOption::MultiValueOption(const std::string& name, const std::string& description, size_t n_mandatory_values,
-                                   size_t n_maximum_values, const values_t& default_values) :
-    base_t(name, description, default_values),
+                                   size_t n_optional_values, const values_t& default_values) :
+    MultiValueOption(name, description, n_mandatory_values, n_optional_values, std::make_optional(default_values)) {}
+
+MultiValueOption::MultiValueOption(const std::string& name, const std::string& description, size_t n_mandatory_values,
+                                   size_t n_optional_values, std::optional<values_t> default_values) :
+    base_t(name, description, std::move(default_values)),
     n_mandatory_values_{n_mandatory_values},
-    n_optional_values_{n_maximum_values},
+    n_optional_values_{n_optional_values},
     values_{} {
     ASSERT_MSG(n_mandatory_values >= 1, "At least 1 mandatory value is expected.");
 }
@@ -48,8 +47,8 @@ MultiValueOption::MultiValueOption(const std::string& name, const std::string& d
 size_t MultiValueOption::set(Configured& parametrisation, [[maybe_unused]] size_t values, args_t::const_iterator begin,
                              args_t::const_iterator end) const {
     if (std::distance(begin, end) < n_mandatory_values_) {
-        throw UserError("Not enough option values found for MultiValueOption, where at least "
-                        + std::to_string(n_mandatory_values_) + " were expected");
+        throw UserError("Not enough option values found for MultiValueOption, where at least " +
+                        std::to_string(n_mandatory_values_) + " were expected");
     }
 
     // Collect n_mandatory_values_ mandatory values from the range [begin, end)

--- a/src/eckit/option/MultiValueOption.h
+++ b/src/eckit/option/MultiValueOption.h
@@ -24,8 +24,8 @@ public:
 
     MultiValueOption(const std::string& name, const std::string& description, size_t n_mandatory_values);
     MultiValueOption(const std::string& name, const std::string& description, size_t n_mandatory_values, size_t n_optional_values);
-    MultiValueOption(const std::string& name, const std::string& description, size_t n_mandatory_values, const values_t& default_values_);
-    MultiValueOption(const std::string& name, const std::string& description, size_t n_mandatory_values, size_t n_maximum_values, const values_t& default_values_);
+    MultiValueOption(const std::string& name, const std::string& description, size_t n_mandatory_values, const values_t& default_values);
+    MultiValueOption(const std::string& name, const std::string& description, size_t n_mandatory_values, size_t n_optional_values, const values_t& default_values);
     ~MultiValueOption() override = default;
 
     size_t set(Configured&, size_t values, args_t::const_iterator begin, args_t::const_iterator end) const override;
@@ -33,6 +33,8 @@ public:
     void print(std::ostream&) const override;
 
 private:
+    MultiValueOption(const std::string& name, const std::string& description, size_t n_mandatory_values, size_t n_maximum_values, std::optional<values_t> default_values);
+
     void set_value(const values_t& values, Configured&) const override;
 
     [[nodiscard]] values_t translate(const std::string& value) const override;

--- a/src/eckit/option/MultiValueOption.h
+++ b/src/eckit/option/MultiValueOption.h
@@ -31,7 +31,7 @@ public:
     void print(std::ostream&) const override;
 
 private:
-    size_t set(Configured&, args_t::const_iterator begin, args_t::const_iterator end) const override;
+    size_t set(Configured&, size_t values, args_t::const_iterator begin, args_t::const_iterator end) const override;
 
     void set_value(const values_t& values, Configured&) const override;
 

--- a/src/eckit/option/MultiValueOption.h
+++ b/src/eckit/option/MultiValueOption.h
@@ -1,0 +1,47 @@
+/*
+ * (C) Copyright 1996- ECMWF.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation nor
+ * does it submit to any jurisdiction.
+ */
+
+#ifndef eckit_option_MultiValueOption_H
+#define eckit_option_MultiValueOption_H
+
+#include <iosfwd>
+
+#include "eckit/option/Option.h"
+
+namespace eckit::option {
+
+class MultiValueOption : public BaseOption<std::vector<std::string>> {
+public:
+    using base_t   = BaseOption<std::vector<std::string>>;
+    using values_t = std::vector<std::string>;
+
+    MultiValueOption(const std::string& name, const std::string& description, size_t n_mandatory_values);
+    MultiValueOption(const std::string& name, const std::string& description, size_t n_mandatory_values, size_t n_optional_values);
+    MultiValueOption(const std::string& name, const std::string& description, size_t n_mandatory_values, const values_t& default_values_);
+    MultiValueOption(const std::string& name, const std::string& description, size_t n_mandatory_values, size_t n_maximum_values, const values_t& default_values_);
+    ~MultiValueOption() override = default;
+
+    void print(std::ostream&) const override;
+
+private:
+    size_t set(Configured&, args_t::const_iterator begin, args_t::const_iterator end) const override;
+
+    void set_value(const values_t& values, Configured&) const override;
+
+    void copy(const Configuration& from, Configured& to) const override;
+
+    size_t n_mandatory_values_;
+    size_t n_optional_values_;
+    values_t values_;
+};
+
+}  // namespace eckit::option
+
+#endif

--- a/src/eckit/option/MultiValueOption.h
+++ b/src/eckit/option/MultiValueOption.h
@@ -28,12 +28,14 @@ public:
     MultiValueOption(const std::string& name, const std::string& description, size_t n_mandatory_values, size_t n_maximum_values, const values_t& default_values_);
     ~MultiValueOption() override = default;
 
+    size_t set(Configured&, size_t values, args_t::const_iterator begin, args_t::const_iterator end) const override;
+
     void print(std::ostream&) const override;
 
 private:
-    size_t set(Configured&, size_t values, args_t::const_iterator begin, args_t::const_iterator end) const override;
-
     void set_value(const values_t& values, Configured&) const override;
+
+    [[nodiscard]] values_t translate(const std::string& value) const override;
 
     void copy(const Configuration& from, Configured& to) const override;
 

--- a/src/eckit/option/Option.cc
+++ b/src/eckit/option/Option.cc
@@ -21,89 +21,12 @@
 namespace eckit::option {
 
 Option::Option(const std::string& name, const std::string& description) :
-    name_(name), description_(description), hasDefault_(false) {}
+    name_(name), description_(description) {}
 
-Option::~Option() {}
-
-const std::string& Option::name() const {
-    return name_;
-}
-
-
-bool Option::active() const {
-    return true;
-}
-
-void Option::set(Configured&) const {
-    std::ostringstream os;
-    os << "Option::set() not implemented for " << *this;
-    throw eckit::SeriousBug(os.str());
-}
-
-Option* Option::defaultValue(const std::string& value) {
-    hasDefault_ = true;
-    default_    = value;
-    return this;
-}
-
-void Option::setDefault(Configured& configured) const {
-    if (hasDefault_) {
-        set(default_, configured);
-    }
-}
-
-
-template <>
-const char* Title<size_t>::operator()() const {
-    return "ordinal";
-}
-
-template <>
-const char* Title<long>::operator()() const {
-    return "integer";
-}
-
-template <>
-const char* Title<double>::operator()() const {
-    return "real";
-}
-
-template <>
-const char* Title<bool>::operator()() const {
-    return "0/1";
-}
-
-template <>
-const char* Title<std::string>::operator()() const {
-    return "string";
-}
-
-template <>
-const char* Title<eckit::PathName>::operator()() const {
-    return "path";
-}
-
-template <>
-void SimpleOption<bool>::set(Configured& parametrisation) const {
-    parametrisation.set(name_, true);
-}
-
-template <>
-void SimpleOption<eckit::PathName>::set(const std::string& value, Configured& parametrisation) const {
-    parametrisation.set(name_, value);
-}
-
-template <>
-void SimpleOption<eckit::PathName>::copy(const Configuration& from, Configured& to) const {
-    std::string v;
-    if (from.get(name_, v)) {
-        to.set(name_, v);
-    }
-}
-
-template <>
-void SimpleOption<bool>::print(std::ostream& out) const {
-    out << "   --" << name_ << " (" << description_ << ")";
+std::ostream& operator<<(std::ostream& s, const Option& p)
+{
+    p.print(s);
+    return s;
 }
 
 }  // namespace eckit::option

--- a/src/eckit/option/Option.h
+++ b/src/eckit/option/Option.h
@@ -43,9 +43,12 @@ public:  // methods
     /**
      * Set the value of the option into `parameter`, taking as many values as necessary from the range `[begin, end)`.
      *
+     * - `values` indicates the number of items in `[begin, end)` that were provided as an option value.
+     *    This parameter is expected to be either 0 (for --flag options) or 1 (for traditional --option=<value>)
+     *
      * Return: number of items consumed from the range `[begin, end)`.
      */
-    virtual size_t set(Configured& parameter, args_t::const_iterator begin, args_t::const_iterator end) const = 0;
+    virtual size_t set(Configured& param, size_t values, args_t::const_iterator begin, args_t::const_iterator end) const = 0;
 
     virtual void copy(const Configuration& from, Configured& to) const = 0;
 

--- a/src/eckit/option/Option.h
+++ b/src/eckit/option/Option.h
@@ -48,7 +48,8 @@ public:  // methods
      *
      * Return: number of items consumed from the range `[begin, end)`.
      */
-    virtual size_t set(Configured& param, size_t values, args_t::const_iterator begin, args_t::const_iterator end) const = 0;
+    virtual size_t set(Configured& param, size_t values, args_t::const_iterator begin,
+                       args_t::const_iterator end) const = 0;
 
     virtual void copy(const Configuration& from, Configured& to) const = 0;
 
@@ -82,13 +83,24 @@ public:
         Option(name, description), default_value_{std::make_optional(default_value_)} {};
     ~BaseOption() override = default;
 
+    [[deprecated("Specify the default value(s) when calling the ctor")]]
+    Option* defaultValue(const std::string& value) {
+        T translated   = translate(value);
+        default_value_ = std::make_optional(translated);
+        return this;
+    }
+
     void setDefault(Configured& parametrisation) const final {
         if (default_value_) {
             set_value(default_value_.value(), parametrisation);
         }
     }
 
+protected:
     virtual void set_value(const T& value, Configured& parametrisation) const = 0;
+
+    // Performs the conversion from 'string' value to actual 'type' value
+    virtual T translate(const std::string& value) const = 0;
 
 private:
     std::optional<T> default_value_;

--- a/src/eckit/option/Option.h
+++ b/src/eckit/option/Option.h
@@ -17,52 +17,81 @@
 #define Option_H
 
 #include <iosfwd>
+#include <optional>
 #include <string>
+#include <vector>
 
+#include "eckit/config/Configuration.h"
+#include "eckit/config/Configured.h"
 #include "eckit/memory/NonCopyable.h"
 
-namespace eckit {
-
-class Configuration;
-class Configured;
-
-namespace option {
-
+namespace eckit::option {
 
 class Option : private eckit::NonCopyable {
+public:
+    using args_t = std::vector<std::string>;
+
 public:  // methods
     Option(const std::string& name, const std::string& description);
+    virtual ~Option() = default;
 
-    virtual ~Option();  // Change to virtual if base class
+    [[nodiscard]] const std::string& name() const { return name_; };
+    [[nodiscard]] const std::string& description() const { return description_; }
 
-    virtual Option* defaultValue(const std::string&);
+    [[nodiscard]] virtual bool active() const { return true; };
 
-    const std::string& name() const;
+    /**
+     * Set the value of the option into `parameter`, taking as many values as necessary from the range `[begin, end)`.
+     *
+     * Return: number of items consumed from the range `[begin, end)`.
+     */
+    virtual size_t set(Configured& parameter, args_t::const_iterator begin, args_t::const_iterator end) const = 0;
 
-    virtual bool active() const;
-
-    virtual void set(Configured&) const;
-    virtual void set(const std::string& value, Configured&) const      = 0;
     virtual void copy(const Configuration& from, Configured& to) const = 0;
-    virtual void setDefault(Configured&) const;
+
+    virtual void setDefault(Configured&) const = 0;
+
+    template <typename T>
+    static void copy(const std::string& name, const Configuration& from, Configured& to) {
+        // This is so generic that could probably be provided by Configuration or Configured
+        T value;
+        if (from.get(name, value)) {
+            to.set(name, value);
+        }
+    }
 
 protected:  // members
     std::string name_;
     std::string description_;
 
-    bool hasDefault_;
-    std::string default_;
-
-    virtual void print(std::ostream&) const = 0;  // Change to virtual if base class
+    virtual void print(std::ostream&) const = 0;
 
 private:
-    friend std::ostream& operator<<(std::ostream& s, const Option& p) {
-        p.print(s);
-        return s;
-    }
+    friend std::ostream& operator<<(std::ostream& s, const Option& p);
 };
 
-}  // namespace option
-}  // namespace eckit
+template <class T>
+class BaseOption : public Option {
+public:
+    BaseOption(const std::string& name, const std::string& description) :
+        Option(name, description), default_value_{std::nullopt} {};
+    BaseOption(const std::string& name, const std::string& description, const T& default_value_) :
+        Option(name, description), default_value_{std::make_optional(default_value_)} {};
+    ~BaseOption() override = default;
+
+    void setDefault(Configured& parametrisation) const final {
+        if (default_value_) {
+            set_value(default_value_.value(), parametrisation);
+        }
+    }
+
+    virtual void set_value(const T& value, Configured& parametrisation) const = 0;
+
+private:
+    std::optional<T> default_value_;
+};
+
+
+}  // namespace eckit::option
 
 #endif

--- a/src/eckit/option/Option.h
+++ b/src/eckit/option/Option.h
@@ -79,8 +79,10 @@ class BaseOption : public Option {
 public:
     BaseOption(const std::string& name, const std::string& description) :
         Option(name, description), default_value_{std::nullopt} {};
-    BaseOption(const std::string& name, const std::string& description, const T& default_value_) :
-        Option(name, description), default_value_{std::make_optional(default_value_)} {};
+    BaseOption(const std::string& name, const std::string& description, const T& default_value) :
+        Option(name, description), default_value_{std::make_optional(default_value)} {};
+    BaseOption(const std::string& name, const std::string& description, std::optional<T> default_value) :
+        Option(name, description), default_value_{std::move(default_value)} {};
     ~BaseOption() override = default;
 
     [[deprecated("Specify the default value(s) when calling the ctor")]]

--- a/src/eckit/option/Separator.cc
+++ b/src/eckit/option/Separator.cc
@@ -27,10 +27,6 @@ Separator::Separator(const std::string& description) :
 Separator::~Separator() {}
 
 
-void Separator::set(const std::string& value, Configured& parametrisation) const {
-    NOTIMP;
-}
-
 void Separator::copy(const Configuration& from, Configured& to) const {
     ;
 }

--- a/src/eckit/option/Separator.cc
+++ b/src/eckit/option/Separator.cc
@@ -26,6 +26,13 @@ Separator::Separator(const std::string& description) :
 
 Separator::~Separator() {}
 
+size_t Separator::set(Configured& parameter, args_t::const_iterator begin, args_t::const_iterator end) const {
+    return 0; // Never consumes any argv tokens
+}
+
+void Separator::setDefault(Configured&) const {
+    ;
+}
 
 void Separator::copy(const Configuration& from, Configured& to) const {
     ;

--- a/src/eckit/option/Separator.cc
+++ b/src/eckit/option/Separator.cc
@@ -21,13 +21,12 @@
 
 namespace eckit::option {
 
-Separator::Separator(const std::string& description) :
-    Option("", description) {}
+Separator::Separator(const std::string& description) : Option("", description) {}
 
 Separator::~Separator() {}
 
-size_t Separator::set(Configured& parameter, args_t::const_iterator begin, args_t::const_iterator end) const {
-    return 0; // Never consumes any argv tokens
+size_t Separator::set(Configured& parameter, size_t values, args_t::const_iterator begin, args_t::const_iterator end) const {
+    return 0;  // Never consumes any argv tokens
 }
 
 void Separator::setDefault(Configured&) const {
@@ -43,8 +42,7 @@ bool Separator::active() const {
 }
 
 void Separator::print(std::ostream& out) const {
-    out << std::endl
-        << description_ << ":" << std::endl;
+    out << std::endl << description_ << ":" << std::endl;
 }
 
 }  // namespace eckit::option

--- a/src/eckit/option/Separator.h
+++ b/src/eckit/option/Separator.h
@@ -85,7 +85,7 @@ private:
     // -- Overridden methods
 
     using Option::set;
-    void set(const std::string& value, Configured&) const override;
+
     bool active() const override;
     void copy(const Configuration& from, Configured& to) const override;
 

--- a/src/eckit/option/Separator.h
+++ b/src/eckit/option/Separator.h
@@ -42,7 +42,8 @@ public:
     // None
 
     // -- Methods
-    size_t set(Configured& parameter, size_t values, args_t::const_iterator begin, args_t::const_iterator end) const override;
+    size_t set(Configured& parameter, size_t values, args_t::const_iterator begin,
+               args_t::const_iterator end) const override;
 
     void setDefault(Configured&) const override;
 
@@ -85,9 +86,6 @@ private:
     // None
 
     // -- Overridden methods
-
-    using Option::set;
-
     bool active() const override;
     void copy(const Configuration& from, Configured& to) const override;
 

--- a/src/eckit/option/Separator.h
+++ b/src/eckit/option/Separator.h
@@ -42,7 +42,9 @@ public:
     // None
 
     // -- Methods
-    // None
+    size_t set(Configured& parameter, args_t::const_iterator begin, args_t::const_iterator end) const override;
+
+    void setDefault(Configured&) const override;
 
 
     // -- Overridden methods

--- a/src/eckit/option/Separator.h
+++ b/src/eckit/option/Separator.h
@@ -42,7 +42,7 @@ public:
     // None
 
     // -- Methods
-    size_t set(Configured& parameter, args_t::const_iterator begin, args_t::const_iterator end) const override;
+    size_t set(Configured& parameter, size_t values, args_t::const_iterator begin, args_t::const_iterator end) const override;
 
     void setDefault(Configured&) const override;
 

--- a/src/eckit/option/SimpleOption.cc
+++ b/src/eckit/option/SimpleOption.cc
@@ -22,9 +22,9 @@
 #include "eckit/option/SimpleOption.h"
 #include "eckit/utils/Translator.h"
 
-namespace eckit {
+namespace eckit::option {
 
-namespace option {
+namespace {
 
 template <class T>
 struct Title {
@@ -32,67 +32,100 @@ struct Title {
 };
 
 template <>
-const char* Title<size_t>::operator()() const;
+inline const char* Title<size_t>::operator()() const {
+    return "ordinal";
+}
 
 template <>
-const char* Title<long>::operator()() const;
+inline const char* Title<long>::operator()() const {
+    return "integer";
+}
 
 template <>
-const char* Title<double>::operator()() const;
+inline const char* Title<double>::operator()() const {
+    return "real";
+}
 
 template <>
-const char* Title<bool>::operator()() const;
+inline const char* Title<bool>::operator()() const {
+    return "0/1";
+}
 
 template <>
-const char* Title<std::string>::operator()() const;
+inline const char* Title<std::string>::operator()() const {
+    return "string";
+}
 
 template <>
-const char* Title<eckit::PathName>::operator()() const;
+inline const char* Title<eckit::PathName>::operator()() const {
+    return "path";
+}
+
+}  // namespace
 
 template <class T>
-SimpleOption<T>::SimpleOption(const std::string& name, const std::string& description) :
-    Option(name, description) {}
+SimpleOption<T>::SimpleOption(const std::string& name, const std::string& description) : base_t(name, description) {}
 
 template <class T>
-SimpleOption<T>::~SimpleOption() {}
+SimpleOption<T>::SimpleOption(const std::string& name, const std::string& description, const T& default_value) :
+    base_t(name, description, default_value) {}
+
+template <>
+inline size_t SimpleOption<bool>::set(Configured& parametrisation, args_t::const_iterator begin [[maybe_unused]],
+                                      args_t::const_iterator end [[maybe_unused]]) const {
+    // When handling bool, there is no actual value in the range [begin, end), thus the need for this specialization
+    set_value(true, parametrisation);
+    return 0;
+}
+
+template <class T>
+size_t SimpleOption<T>::set(Configured& parametrisation, args_t::const_iterator begin,
+                            args_t::const_iterator end) const {
+    if (begin == end) {
+        throw UserError("No option value found for SimpleOption, where 1 was expected");
+    }
+    set(*begin, parametrisation);
+    return 1;
+}
+
+template <>
+inline void SimpleOption<eckit::PathName>::set(const std::string& value, Configured& parametrisation) const {
+    parametrisation.set(name_, value);
+}
+
 
 template <class T>
 void SimpleOption<T>::set(const std::string& value, Configured& parametrisation) const {
     T v = eckit::Translator<std::string, T>()(value);
-    parametrisation.set(name_, v);
+    set_value(v, parametrisation);
 }
 
 template <class T>
-void SimpleOption<T>::set(Configured& parametrisation) const {
-    Option::set(parametrisation);
+void SimpleOption<T>::set_value(const T& value, Configured& parametrisation) const {
+    parametrisation.set(this->name(), value);
 }
 
-
-template <class T>
-void SimpleOption<T>::copy(const Configuration& from, Configured& to) const {
-    T v;
+template <>
+inline void SimpleOption<eckit::PathName>::copy(const Configuration& from, Configured& to) const {
+    std::string v;
     if (from.get(name_, v)) {
         to.set(name_, v);
     }
 }
 
-template <>
-void SimpleOption<eckit::PathName>::set(const std::string& value, Configured& parametrisation) const;
-
-template <>
-void SimpleOption<eckit::PathName>::copy(const Configuration& from, Configured& to) const;
-
-template <>
-void SimpleOption<bool>::print(std::ostream& out) const;
-
 template <class T>
-void SimpleOption<T>::print(std::ostream& out) const {
-    out << "   --" << name_ << "=" << Title<T>()() << " (" << description_ << ")";
+void SimpleOption<T>::copy(const Configuration& from, Configured& to) const {
+    Option::copy<T>(this->name(), from, to);
 }
 
 template <>
-void SimpleOption<bool>::set(Configured& parametrisation) const;
+inline void SimpleOption<bool>::print(std::ostream& out) const {
+    out << "   --" << name_ << " (" << description_ << ")";
+}
 
-}  // namespace option
+template <class T>
+void SimpleOption<T>::print(std::ostream& out) const {
+    out << "   --" << this->name() << "=" << Title<T>()() << " (" << this->description() << ")";
+}
 
-}  // namespace eckit
+}  // namespace eckit::option

--- a/src/eckit/option/SimpleOption.cc
+++ b/src/eckit/option/SimpleOption.cc
@@ -71,15 +71,20 @@ SimpleOption<T>::SimpleOption(const std::string& name, const std::string& descri
     base_t(name, description, default_value) {}
 
 template <>
-inline size_t SimpleOption<bool>::set(Configured& parametrisation, args_t::const_iterator begin [[maybe_unused]],
-                                      args_t::const_iterator end [[maybe_unused]]) const {
-    // When handling bool, there is no actual value in the range [begin, end), thus the need for this specialization
+inline size_t SimpleOption<bool>::set(Configured& parametrisation, [[maybe_unused]] size_t values, args_t::const_iterator begin,
+                                      [[maybe_unused]] args_t::const_iterator end) const {
+    // When handling bool, we might not have a value in the range [begin, end), thus the need for this specialization
+    if (values > 0) {
+        bool value = Translator<std::string, bool>()(*begin);
+        set_value(value, parametrisation);
+        return 1;
+    }
     set_value(true, parametrisation);
     return 0;
 }
 
 template <class T>
-size_t SimpleOption<T>::set(Configured& parametrisation, args_t::const_iterator begin,
+size_t SimpleOption<T>::set(Configured& parametrisation, [[maybe_unused]] size_t values, args_t::const_iterator begin,
                             args_t::const_iterator end) const {
     if (begin == end) {
         throw UserError("No option value found for SimpleOption, where 1 was expected");

--- a/src/eckit/option/SimpleOption.h
+++ b/src/eckit/option/SimpleOption.h
@@ -23,18 +23,25 @@
 namespace eckit::option {
 
 template <class T>
-class SimpleOption : public Option {
+class SimpleOption : public BaseOption<T> {
 public:
-    SimpleOption(const std::string& name, const std::string& description);
+    using base_t = BaseOption<T>;
+    using args_t = Option::args_t;
 
-    ~SimpleOption() override;
+    SimpleOption(const std::string& name, const std::string& description);
+    SimpleOption(const std::string& name, const std::string& description, const T& default_value);
+
+    ~SimpleOption() override = default;
 
 protected:
     void print(std::ostream&) const override;
 
 private:
-    void set(Configured&) const override;
-    void set(const std::string& value, Configured&) const override;
+    size_t set(Configured&, args_t::const_iterator begin, args_t::const_iterator end) const override;
+
+    void set(const std::string& value, Configured&) const;
+    void set_value(const T& value, Configured&) const override;
+
     void copy(const Configuration& from, Configured& to) const override;
 };
 

--- a/src/eckit/option/SimpleOption.h
+++ b/src/eckit/option/SimpleOption.h
@@ -37,7 +37,7 @@ protected:
     void print(std::ostream&) const override;
 
 private:
-    size_t set(Configured&, args_t::const_iterator begin, args_t::const_iterator end) const override;
+    size_t set(Configured&, size_t values, args_t::const_iterator begin, args_t::const_iterator end) const override;
 
     void set(const std::string& value, Configured&) const;
     void set_value(const T& value, Configured&) const override;

--- a/src/eckit/option/SimpleOption.h
+++ b/src/eckit/option/SimpleOption.h
@@ -33,14 +33,16 @@ public:
 
     ~SimpleOption() override = default;
 
+    size_t set(Configured&, size_t values, args_t::const_iterator begin, args_t::const_iterator end) const override;
+
 protected:
     void print(std::ostream&) const override;
 
 private:
-    size_t set(Configured&, size_t values, args_t::const_iterator begin, args_t::const_iterator end) const override;
 
-    void set(const std::string& value, Configured&) const;
     void set_value(const T& value, Configured&) const override;
+
+    [[nodiscard]] T translate(const std::string& value) const override;
 
     void copy(const Configuration& from, Configured& to) const override;
 };

--- a/src/eckit/option/VectorOption.cc
+++ b/src/eckit/option/VectorOption.cc
@@ -46,21 +46,28 @@ size_t VectorOption<T>::set(Configured& parametrisation, size_t values, args_t::
     if (begin == end) {
         throw UserError("No option value found for VectorOption, where 1 was expected");
     }
-    set(*begin, parametrisation);
+    // Take first value in range [begin, end)
+    auto value = translate(*begin);
+    set_value(value, parametrisation);
     return 1;
 }
 
 template <class T>
-void VectorOption<T>::set(const std::string& value, Configured& parametrisation) const {
+void VectorOption<T>::set_value(const std::vector<T>& value, Configured& parametrisation) const {
+    parametrisation.set(this->name(), value);
+}
+
+template <class T>
+std::vector<T> VectorOption<T>::translate(const std::string& value) const {
     eckit::Translator<std::string, T> t;
 
     eckit::Tokenizer parse(separator_);
-    std::vector<std::string> v;
-    parse(value, v);
+    std::vector<std::string> tokens;
+    parse(value, tokens);
 
     std::vector<T> values;
-    for (size_t i = 0; i < v.size(); i++) {
-        values.push_back(t(v[i]));
+    for (size_t i = 0; i < tokens.size(); i++) {
+        values.push_back(t(tokens[i]));
     }
 
     if (size_) {
@@ -68,12 +75,7 @@ void VectorOption<T>::set(const std::string& value, Configured& parametrisation)
             throw UserError(std::string("Size of supplied vector \"") + this->name() + "\" incorrect", Here());
     }
 
-    set_value(values, parametrisation);
-}
-
-template <class T>
-void VectorOption<T>::set_value(const std::vector<T>& value, Configured& parametrisation) const {
-    parametrisation.set(this->name(), value);
+    return values;
 }
 
 template <class T>

--- a/src/eckit/option/VectorOption.cc
+++ b/src/eckit/option/VectorOption.cc
@@ -41,7 +41,8 @@ VectorOption<T>::VectorOption(const std::string& name, const std::string& descri
 
 
 template <class T>
-size_t VectorOption<T>::set(Configured& parametrisation, args_t::const_iterator begin, args_t::const_iterator end) const {
+size_t VectorOption<T>::set(Configured& parametrisation, size_t values, args_t::const_iterator begin,
+                            args_t::const_iterator end) const {
     if (begin == end) {
         throw UserError("No option value found for VectorOption, where 1 was expected");
     }
@@ -95,7 +96,7 @@ void VectorOption<T>::print(std::ostream& out) const {
 
 template <class T>
 void VectorOption<T>::copy(const Configuration& from, Configured& to) const {
-    Option::copy<T>(this->name(), from, to);
+    Option::copy<std::vector<T>>(this->name(), from, to);
 }
 
 

--- a/src/eckit/option/VectorOption.h
+++ b/src/eckit/option/VectorOption.h
@@ -91,7 +91,7 @@ private:
 
     // -- Overridden methods
 
-    size_t set(Configured&, args_t::const_iterator begin, args_t::const_iterator end) const override;
+    size_t set(Configured&, size_t values, args_t::const_iterator begin, args_t::const_iterator end) const override;
     void set(const std::string& value, Configured&) const;
 
     void copy(const Configuration& from, Configured& to) const override;

--- a/src/eckit/option/VectorOption.h
+++ b/src/eckit/option/VectorOption.h
@@ -24,18 +24,21 @@
 namespace eckit::option {
 
 template <class T>
-class VectorOption : public Option {
+class VectorOption : public BaseOption<std::vector<T>> {
 public:
+    using base_t = BaseOption<std::vector<T>>;
+    using args_t = Option::args_t;
     // -- Exceptions
     // None
 
     // -- Contructors
 
     VectorOption(const std::string& name, const std::string& description, size_t size, const char* separator = "/");
+    VectorOption(const std::string& name, const std::string& description, size_t size, const std::vector<T>& default_value, const char* separator = "/");
 
     // -- Destructor
 
-    ~VectorOption() override;  // Change to virtual if base class
+    ~VectorOption() override = default;
 
     // -- Convertors
     // None
@@ -44,7 +47,7 @@ public:
     // None
 
     // -- Methods
-    // None
+    void set_value(const std::vector<T>& value, Configured&) const override;
 
 
     // -- Overridden methods
@@ -88,8 +91,9 @@ private:
 
     // -- Overridden methods
 
-    void set(Configured&) const override;
-    void set(const std::string& value, Configured&) const override;
+    size_t set(Configured&, args_t::const_iterator begin, args_t::const_iterator end) const override;
+    void set(const std::string& value, Configured&) const;
+
     void copy(const Configuration& from, Configured& to) const override;
 
     // -- Class members

--- a/src/eckit/option/VectorOption.h
+++ b/src/eckit/option/VectorOption.h
@@ -47,11 +47,10 @@ public:
     // None
 
     // -- Methods
-    void set_value(const std::vector<T>& value, Configured&) const override;
-
+    // None
 
     // -- Overridden methods
-    // None
+    size_t set(Configured&, size_t values, args_t::const_iterator begin, args_t::const_iterator end) const override;
 
     // -- Class members
     // None
@@ -90,9 +89,9 @@ private:
     // None
 
     // -- Overridden methods
+    void set_value(const std::vector<T>& value, Configured&) const override;
 
-    size_t set(Configured&, size_t values, args_t::const_iterator begin, args_t::const_iterator end) const override;
-    void set(const std::string& value, Configured&) const;
+    [[nodiscard]] std::vector<T> translate(const std::string& value) const override;
 
     void copy(const Configuration& from, Configured& to) const override;
 

--- a/src/eckit/utils/Tokenizer.h
+++ b/src/eckit/utils/Tokenizer.h
@@ -42,6 +42,15 @@ public:  // methods
     std::vector<std::string> tokenize(const std::string&) const;
     std::vector<std::string> tokenize(std::istream&) const;
 
+    /**
+     * Splits the given the string on the first instance of the separator.
+     *
+     * The result is the set of separated tokens:
+     *  - if the separator is not found, containing 1 token: [begin, end]
+     *  - if the separator is found, containing 2 tokens: [begin, separator[, ]separator, end]
+     * */
+    static std::vector<std::string> split_at(const std::string& s, char separator);
+
 private:
     std::set<char, std::less<char> > separator_;  // To make searching faster
     bool keepEmpty_;
@@ -67,6 +76,13 @@ inline std::vector<std::string> Tokenizer::tokenize(std::istream& s) const {
     std::vector<std::string> r;
     this->operator()(s, r);
     return r;
+}
+
+inline std::vector<std::string> Tokenizer::split_at(const std::string& s, char separator) {
+    if (auto found = s.find_first_of(separator); found != std::string::npos) {
+        return {s.substr(0, found), s.substr(found + 1)};
+    }
+    return {s};
 }
 
 //---------------------------------------------------------------------------------------------------------------------

--- a/tests/option/CMakeLists.txt
+++ b/tests/option/CMakeLists.txt
@@ -1,4 +1,4 @@
-foreach( TESTCASE RANGE 1 28 )
+foreach( TESTCASE RANGE 1 30 )
   ecbuild_add_test(
     TARGET      eckit_test_option_cmdargs_${TESTCASE}
     SOURCES     eckit_test_option_cmdargs.cc

--- a/tests/option/CMakeLists.txt
+++ b/tests/option/CMakeLists.txt
@@ -1,4 +1,4 @@
-foreach( TESTCASE RANGE 1 37 )
+foreach( TESTCASE RANGE 1 38 )
   ecbuild_add_test(
     TARGET      eckit_test_option_cmdargs_${TESTCASE}
     SOURCES     eckit_test_option_cmdargs.cc

--- a/tests/option/CMakeLists.txt
+++ b/tests/option/CMakeLists.txt
@@ -1,4 +1,4 @@
-foreach( TESTCASE RANGE 1 12 )
+foreach( TESTCASE RANGE 1 28 )
   ecbuild_add_test(
     TARGET      eckit_test_option_cmdargs_${TESTCASE}
     SOURCES     eckit_test_option_cmdargs.cc

--- a/tests/option/CMakeLists.txt
+++ b/tests/option/CMakeLists.txt
@@ -1,4 +1,4 @@
-foreach( TESTCASE RANGE 1 38 )
+foreach( TESTCASE RANGE 1 40 )
   ecbuild_add_test(
     TARGET      eckit_test_option_cmdargs_${TESTCASE}
     SOURCES     eckit_test_option_cmdargs.cc

--- a/tests/option/CMakeLists.txt
+++ b/tests/option/CMakeLists.txt
@@ -1,4 +1,4 @@
-foreach( TESTCASE RANGE 1 30 )
+foreach( TESTCASE RANGE 1 36 )
   ecbuild_add_test(
     TARGET      eckit_test_option_cmdargs_${TESTCASE}
     SOURCES     eckit_test_option_cmdargs.cc

--- a/tests/option/eckit_test_option_cmdargs.cc
+++ b/tests/option/eckit_test_option_cmdargs.cc
@@ -1059,6 +1059,79 @@ CASE("test_eckit_option__allows_to_set_default_value_for_options") {
 }
 #endif
 
+#if TESTCASE == 39
+CASE("test_eckit_option__cmdargs_argument_with_dot_in_option_name") {
+    options_t options;
+    options.push_back(new SimpleOption<std::string>("a.a", ""));
+    options.push_back(new SimpleOption<std::string>("b.b.b", ""));
+    options.push_back(new SimpleOption<std::string>("c.", ""));
+    options.push_back(new SimpleOption<std::string>(".d", ""));
+
+    std::vector<const char*> input = {"exe", "--a.a=a", "--b.b.b=b", "--c.=c", "--.d=d"};
+    Main::initialise(input.size(), const_cast<char**>(&input[0]));
+
+    CmdArgs args(&usage, options, 0, 0, true);
+    Log::info() << args << std::endl;
+
+    std::string a;
+    EXPECT(args.get("a.a", a));
+    EXPECT(a == "a");
+    EXPECT(args.getString("a.a") == a);
+
+    std::string b;
+    EXPECT(args.get("b.b.b", b));
+    EXPECT(b == "b");
+    EXPECT(args.getString("b.b.b") == b);
+
+    std::string c;
+    EXPECT(args.get("c.", c));
+    EXPECT(c == "c");
+    EXPECT(args.getString("c.") == c);
+
+    std::string d;
+    EXPECT(args.get(".d", d));
+    EXPECT(d == "d");
+    EXPECT(args.getString(".d") == d);
+}
+#endif
+
+#if TESTCASE == 40
+CASE("test_eckit_option__cmdargs_argument_with_dot_in_option_name_and_value") {
+    options_t options;
+    options.push_back(new SimpleOption<std::string>("a.a", ""));
+    options.push_back(new SimpleOption<std::string>("b.b.b", ""));
+    options.push_back(new SimpleOption<std::string>("c.", ""));
+    options.push_back(new SimpleOption<std::string>(".d", ""));
+
+    std::vector<const char*> input = {"exe", "--a.a=a.a", "--b.b.b=b.b.b", "--c.=c.", "--.d=.d"};
+    Main::initialise(input.size(), const_cast<char**>(&input[0]));
+
+    CmdArgs args(&usage, options, 0, 0, true);
+    Log::info() << args << std::endl;
+
+    std::string a;
+    EXPECT(args.get("a.a", a));
+    EXPECT(a == "a.a");
+    EXPECT(args.getString("a.a") == a);
+
+    std::string b;
+    EXPECT(args.get("b.b.b", b));
+    EXPECT(b == "b.b.b");
+    EXPECT(args.getString("b.b.b") == b);
+
+    std::string c;
+    EXPECT(args.get("c.", c));
+    EXPECT(c == "c.");
+    EXPECT(args.getString("c.") == c);
+
+    std::string d;
+    EXPECT(args.get(".d", d));
+    EXPECT(d == ".d");
+    EXPECT(args.getString(".d") == d);
+}
+#endif
+
+
 //----------------------------------------------------------------------------------------------------------------------
 
 }  // namespace eckit::test

--- a/tests/option/eckit_test_option_cmdargs.cc
+++ b/tests/option/eckit_test_option_cmdargs.cc
@@ -389,8 +389,8 @@ CASE("test_eckit_option__long_plus_joint_and_separated_string") {
     options.push_back(new SimpleOption<std::string>("arg2", ""));
     options.push_back(new SimpleOption<long>("arg3", ""));
 
-    std::vector<const char*> input
-        = {"exe", "--arg1", "value1", "pos1", "pos2", "pos3", "--arg2=value2", "pos4", "--arg3=1234", "pos5"};
+    std::vector<const char*> input = {"exe",  "--arg1",        "value1", "pos1",        "pos2",
+                                      "pos3", "--arg2=value2", "pos4",   "--arg3=1234", "pos5"};
     Main::initialise(input.size(), const_cast<char**>(&input[0]));
 
     CmdArgs args(&usage, options, -1, 4, true);
@@ -618,8 +618,8 @@ CASE("test_eckit_option__multi_value_with_2_mandatory_2_optional_2_provided") {
     options.push_back(new MultiValueOption("arg1", "", 2, 2));
     options.push_back(new SimpleOption<bool>("arg2", ""));
 
-    std::vector<const char*> input
-        = {"exe", "--arg1", "value1", "value2", "optional1", "optional2", "--arg2", "pos1", "pos2"};
+    std::vector<const char*> input = {"exe",       "--arg1", "value1", "value2", "optional1",
+                                      "optional2", "--arg2", "pos1",   "pos2"};
     Main::initialise(input.size(), const_cast<char**>(&input[0]));
 
     CmdArgs args(&usage, options, -1, 2, true);
@@ -950,11 +950,7 @@ CASE("test_eckit_option__can_handle_simple_option_provided_twice") {
     options.push_back(new SimpleOption<std::string>("arg1", "description"));
 
     std::vector<const char*> input = {
-        "exe",
-        "--arg1=first.value",
-        "--arg1",
-        "second.value",
-        "--arg1=last.value",
+        "exe", "--arg1=first.value", "--arg1", "second.value", "--arg1=last.value",
     };
     Main::initialise(input.size(), const_cast<char**>(&input[0]));
 
@@ -973,10 +969,7 @@ CASE("test_eckit_option__can_handle_vector_option_of_double") {
     options_t options;
     options.push_back(new VectorOption<double>("arg1", "description", 2));
 
-    std::vector<const char*> input = {
-        "exe",
-        "--arg1=-32.0/10"
-    };
+    std::vector<const char*> input = {"exe", "--arg1=-32.0/10"};
     Main::initialise(input.size(), const_cast<char**>(&input[0]));
 
     CmdArgs args(&usage, options, 0, 0, true);
@@ -996,20 +989,10 @@ CASE("test_eckit_option_cmdargs_value_with_equals") {
         options.push_back(new SimpleOption<std::string>(std::string{c}, ""));
     }
 
-    const char* input[] = {"exe",
-                           "--a=a",
-                           "--b==b",
-                           "--c=c=",
-                           "--d===d",
-                           "--e==e=",
-                           "--f=f==",
-                           "--g=g=g",
-                           "--h==h=h",
-                           "--i==ii=",
-                           "--j=j==j",
-                           "--k=k=k="};
+    std::vector<const char*> input = {"exe",     "--a=a",   "--b==b",   "--c=c=",   "--d===d",  "--e==e=",
+                                      "--f=f==", "--g=g=g", "--h==h=h", "--i==ii=", "--j=j==j", "--k=k=k="};
 
-    Main::initialise(12, const_cast<char**>(input));
+    Main::initialise(input.size(), const_cast<char**>(&input[0]));
 
     CmdArgs args(&usage, options, 0, 0, true);
 
@@ -1024,6 +1007,55 @@ CASE("test_eckit_option_cmdargs_value_with_equals") {
     EXPECT(args.getString("i") == "=ii=");
     EXPECT(args.getString("j") == "j==j");
     EXPECT(args.getString("k") == "k=k=");
+}
+#endif
+
+#if TESTCASE == 38
+CASE("test_eckit_option__allows_to_set_default_value_for_options") {
+    options_t options;
+    {
+        auto o = (new SimpleOption<std::string>("arg1", ""))->defaultValue("default string");
+        options.push_back(o);
+    }
+    {
+        auto o = (new VectorOption<std::string>("arg2", "", 0))->defaultValue("q/w/e/r/t/y");
+        options.push_back(o);
+    }
+    {
+        auto o = (new VectorOption<long>("arg3", "", 0))->defaultValue("1/2/3/4");
+        options.push_back(o);
+    }
+
+    std::vector<const char*> input = {"exe"};
+    Main::initialise(input.size(), const_cast<char**>(&input[0]));
+
+    CmdArgs args(&usage, options, 0, 0, true);
+
+    {
+        EXPECT(args.has("arg1"));
+        auto v = args.getString("arg1");
+        EXPECT_EQUAL(v, "default string");
+    }
+    {
+        EXPECT(args.has("arg2"));
+        auto v = args.getStringVector("arg2");
+        EXPECT_EQUAL(v.size(), 6);
+        EXPECT_EQUAL(v[0], "q");
+        EXPECT_EQUAL(v[1], "w");
+        EXPECT_EQUAL(v[2], "e");
+        EXPECT_EQUAL(v[3], "r");
+        EXPECT_EQUAL(v[4], "t");
+        EXPECT_EQUAL(v[5], "y");
+    }
+    {
+        EXPECT(args.has("arg3"));
+        auto v = args.getLongVector("arg3");
+        EXPECT_EQUAL(v.size(), 4);
+        EXPECT_EQUAL(v[0], 1L);
+        EXPECT_EQUAL(v[1], 2L);
+        EXPECT_EQUAL(v[2], 3L);
+        EXPECT_EQUAL(v[3], 4L);
+    }
 }
 #endif
 

--- a/tests/option/eckit_test_option_cmdargs.cc
+++ b/tests/option/eckit_test_option_cmdargs.cc
@@ -839,6 +839,145 @@ CASE("test_eckit_option__with_separator_and_some_invalid_option_to_force_logging
 }
 #endif
 
+#if TESTCASE == 31
+CASE("test_eckit_option__with_simple_string_value_containing_equals_sign") {
+    std::vector<Option*> options;
+    options.push_back(new SimpleOption<std::string>("arg1", "description"));
+
+    std::vector<const char*> input = {"exe", "--arg1=some=value=with=equals", "/some/path", "/another/path"};
+    Main::initialise(input.size(), const_cast<char**>(&input[0]));
+
+    CmdArgs args(&usage, options, -1, 2, true);
+
+    auto args_count = args.count();
+    EXPECT_EQUAL(args_count, 2);
+
+    {
+        EXPECT(args.has("arg1"));
+        std::string s;
+        args.get("arg1", s);
+        EXPECT_EQUAL(s, "some=value=with=equals");
+    }
+}
+#endif
+
+#if TESTCASE == 32
+CASE("test_eckit_option__can_handle_bool_option_without_value") {
+    std::vector<Option*> options;
+    options.push_back(new SimpleOption<bool>("arg1", "description"));
+
+    std::vector<const char*> input = {
+        "exe",
+        "--arg1",
+    };
+    Main::initialise(input.size(), const_cast<char**>(&input[0]));
+
+    CmdArgs args(&usage, options, 0, 0, true);
+
+    auto args_count = args.count();
+    EXPECT_EQUAL(args_count, 0);
+
+    {
+        EXPECT(args.has("arg1"));
+        bool v = args.getBool("arg1");
+        EXPECT_EQUAL(v, true);
+    }
+}
+#endif
+
+#if TESTCASE == 33
+CASE("test_eckit_option__can_handle_bool_option_with_true_value") {
+    std::vector<Option*> options;
+    options.push_back(new SimpleOption<bool>("arg1", "description"));
+
+    std::vector<const char*> input = {
+        "exe",
+        "--arg1=yes",
+    };
+    Main::initialise(input.size(), const_cast<char**>(&input[0]));
+
+    CmdArgs args(&usage, options, 0, 0, true);
+
+    auto args_count = args.count();
+    EXPECT_EQUAL(args_count, 0);
+
+    {
+        EXPECT(args.has("arg1"));
+        bool v = args.getBool("arg1");
+        EXPECT_EQUAL(v, true);
+    }
+}
+#endif
+
+#if TESTCASE == 34
+CASE("test_eckit_option__can_handle_bool_option_with_false_value") {
+    std::vector<Option*> options;
+    options.push_back(new SimpleOption<bool>("arg1", "description"));
+
+    std::vector<const char*> input = {
+        "exe",
+        "--arg1=0",
+    };
+    Main::initialise(input.size(), const_cast<char**>(&input[0]));
+
+    CmdArgs args(&usage, options, 0, 0, true);
+
+    auto args_count = args.count();
+    EXPECT_EQUAL(args_count, 0);
+
+    {
+        EXPECT(args.has("arg1"));
+        bool v = args.getBool("arg1");
+        EXPECT_EQUAL(v, false);
+    }
+}
+#endif
+
+#if TESTCASE == 35
+CASE("test_eckit_option__can_handle_simple_option_provided_twice") {
+    std::vector<Option*> options;
+    options.push_back(new SimpleOption<std::string>("arg1", "description"));
+
+    std::vector<const char*> input = {
+        "exe",
+        "--arg1=first.value",
+        "--arg1",
+        "second.value",
+        "--arg1=last.value",
+    };
+    Main::initialise(input.size(), const_cast<char**>(&input[0]));
+
+    CmdArgs args(&usage, options, 0, 0, true);
+
+    {
+        EXPECT(args.has("arg1"));
+        std::string s = args.getString("arg1");
+        EXPECT_EQUAL(s, "last.value");
+    }
+}
+#endif
+
+#if TESTCASE == 36
+CASE("test_eckit_option__can_handle_vector_option_of_double") {
+    std::vector<Option*> options;
+    options.push_back(new VectorOption<double>("arg1", "description", 2));
+
+    std::vector<const char*> input = {
+        "exe",
+        "--arg1=-32.0/10"
+    };
+    Main::initialise(input.size(), const_cast<char**>(&input[0]));
+
+    CmdArgs args(&usage, options, 0, 0, true);
+
+    {
+        EXPECT(args.has("arg1"));
+        auto s = args.getDoubleVector("arg1");
+        EXPECT_EQUAL(s.size(), 2);
+    }
+}
+#endif
+
 }  // namespace eckit::test
 
 int main(int argc, char** argv) {


### PR DESCRIPTION
This pull request enables the support for multi-value options in CmdArgs.

A multi-value Option allows collecting multiple argv values, as if these values where positional relative to the option e.g. `--option <command> <name> <value> /path/to/one /path/to/two ... --next`.

The goal is to allow collecting argv values until: 1) there are no more values to collect, either because the end of the list of values was reached or because the next option was found; or, 2) a mandatory+optional number of values has been collected.