### PR TITLE
Add missing #include<cstddef>

### DIFF
--- a/src/eckit/system/ResourceUsage.h
+++ b/src/eckit/system/ResourceUsage.h
@@ -16,6 +16,7 @@
 #define eckit_system_ResourceUsage_H
 
 #include <sys/resource.h>
+#include <cstddef>
 #include <iosfwd>
 
 namespace eckit::system {


### PR DESCRIPTION

Adding #include <cstddef> suppresses the compilation error `error: unknown type name 'size_t'` issued by Clang 17 on macOS.