### PR TITLE
Correct macOS specific downstream issues ECKIT-620

### DIFF
--- a/src/eckit/CMakeLists.txt
+++ b/src/eckit/CMakeLists.txt
@@ -876,22 +876,25 @@ foreach( dir ${eckit_dirs} )
 endforeach()
 
 list( APPEND eckit_templates
+                    container/BTree.cc
+                    container/BloomFilter.cc
                     container/CacheLRU.cc
+                    container/MappedArray.cc
+                    container/SharedMemArray.cc
+                    container/Trie.cc
+                    container/bsptree/BSPNode.cc
                     container/kdtree/KDNode.cc
                     container/sptree/SPNode.cc
                     filesystem/BasePathNameT.cc
                     io/FileBase.cc
+                    option/FactoryOption.cc
+                    option/SimpleOption.cc
+                    option/VectorOption.cc
                     runtime/PipeHandler.cc
                     serialisation/Reanimator.cc
                     transaction/TxnLog.cc
                     types/Types.cc
                     utils/RLE.cc
-                    container/BTree.cc
-                    container/BloomFilter.cc
-                    container/MappedArray.cc
-                    container/SharedMemArray.cc
-                    container/Trie.cc
-                    container/bsptree/BSPNode.cc
 )
 
 list( APPEND eckit_persistent

--- a/src/eckit/option/CMakeLists.txt
+++ b/src/eckit/option/CMakeLists.txt
@@ -4,7 +4,7 @@ ecbuild_add_library( TARGET eckit_option TYPE SHARED
 
     HEADER_DESTINATION ${INSTALL_INCLUDE_DIR}/eckit/option
 
-	SOURCES
+    SOURCES
         FactoryOption.cc
         FactoryOption.h
         MultiValueOption.cc

--- a/src/eckit/option/CMakeLists.txt
+++ b/src/eckit/option/CMakeLists.txt
@@ -15,6 +15,7 @@ ecbuild_add_library( TARGET eckit_option TYPE SHARED
         Separator.h
         SimpleOption.cc
         SimpleOption.h
+        Title.h
         VectorOption.cc
         VectorOption.h
         CmdArgs.cc

--- a/src/eckit/option/FactoryOption.cc
+++ b/src/eckit/option/FactoryOption.cc
@@ -12,6 +12,8 @@
 /// @author Tiago Quintino
 /// @date Apr 2015
 
+#pragma once
+
 #include <iostream>
 
 #include "eckit/config/Configuration.h"

--- a/src/eckit/option/FactoryOption.cc
+++ b/src/eckit/option/FactoryOption.cc
@@ -16,15 +16,11 @@
 
 #include <iostream>
 
-#include "eckit/config/Configuration.h"
 #include "eckit/config/Configured.h"
-
 #include "eckit/exception/Exceptions.h"
 #include "eckit/option/FactoryOption.h"
-#include "eckit/utils/Translator.h"
 
-namespace eckit {
-namespace option {
+namespace eckit::option {
 
 
 template <class T>
@@ -62,11 +58,9 @@ void FactoryOption<T>::copy(const Configuration& from, Configured& to) const {
 
 template <class T>
 void FactoryOption<T>::print(std::ostream& out) const {
-    out << "   --" << name_ << "=name"
-        << " (" << description_ << ")";
+    out << "   --" << name_ << "=name" << " (" << description_ << ")";
     out << std::endl << "     Values are: ";
     T::list(out);
 }
 
-}  // namespace option
-}  // namespace eckit
+}  // namespace eckit::option

--- a/src/eckit/option/FactoryOption.h
+++ b/src/eckit/option/FactoryOption.h
@@ -12,9 +12,7 @@
 /// @author Tiago Quintino
 /// @date Apr 2015
 
-
-#ifndef eckit_option_FactoryOption_H
-#define eckit_option_FactoryOption_H
+#pragma once
 
 #include <iosfwd>
 
@@ -52,5 +50,3 @@ private:
 }  // namespace eckit::option
 
 #include "eckit/option/FactoryOption.cc"
-
-#endif

--- a/src/eckit/option/MultiValueOption.cc
+++ b/src/eckit/option/MultiValueOption.cc
@@ -13,9 +13,7 @@
 #include <algorithm>
 #include <iostream>
 
-#include "eckit/config/Configuration.h"
 #include "eckit/config/Configured.h"
-
 #include "eckit/exception/Exceptions.h"
 
 namespace eckit::option {
@@ -39,16 +37,15 @@ MultiValueOption::MultiValueOption(const std::string& name, const std::string& d
                                    size_t n_optional_values, std::optional<values_t> default_values) :
     base_t(name, description, std::move(default_values)),
     n_mandatory_values_{n_mandatory_values},
-    n_optional_values_{n_optional_values},
-    values_{} {
+    n_optional_values_{n_optional_values} {
     ASSERT_MSG(n_mandatory_values >= 1, "At least 1 mandatory value is expected.");
 }
 
 size_t MultiValueOption::set(Configured& parametrisation, [[maybe_unused]] size_t values, args_t::const_iterator begin,
                              args_t::const_iterator end) const {
     if (std::distance(begin, end) < n_mandatory_values_) {
-        throw UserError("Not enough option values found for MultiValueOption, where at least " +
-                        std::to_string(n_mandatory_values_) + " were expected");
+        throw UserError("Not enough option values found for MultiValueOption, where at least "
+                        + std::to_string(n_mandatory_values_) + " were expected");
     }
 
     // Collect n_mandatory_values_ mandatory values from the range [begin, end)

--- a/src/eckit/option/MultiValueOption.h
+++ b/src/eckit/option/MultiValueOption.h
@@ -8,8 +8,7 @@
  * does it submit to any jurisdiction.
  */
 
-#ifndef eckit_option_MultiValueOption_H
-#define eckit_option_MultiValueOption_H
+#pragma once
 
 #include <iosfwd>
 
@@ -23,9 +22,12 @@ public:
     using values_t = std::vector<std::string>;
 
     MultiValueOption(const std::string& name, const std::string& description, size_t n_mandatory_values);
-    MultiValueOption(const std::string& name, const std::string& description, size_t n_mandatory_values, size_t n_optional_values);
-    MultiValueOption(const std::string& name, const std::string& description, size_t n_mandatory_values, const values_t& default_values);
-    MultiValueOption(const std::string& name, const std::string& description, size_t n_mandatory_values, size_t n_optional_values, const values_t& default_values);
+    MultiValueOption(const std::string& name, const std::string& description, size_t n_mandatory_values,
+                     size_t n_optional_values);
+    MultiValueOption(const std::string& name, const std::string& description, size_t n_mandatory_values,
+                     const values_t& default_values);
+    MultiValueOption(const std::string& name, const std::string& description, size_t n_mandatory_values,
+                     size_t n_optional_values, const values_t& default_values);
     ~MultiValueOption() override = default;
 
     size_t set(Configured&, size_t values, args_t::const_iterator begin, args_t::const_iterator end) const override;
@@ -33,7 +35,8 @@ public:
     void print(std::ostream&) const override;
 
 private:
-    MultiValueOption(const std::string& name, const std::string& description, size_t n_mandatory_values, size_t n_maximum_values, std::optional<values_t> default_values);
+    MultiValueOption(const std::string& name, const std::string& description, size_t n_mandatory_values,
+                     size_t n_maximum_values, std::optional<values_t> default_values);
 
     void set_value(const values_t& values, Configured&) const override;
 
@@ -47,5 +50,3 @@ private:
 };
 
 }  // namespace eckit::option
-
-#endif

--- a/src/eckit/option/Option.cc
+++ b/src/eckit/option/Option.cc
@@ -14,7 +14,6 @@
 
 
 #include "eckit/option/Option.h"
-#include "eckit/option/SimpleOption.h"
 
 #include "eckit/exception/Exceptions.h"
 

--- a/src/eckit/option/SimpleOption.cc
+++ b/src/eckit/option/SimpleOption.cc
@@ -18,7 +18,6 @@
 
 #include "eckit/config/Configuration.h"
 #include "eckit/config/Configured.h"
-
 #include "eckit/exception/Exceptions.h"
 #include "eckit/filesystem/PathName.h"
 #include "eckit/option/SimpleOption.h"
@@ -68,12 +67,12 @@ void SimpleOption<T>::set_value(const T& value, Configured& parametrisation) con
 
 template <class T>
 T SimpleOption<T>::translate(const std::string& value) const {
-    T v = eckit::Translator<std::string, T>()(value);
+    T v = Translator<std::string, T>()(value);
     return v;
 }
 
 template <>
-inline void SimpleOption<eckit::PathName>::copy(const Configuration& from, Configured& to) const {
+inline void SimpleOption<PathName>::copy(const Configuration& from, Configured& to) const {
     std::string v;
     if (from.get(name_, v)) {
         to.set(name_, v);

--- a/src/eckit/option/SimpleOption.cc
+++ b/src/eckit/option/SimpleOption.cc
@@ -12,6 +12,8 @@
 /// @author Tiago Quintino
 /// @date Apr 2015
 
+#pragma once
+
 #include <iostream>
 
 #include "eckit/config/Configuration.h"

--- a/src/eckit/option/SimpleOption.cc
+++ b/src/eckit/option/SimpleOption.cc
@@ -20,48 +20,10 @@
 #include "eckit/exception/Exceptions.h"
 #include "eckit/filesystem/PathName.h"
 #include "eckit/option/SimpleOption.h"
+#include "eckit/option/Title.h"
 #include "eckit/utils/Translator.h"
 
 namespace eckit::option {
-
-namespace {
-
-template <class T>
-struct Title {
-    const char* operator()() const;
-};
-
-template <>
-inline const char* Title<size_t>::operator()() const {
-    return "ordinal";
-}
-
-template <>
-inline const char* Title<long>::operator()() const {
-    return "integer";
-}
-
-template <>
-inline const char* Title<double>::operator()() const {
-    return "real";
-}
-
-template <>
-inline const char* Title<bool>::operator()() const {
-    return "0/1";
-}
-
-template <>
-inline const char* Title<std::string>::operator()() const {
-    return "string";
-}
-
-template <>
-inline const char* Title<eckit::PathName>::operator()() const {
-    return "path";
-}
-
-}  // namespace
 
 template <class T>
 SimpleOption<T>::SimpleOption(const std::string& name, const std::string& description) : base_t(name, description) {}
@@ -128,7 +90,7 @@ inline void SimpleOption<bool>::print(std::ostream& out) const {
 
 template <class T>
 void SimpleOption<T>::print(std::ostream& out) const {
-    out << "   --" << this->name() << "=" << Title<T>()() << " (" << this->description() << ")";
+    out << "   --" << this->name() << "=" << implementation_detail::Title<T>()() << " (" << this->description() << ")";
 }
 
 }  // namespace eckit::option

--- a/src/eckit/option/SimpleOption.h
+++ b/src/eckit/option/SimpleOption.h
@@ -12,9 +12,7 @@
 /// @author Tiago Quintino
 /// @date Apr 2015
 
-
-#ifndef eckit_option_SimpleOption_H
-#define eckit_option_SimpleOption_H
+#pragma once
 
 #include <iosfwd>
 
@@ -39,7 +37,6 @@ protected:
     void print(std::ostream&) const override;
 
 private:
-
     void set_value(const T& value, Configured&) const override;
 
     [[nodiscard]] T translate(const std::string& value) const override;
@@ -50,5 +47,3 @@ private:
 }  // namespace eckit::option
 
 #include "eckit/option/SimpleOption.cc"
-
-#endif

--- a/src/eckit/option/Title.h
+++ b/src/eckit/option/Title.h
@@ -1,0 +1,65 @@
+/*
+ * (C) Copyright 1996- ECMWF.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation nor
+ * does it submit to any jurisdiction.
+ */
+
+#ifndef eckit_option_Title_H
+#define eckit_option_Title_H
+
+#include <string>
+
+#include "eckit/filesystem/PathName.h"
+
+namespace eckit::option {
+
+namespace implementation_detail {
+
+/*
+ * The following is a utility used to automatically determine the description of an option type.
+ */
+
+template <class T>
+struct Title {
+    const char* operator()() const;
+};
+
+template <>
+inline const char* Title<size_t>::operator()() const {
+    return "ordinal";
+}
+
+template <>
+inline const char* Title<long>::operator()() const {
+    return "integer";
+}
+
+template <>
+inline const char* Title<double>::operator()() const {
+    return "real";
+}
+
+template <>
+inline const char* Title<bool>::operator()() const {
+    return "0/1";
+}
+
+template <>
+inline const char* Title<std::string>::operator()() const {
+    return "string";
+}
+
+template <>
+inline const char* Title<eckit::PathName>::operator()() const {
+    return "path";
+}
+
+}  // namespace implementation_detail
+
+}  // namespace eckit::option
+
+#endif

--- a/src/eckit/option/VectorOption.cc
+++ b/src/eckit/option/VectorOption.cc
@@ -16,8 +16,8 @@
 #include <iostream>
 
 #include "eckit/exception/Exceptions.h"
+#include "eckit/option/Title.h"
 #include "eckit/option/VectorOption.h"
-#include "eckit/types/Types.h"
 #include "eckit/utils/Tokenizer.h"
 #include "eckit/utils/Translator.h"
 
@@ -84,7 +84,7 @@ void VectorOption<T>::print(std::ostream& out) const {
 
     const char* sep = "=";
     for (size_t i = 0; i < (size_ ? size_ : 2); i++) {
-        out << sep << Title<T>()();
+        out << sep << implementation_detail::Title<T>()();
         sep = separator_;
     }
 

--- a/src/eckit/option/VectorOption.cc
+++ b/src/eckit/option/VectorOption.cc
@@ -23,13 +23,7 @@
 #include "eckit/utils/Tokenizer.h"
 #include "eckit/utils/Translator.h"
 
-
-namespace eckit {
-
-namespace option {
-
-//----------------------------------------------------------------------------------------------------------------------
-
+namespace eckit::option {
 
 template <class T>
 VectorOption<T>::VectorOption(const std::string& name, const std::string& description, size_t size,
@@ -61,9 +55,9 @@ void VectorOption<T>::set_value(const std::vector<T>& value, Configured& paramet
 
 template <class T>
 std::vector<T> VectorOption<T>::translate(const std::string& value) const {
-    eckit::Translator<std::string, T> t;
+    Translator<std::string, T> t;
 
-    eckit::Tokenizer parse(separator_);
+    Tokenizer parse(separator_);
     std::vector<std::string> tokens;
     parse(value, tokens);
 
@@ -97,16 +91,9 @@ void VectorOption<T>::print(std::ostream& out) const {
     out << " (" << this->description() << ")";
 }
 
-
 template <class T>
 void VectorOption<T>::copy(const Configuration& from, Configured& to) const {
     Option::copy<std::vector<T>>(this->name(), from, to);
 }
 
-
-//----------------------------------------------------------------------------------------------------------------------
-
-
-}  // namespace option
-
-}  // namespace eckit
+}  // namespace eckit::option

--- a/src/eckit/option/VectorOption.cc
+++ b/src/eckit/option/VectorOption.cc
@@ -13,6 +13,8 @@
 /// @author Simon Smart
 /// @date March 2016
 
+#pragma once
+
 #include <iostream>
 
 #include "eckit/exception/Exceptions.h"

--- a/src/eckit/option/VectorOption.h
+++ b/src/eckit/option/VectorOption.h
@@ -19,7 +19,6 @@
 #include <iosfwd>
 
 #include "eckit/option/Option.h"
-#include "eckit/option/SimpleOption.h"
 
 namespace eckit::option {
 

--- a/src/eckit/option/VectorOption.h
+++ b/src/eckit/option/VectorOption.h
@@ -13,8 +13,7 @@
 /// @date Apr 2015
 
 
-#ifndef VectorOption_H
-#define VectorOption_H
+#pragma once
 
 #include <iosfwd>
 
@@ -33,7 +32,8 @@ public:
     // -- Contructors
 
     VectorOption(const std::string& name, const std::string& description, size_t size, const char* separator = "/");
-    VectorOption(const std::string& name, const std::string& description, size_t size, const std::vector<T>& default_value, const char* separator = "/");
+    VectorOption(const std::string& name, const std::string& description, size_t size,
+                 const std::vector<T>& default_value, const char* separator = "/");
 
     // -- Destructor
 
@@ -106,5 +106,3 @@ private:
 }  // namespace eckit::option
 
 #include "eckit/option/VectorOption.cc"
-
-#endif


### PR DESCRIPTION
This set of changes resolves build issues specific to Apple Clang 14 (on macOS 13).

Apparently this compiler doesn't work well with inner unnamed namespaces, and doesn't seem to generate the intended linkage symbols. This affected the definition of struct Title, which is a small internal utility to determine the description of an option based on the option type.

The solution was simply to move the Title class to a named namespace.