### PR TITLE
Increase ChannelBuffer size from 1024 to 4096

### DIFF
--- a/src/eckit/log/ChannelBuffer.h
+++ b/src/eckit/log/ChannelBuffer.h
@@ -33,7 +33,7 @@ class ChannelBuffer : public std::streambuf, private NonCopyable {
 
 private:  // methods
     /// constructor, taking ownership of stream
-    ChannelBuffer(std::size_t size = 1024);
+    ChannelBuffer(std::size_t size = 4096);
 
     ~ChannelBuffer() override;
 


### PR DESCRIPTION
We are sometimes experiencing SEGFAULTS due to buffer overflows.

@raguridan may add more information.