### PR TITLE
Normalise angle fix

### DIFF
--- a/src/eckit/geometry/CoordinateHelpers.cc
+++ b/src/eckit/geometry/CoordinateHelpers.cc
@@ -5,9 +5,9 @@
  * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
+#include <cmath>
 #include <limits>
 #include <sstream>
-#include <cmath>
 
 #include "eckit/exception/Exceptions.h"
 #include "eckit/geometry/CoordinateHelpers.h"
@@ -18,11 +18,11 @@ namespace eckit::geometry {
 //----------------------------------------------------------------------------------------------------------------------
 
 inline double modulo(const double a, const double b) {
-    return a-b*std::floor(a/b);
+    return a - b * std::floor(a / b);
 }
 
 double normalise_angle(const double a, const double minimum) {
-    return minimum + modulo(a-minimum, 360.);
+    return minimum + modulo(a - minimum, 360.);
 }
 
 //----------------------------------------------------------------------------------------------------------------------

--- a/src/eckit/geometry/CoordinateHelpers.cc
+++ b/src/eckit/geometry/CoordinateHelpers.cc
@@ -7,6 +7,7 @@
 
 #include <limits>
 #include <sstream>
+#include <cmath>
 
 #include "eckit/exception/Exceptions.h"
 #include "eckit/geometry/CoordinateHelpers.h"
@@ -16,14 +17,12 @@ namespace eckit::geometry {
 
 //----------------------------------------------------------------------------------------------------------------------
 
-double normalise_angle(double a, const double minimum) {
-    while (a < minimum) {
-        a += 360.;
-    }
-    while (a >= minimum + 360.) {
-        a -= 360.;
-    }
-    return a;
+inline double modulo(const double a, const double b) {
+    return a-b*std::floor(a/b);
+}
+
+double normalise_angle(const double a, const double minimum) {
+    return minimum + modulo(a-minimum, 360.);
 }
 
 //----------------------------------------------------------------------------------------------------------------------

--- a/tests/geometry/test_coordinate_helpers.cc
+++ b/tests/geometry/test_coordinate_helpers.cc
@@ -21,6 +21,13 @@ CASE("normalise angles") {
     EXPECT(14. == normalise_angle(374., 0.));
     EXPECT(14. == normalise_angle(374., -90.));
     EXPECT(374. == normalise_angle(374., 90.));
+    EXPECT(14. == normalise_angle(-346., 0.));
+    EXPECT(14. == normalise_angle(-346., -90.));
+    EXPECT(374. == normalise_angle(-346., 90.));
+    EXPECT(0. == normalise_angle(360.*1e12, 0.));
+    EXPECT(14. == normalise_angle(360.*1e12+14, 0.));
+    EXPECT(0. == normalise_angle(-360.*1e12, 0.));
+    EXPECT(14. == normalise_angle(-360.*1e12+14, 0.));
 }
 
 CASE("canonicalise on sphere") {

--- a/tests/geometry/test_coordinate_helpers.cc
+++ b/tests/geometry/test_coordinate_helpers.cc
@@ -24,10 +24,10 @@ CASE("normalise angles") {
     EXPECT(14. == normalise_angle(-346., 0.));
     EXPECT(14. == normalise_angle(-346., -90.));
     EXPECT(374. == normalise_angle(-346., 90.));
-    EXPECT(0. == normalise_angle(360.*1e12, 0.));
-    EXPECT(14. == normalise_angle(360.*1e12+14, 0.));
-    EXPECT(0. == normalise_angle(-360.*1e12, 0.));
-    EXPECT(14. == normalise_angle(-360.*1e12+14, 0.));
+    EXPECT(0. == normalise_angle(360. * 1e12, 0.));
+    EXPECT(14. == normalise_angle(360. * 1e12 + 14, 0.));
+    EXPECT(0. == normalise_angle(-360. * 1e12, 0.));
+    EXPECT(14. == normalise_angle(-360. * 1e12 + 14, 0.));
 }
 
 CASE("canonicalise on sphere") {


### PR DESCRIPTION
This modifies `eckit::geometry::normalise_angle`` so that it uses a modulo operator to find the correct output value, rather than repeatedly adding or subtracting 360 from the input. This makes the function orders of magnitude faster for very large input values.

Also added a few additional checks to test_coordinate_helpers to verify that `normalise_angle` works correctly on negative inputs and very large (positive or negative) inputs.

Fixes #102.