### PR TITLE
Deprecate access to `const Value& Configuration::get()`

### DIFF
--- a/src/eckit/codec/Metadata.h
+++ b/src/eckit/codec/Metadata.h
@@ -57,14 +57,8 @@ public:
 
     // extended LocalConfiguration:
     using LocalConfiguration::set;
-    Metadata& set(const LocalConfiguration& other) {
-        auto& root             = const_cast<Value&>(get());
-        const auto& other_root = other.get();
-        std::vector<std::string> other_keys;
-        fromValue(other_keys, other_root.keys());
-        for (auto& key : other_keys) {
-            root[key] = other_root[key];
-        }
+    Metadata& set(const Configuration& other) {
+        LocalConfiguration::set(other);
         return *this;
     }
 
@@ -79,17 +73,8 @@ public:
 
 
     Metadata& remove(const std::string& name) {
-        auto& root = const_cast<Value&>(get());
-        root.remove(name);
+        LocalConfiguration::remove(name);
         return *this;
-    }
-
-
-    std::vector<std::string> keys() const {
-        // Preserves order of keys
-        std::vector<std::string> result;
-        fromValue(result, get().keys());
-        return result;
     }
 };
 

--- a/src/eckit/codec/types/scalar.cc
+++ b/src/eckit/codec/types/scalar.cc
@@ -16,7 +16,7 @@
 #endif
 
 // GNU C++ compiler (version 11) should not try to optimize this code
-#if defined(__GNUC__) && !defined(__NVCOMPILER)
+#if defined(__GNUC__) && !defined(__NVCOMPILER) && !defined(__clang__)
 #pragma GCC optimize("O0")
 #endif
 

--- a/src/eckit/config/Configuration.cc
+++ b/src/eckit/config/Configuration.cc
@@ -299,7 +299,7 @@ bool Configuration::get(const std::string& name, LocalConfiguration& value) cons
     return found;
 }
 
-const Value& Configuration::get() const {
+const Value& Configuration::getValue() const {
     return *root_;
 }
 
@@ -581,10 +581,7 @@ void Configuration::json(JSON& s) const {
 
 std::vector<std::string> Configuration::keys() const {
     std::vector<std::string> result;
-    ValueMap m = *root_;
-    for (ValueMap::const_iterator j = m.begin(); j != m.end(); ++j) {
-        result.push_back((*j).first);
-    }
+    eckit::fromValue(result, root_->keys());
     return result;
 }
 

--- a/src/eckit/config/Configuration.h
+++ b/src/eckit/config/Configuration.h
@@ -125,8 +125,11 @@ public:  // methods
     bool get(const std::string& name, LocalConfiguration&) const;
 
     /// @todo This method should be protected. As per note above,
-    ///       we don't wnat to expose eckit::Value out of Configuration.
-    const Value& get() const;
+    ///       we don't want to expose eckit::Value out of Configuration.
+    [[deprecated("eckit::Value should not be exposed via eckit::Configuration::get(). This method Will be removed in a next release.")]]
+    const Value& get() const {
+        return getValue();
+    }
 
     virtual void hash(eckit::Hash&) const;
 
@@ -144,7 +147,10 @@ protected:  // methods
 
     operator Value() const;
 
+    const Value& getValue() const;
+
 protected:  // members
+    friend class LocalConfiguration;
     std::unique_ptr<Value> root_;
     char separator_;
 

--- a/src/eckit/config/LocalConfiguration.cc
+++ b/src/eckit/config/LocalConfiguration.cc
@@ -185,17 +185,31 @@ LocalConfiguration& LocalConfiguration::set(const std::string& s, const std::vec
 }
 
 
-LocalConfiguration& LocalConfiguration::set(const std::string& s, const LocalConfiguration& value) {
-    setValue(s, *value.root_);
+LocalConfiguration& LocalConfiguration::set(const std::string& s, const Configuration& value) {
+    setValue(s, value.getValue());
     return *this;
 }
 
-LocalConfiguration& LocalConfiguration::set(const std::string& s, const std::vector<LocalConfiguration>& value) {
+LocalConfiguration& LocalConfiguration::set(const std::string& s, const Configuration* value[], size_t size) {
     ValueList values;
-    for (std::vector<LocalConfiguration>::const_iterator v = value.begin(); v != value.end(); ++v) {
-        values.push_back(*v->root_);
+    for (size_t i=0; i<size; ++i) {
+        values.push_back(value[i]->getValue());
     }
     setValue(s, values);
+    return *this;
+}
+
+LocalConfiguration& LocalConfiguration::set(const Configuration& other) {
+    eckit::Value& root             = *root_;
+    eckit::Value const& other_root = *other.root_;
+    for (auto& key : other.keys()) {
+        root[key] = other_root[key];
+    }
+    return *this;
+}
+
+LocalConfiguration& LocalConfiguration::remove(const std::string& name) {
+    root_->remove(name);
     return *this;
 }
 

--- a/src/eckit/option/CmdArgs.cc
+++ b/src/eckit/option/CmdArgs.cc
@@ -44,17 +44,6 @@ CmdArgs::CmdArgs(std::function<void(const std::string&)> usage, std::vector<Opti
     init(usage, args_count, minimum_args, throw_on_error);
 }
 
-namespace {
-
-std::vector<std::string> split_at(const std::string& s, char separator) {
-    if (auto found = s.find_first_of(separator); found != std::string::npos) {
-        return {s.substr(0, found), s.substr(found + 1)};
-    }
-    return {s};
-}
-
-}  // namespace
-
 void CmdArgs::init(std::function<void(const std::string&)> usage, int args_count, int minimum_args,
                    bool throw_on_error) {
     const Main& ctx = Main::instance();

--- a/tests/option/eckit_test_option_cmdargs.cc
+++ b/tests/option/eckit_test_option_cmdargs.cc
@@ -1011,6 +1011,11 @@ CASE("test_eckit_option_cmdargs_value_with_equals") {
 #endif
 
 #if TESTCASE == 38
+// disable deprecated declarations warning here as we are testing it
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+#endif
 CASE("test_eckit_option__allows_to_set_default_value_for_options") {
     options_t options;
     {
@@ -1057,6 +1062,9 @@ CASE("test_eckit_option__allows_to_set_default_value_for_options") {
         EXPECT_EQUAL(v[3], 4L);
     }
 }
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
 #endif
 
 #if TESTCASE == 39


### PR DESCRIPTION
`const eckit::Value& eckit::Configuration::get()` is "public" and likely abused in various places, leaking the `eckit::Value` abstraction.

This pull request marks this function as deprecated, and warns for it to be removed in a next release.

Further changes to `LocalConfiguration` have been made so that classes like e.g. `eckit::codec::MetaData` or `atlas::Config` which derive from `LocalConfiguration` don't need internal access to `eckit::Value`.

I have modified the `atlas::Config` class respectively and can commit that once this PR is merged.

This relates to PR #101 as without access to `eckit::Value` one will no longer be able to use `eckit::Value` for introspection.