### PR TITLE
Compiler warnings re sprintf

### DIFF
--- a/src/eckit/cmd/UserInput.cc
+++ b/src/eckit/cmd/UserInput.cc
@@ -124,8 +124,9 @@ typedef struct context {
 static bool processCode(int c, context* s);
 
 static void output(const context* s) {
-    char* buffer = (char*)malloc(strlen(s->prompt) + strlen(s->curr->edit) + 20);
-    sprintf(buffer, "\r%s%s\033[0K\r\033[%luC", s->prompt, s->curr->edit, strlen(s->prompt) + s->pos);
+    const size_t numBytes = strlen(s->prompt) + strlen(s->curr->edit) + 20;
+    char* buffer = (char*)malloc(numBytes);
+    snprintf(buffer, numBytes,"\r%s%s\033[0K\r\033[%luC", s->prompt, s->curr->edit, strlen(s->prompt) + s->pos);
     write(1, buffer, strlen(buffer));
     free(buffer);
 }

--- a/src/eckit/config/ResourceMgr.cc
+++ b/src/eckit/config/ResourceMgr.cc
@@ -199,8 +199,8 @@ int ResourceQualifier::operator<(const ResourceQualifier& other) const {
     char buf1[1024];
     char buf2[1024];
 
-    sprintf(buf1, "%s.%s.%s", owner_.c_str(), kind_.c_str(), name_.c_str());
-    sprintf(buf2, "%s.%s.%s", other.owner_.c_str(), other.kind_.c_str(), other.name_.c_str());
+    snprintf(buf1, sizeof(buf1), "%s.%s.%s", owner_.c_str(), kind_.c_str(), name_.c_str());
+    snprintf(buf2, sizeof(buf2), "%s.%s.%s", other.owner_.c_str(), other.kind_.c_str(), other.name_.c_str());
 
     return strcmp(buf1, buf2) < 0;
 }

--- a/src/eckit/filesystem/TmpFile.cc
+++ b/src/eckit/filesystem/TmpFile.cc
@@ -26,7 +26,7 @@ static PathName tmp() {
     long max   = pathconf(tmpdir, _PC_PATH_MAX);
     char* path = new char[max];
 
-    sprintf(path, "%s/eckitXXXXXXXXXXX", tmpdir);
+    snprintf(path, max, "%s/eckitXXXXXXXXXXX", tmpdir);
     int fd;
     SYSCALL2(fd = ::mkstemp(path), path);
 


### PR DESCRIPTION
warning: 'sprintf' is deprecated: This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead. [-Wdeprecated-declarations]

