### PR TITLE
IFS crashes without this increased buffer size with TCo1279 - NG5 and multIO in FESOM on LUMI-g

### DIFF
--- a/src/eckit/log/ChannelBuffer.h
+++ b/src/eckit/log/ChannelBuffer.h
@@ -33,7 +33,7 @@ class ChannelBuffer : public std::streambuf, private NonCopyable {
 
 private:  // methods
     /// constructor, taking ownership of stream
-    ChannelBuffer(std::size_t size = 1024);
+    ChannelBuffer(std::size_t size = 4096);
 
     ~ChannelBuffer() override;
 


### PR DESCRIPTION
nid005309:40:1 : [06]: MPIR_Err_return_comm /opt/cray/pe/mpich/8.1.27/ofi/cray/14.0/lib/libmpi_cray.so.12 0x1482f6ce6000 0x1482f8c8c7db # addr2line
nid005309:40:1 : [07]: PMPI_Send /opt/cray/pe/mpich/8.1.27/ofi/cray/14.0/lib/libmpi_cray.so.12 0x1482f6ce6000 0x1482f76b3f81 # addr2line

**nid005309:40:1 : [08]: eckit::mpi::Parallel::send(void const*, unsigned long, eckit::mpi::Data::Code, int, int) const /pfs/lustrep3/scratch/project_462000146/thorackow/ifs-bundle-DE_CY48R1.0_climateDT_develop/build-fesom.lumi-g/bin/../lib/../lib/libeckit_mpi.so 0x1482f9d2f000 0x1482f9d58ef0 # addr2line**

nid005309:40:1 : [09]: multio::transport::MpiTransport::send(multio::message::Message const&) /pfs/lustrep3/scratch/project_462000146/thorackow/ifs-bundle-DE_CY48R1.0_climateDT_develop/build-fesom.lumi-g/bin/../lib/../lib/libmultio.so 0x14833b8a8000 0x14833b94f675 # addr2line
nid005309:40:1 : [10]: multio::action::Transport::executeImpl(multio::message::Message) /pfs/lustrep3/scratch/project_462000146/thorackow/ifs-bundle-DE_CY48R1.0_climateDT_develop/build-fesom.lumi-g/bin/../lib/../lib/libmultio-action-transport.so 0x14833b9ec000 0x14833b9f5504 # addr2line
