### PR TITLE
Fix warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -180,9 +180,10 @@ else()
                         REQUIRED_PACKAGES "LAPACK QUIET" )
 endif()
 
-### OpenSSL (for SHA1)
+### OpenSSL (for SHA1 and MD4)
 
 ecbuild_add_option( FEATURE SSL
+                    DEFAULT OFF # We only use deprecated functionality from OpenSSL
                     DESCRIPTION "OpenSSL support"
                     REQUIRED_PACKAGES OpenSSL )
 

--- a/src/eckit/cmd/CmdParser.cc
+++ b/src/eckit/cmd/CmdParser.cc
@@ -64,8 +64,6 @@ static History history_;
 // For Lex
 static bool eckit_cmd_debug_;
 
-static long pos_ = 0;
-
 //----------------------------------------------------------------------------------------------------------------------
 
 namespace CmdYacc {
@@ -94,7 +92,6 @@ void eckit_cmd_error(const char* msg) {
 
 void CmdParser::parse(const std::string& line, std::ostream& out) {
     command_ = line;
-    pos_     = 0;
     out_     = &out;
 
     if (command_.size() > 0) {
@@ -153,7 +150,6 @@ void CmdParser::parse(std::istream& in, std::ostream& out, const Prompter& promp
         }
 
         command_ = p;
-        pos_     = 0;
 
         if (command_.size() > 0) {
             // Prepare for parse

--- a/src/eckit/cmd/UserInput.cc
+++ b/src/eckit/cmd/UserInput.cc
@@ -286,10 +286,7 @@ static bool processCode(int c, context* s) {
             if (strlen(s->curr->edit)) {
                 return processCode(BACKSPACE, s);
             }
-            else {
-                return processCode(0, s);
-            }
-            break;
+            return processCode(0, s);
 
         case BACKSPACE:
         case CONTROL_H:
@@ -421,14 +418,12 @@ static bool processCode(int c, context* s) {
         case CR:
             write(1, "\r\n", 2);
             return true;
-            break;
 
         case CONTROL_C:
             write(1, "\r\n", 2);
             s->pos = 0;
             return processCode(0,
                                s);  // CONTROL_C behaves as CONTROL_D -- for backward compatibility to previous marsadm
-            break;
 
         case CONTROL_G:
             break;

--- a/src/eckit/exception/Exceptions.h
+++ b/src/eckit/exception/Exceptions.h
@@ -186,7 +186,7 @@ public:
 };
 
 /// For compatibility
-using MethodNotYetImplemented = NotImplemented;
+using MethodNotYetImplemented [[deprecated("Use eckit::NotImplemented directly")]] = NotImplemented;
 
 class FunctionalityNotSupported : public NotImplemented {
 public:

--- a/src/eckit/filesystem/StdDir.cc
+++ b/src/eckit/filesystem/StdDir.cc
@@ -46,6 +46,14 @@ struct dirent* StdDir::dirent() {
     ///       however readdir() isn't thread-safe yet, not even in glic implementation
     ///       until then we prefer to use readdir_r
 #if eckit_HAVE_READDIR_R
+// Disable deprecation warning of using readdir_r
+#if defined(__INTEL_COMPILER)
+#pragma warning ( disable:1478 )
+#elif defined(__NVCOMPILER)
+#pragma diag_suppress 1216
+#elif defined(__GNUC__)
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
     ::readdir_r(d_, &buf, &e);
 #else
     e = ::readdir(d_);

--- a/src/eckit/io/EasyCURL.cc
+++ b/src/eckit/io/EasyCURL.cc
@@ -8,6 +8,11 @@
  * does it submit to any jurisdiction.
  */
 
+// Disable warnings: warning #550-D: variable "__d0" was set but never used [set_but_not_used] in FD_ZERO(&r);
+#if defined(__NVCOMPILER)
+#pragma diag_suppress 550
+#endif
+
 #include "eckit/io/EasyCURL.h"
 
 #include <unistd.h>

--- a/src/eckit/io/Select.cc
+++ b/src/eckit/io/Select.cc
@@ -8,6 +8,10 @@
  * does it submit to any jurisdiction.
  */
 
+// Disable warnings: warning #550-D: variable "__d0" was set but never used [set_but_not_used] in FD_ZERO(&r);
+#if defined(__NVCOMPILER)
+#pragma diag_suppress 550
+#endif
 
 #include <sys/ioctl.h>
 #include <unistd.h>

--- a/src/eckit/io/SharedHandle.h
+++ b/src/eckit/io/SharedHandle.h
@@ -66,6 +66,7 @@ public:
 
     DataHandle* clone() const override;
 
+    using DataHandle::saveInto;
     Length saveInto(DataHandle& other, TransferWatcher& watcher) override;
 
     std::string name() const override;

--- a/src/eckit/io/StatsHandle.h
+++ b/src/eckit/io/StatsHandle.h
@@ -67,6 +67,7 @@ public:
 
     DataHandle* clone() const override;
 
+    using DataHandle::saveInto;
     Length saveInto(DataHandle& other, TransferWatcher& watcher) override;
 
     std::string name() const override;

--- a/src/eckit/io/StdioBuf.h
+++ b/src/eckit/io/StdioBuf.h
@@ -14,7 +14,7 @@
 #ifndef eckit_StdioBuf_h
 #define eckit_StdioBuf_h
 
-#include <strstream>
+#include <cstdio>
 
 #include "eckit/eckit.h"
 

--- a/src/eckit/io/cluster/ClusterNodes.cc
+++ b/src/eckit/io/cluster/ClusterNodes.cc
@@ -171,7 +171,7 @@ public:
     const char* host() const { return host_; }
 
     void attributes(const std::set<std::string>& attrs) {
-        ASSERT(attrs.size() >= 0 && attrs.size() <= MAX_NODE_ATTRIBUTES);
+        ASSERT(attrs.size() <= MAX_NODE_ATTRIBUTES);
         zero(attributes_);
         nattrs_ = 0;
         for (const auto& a : attrs) {

--- a/src/eckit/linalg/CMakeLists.txt
+++ b/src/eckit/linalg/CMakeLists.txt
@@ -49,7 +49,6 @@ if( eckit_HAVE_EIGEN )
           dense/LinearAlgebraEigen.h
           sparse/LinearAlgebraEigen.cc
           sparse/LinearAlgebraEigen.h )
-    list( APPEND eckit_la_pincludes "${EIGEN3_INCLUDE_DIRS}" )
 endif()
 
 if( eckit_HAVE_LAPACK )
@@ -89,6 +88,11 @@ ecbuild_add_library( TARGET             eckit_linalg TYPE SHARED
                      PRIVATE_INCLUDES   ${eckit_la_pincludes}
                      PUBLIC_LIBS        eckit
                      PRIVATE_LIBS       ${eckit_la_plibs} )
+
+if( eckit_HAVE_EIGEN )
+    # Add include directories with "SYSTEM" to avoid warnings from within Eigen headers
+    target_include_directories( eckit_linalg SYSTEM PRIVATE ${EIGEN3_INCLUDE_DIRS} )
+endif()
 
 if( CUDA_FOUND )
   set( CUDA_LINK_LIBRARIES_KEYWORD PRIVATE )

--- a/src/eckit/linalg/dense/LinearAlgebraMKL.cc
+++ b/src/eckit/linalg/dense/LinearAlgebraMKL.cc
@@ -42,7 +42,7 @@ void LinearAlgebraMKL::print(std::ostream& out) const {
 Scalar LinearAlgebraMKL::dot(const Vector& x, const Vector& y) const {
     ASSERT(x.size() == y.size());
 
-    const auto n   = static_cast<const MKL_INT>(x.size());
+    const auto n   = static_cast<MKL_INT>(x.size());
     const auto* _x = static_cast<const double*>(x.data());
     const auto* _y = static_cast<const double*>(y.data());
 
@@ -57,8 +57,8 @@ void LinearAlgebraMKL::gemv(const Matrix& A, const Vector& x, Vector& y) const {
     ASSERT(x.size() == A.cols());
     ASSERT(y.size() == A.rows());
 
-    const auto m = static_cast<const MKL_INT>(A.rows());
-    const auto n = static_cast<const MKL_INT>(A.cols());
+    const auto m = static_cast<MKL_INT>(A.rows());
+    const auto n = static_cast<MKL_INT>(A.cols());
 
     const auto* _A = static_cast<const double*>(A.data());
     const auto* _x = static_cast<const double*>(x.data());
@@ -79,9 +79,9 @@ void LinearAlgebraMKL::gemm(const Matrix& A, const Matrix& B, Matrix& C) const {
     ASSERT(A.rows() == C.rows());
     ASSERT(B.cols() == C.cols());
 
-    const auto m = static_cast<const MKL_INT>(A.rows());
-    const auto n = static_cast<const MKL_INT>(B.cols());
-    const auto k = static_cast<const MKL_INT>(A.cols());
+    const auto m = static_cast<MKL_INT>(A.rows());
+    const auto n = static_cast<MKL_INT>(B.cols());
+    const auto k = static_cast<MKL_INT>(A.cols());
 
     const auto* _A = static_cast<const double*>(A.data());
     const auto* _B = static_cast<const double*>(B.data());

--- a/src/eckit/linalg/sparse/LinearAlgebraMKL.cc
+++ b/src/eckit/linalg/sparse/LinearAlgebraMKL.cc
@@ -71,9 +71,9 @@ void LinearAlgebraMKL::spmm(const SparseMatrix& A, const Matrix& B, Matrix& C) c
     // We expect indices to be 0-based
     ASSERT(A.outer()[0] == 0);
 
-    const auto m = static_cast<const MKL_INT>(A.rows());
-    const auto n = static_cast<const MKL_INT>(C.cols());
-    const auto k = static_cast<const MKL_INT>(A.cols());
+    const auto m = static_cast<MKL_INT>(A.rows());
+    const auto n = static_cast<MKL_INT>(C.cols());
+    const auto k = static_cast<MKL_INT>(A.cols());
 
     // FIXME: with 0-based indexing, MKL assumes row-major ordering for B and C
     // We need to use 1-based indexing i.e. offset outer and inner indices by 1

--- a/src/eckit/maths/CMakeLists.txt
+++ b/src/eckit/maths/CMakeLists.txt
@@ -19,6 +19,9 @@ ecbuild_add_library(
     HEADER_DESTINATION  ${INSTALL_INCLUDE_DIR}/eckit/maths
     SOURCES             ${eckit_maths_sources}
     PRIVATE_LIBS        ${eckit_maths_private_libs}
-    PUBLIC_INCLUDES     "${EIGEN3_INCLUDE_DIRS}"
     PUBLIC_LIBS         eckit)
 
+if( HAVE_EIGEN )
+    # Add include directories with "SYSTEM" to avoid warnings from within Eigen headers
+    target_include_directories(eckit_maths SYSTEM PUBLIC ${EIGEN3_INCLUDE_DIRS})
+endif()

--- a/src/eckit/mpi/Group.cc
+++ b/src/eckit/mpi/Group.cc
@@ -32,7 +32,7 @@ public:
 
     virtual NullGroupContent* union_group(const GroupContent&) const { return new NullGroupContent(); }
 
-    virtual size_t size() const { return -1; }
+    virtual size_t size() const { return 0; }
 
     virtual int rank() const { return -1; }
 

--- a/src/eckit/net/TCPSocket.cc
+++ b/src/eckit/net/TCPSocket.cc
@@ -8,6 +8,11 @@
  * does it submit to any jurisdiction.
  */
 
+// Disable warnings: warning #550-D: variable "__d0" was set but never used [set_but_not_used] in FD_ZERO(&r);
+#if defined(__NVCOMPILER)
+#pragma diag_suppress 550
+#endif
+
 #include <sys/types.h>  // FreeBSD: must appear before netinet/ip.h
 
 #include <arpa/inet.h>

--- a/src/eckit/parser/YAMLParser.cc
+++ b/src/eckit/parser/YAMLParser.cc
@@ -462,6 +462,7 @@ static Value toValue(std::string& s) {
                     s.erase(remove(s.begin(), s.end(), '_'), s.end());
                     return Value(strtol(s.substr(2).c_str(), 0, 16));
                 }
+                [[fallthrough]];
 
             case '1':
             case '2':
@@ -478,6 +479,7 @@ static Value toValue(std::string& s) {
                     long long d = Translator<std::string, long long>()(s);
                     return Value(d);
                 }
+                [[fallthrough]];
 
             case '.':
 

--- a/src/eckit/sql/CMakeLists.txt
+++ b/src/eckit/sql/CMakeLists.txt
@@ -178,6 +178,6 @@ ecbuild_add_library( TARGET              eckit_sql TYPE SHARED
                                          expression/ShiftedColumnExpression.cc
                      PUBLIC_LIBS         eckit )
 
-# Disable all warnings for PGI compiler as it is overzealous and cherry-picking is not possible
-target_compile_options( eckit_sql PRIVATE $<$<CXX_COMPILER_ID:PGI>:-w> )
+# Disable all warnings for PGI/NVHPC compiler as it is overzealous and cherry-picking is not possible
+target_compile_options( eckit_sql PRIVATE $<$<CXX_COMPILER_ID:PGI>:-w> $<$<CXX_COMPILER_ID:NVHPC>:-w> )
 

--- a/src/eckit/sql/expression/BitColumnExpression.h
+++ b/src/eckit/sql/expression/BitColumnExpression.h
@@ -45,6 +45,7 @@ protected:
     // -- Overridden methods
     void prepare(SQLSelect& sql) override;
     void updateType(SQLSelect& sql) override;
+    using ColumnExpression::eval;
     double eval(bool& missing) const override;
     virtual void expandStars(const std::vector<std::reference_wrapper<const SQLTable>>&,
                              expression::Expressions&) override;

--- a/src/eckit/sql/expression/ConstantExpression.h
+++ b/src/eckit/sql/expression/ConstantExpression.h
@@ -43,6 +43,7 @@ public:
     void cleanup(SQLSelect&) override { NOTIMP; }
 
     // -- For WHERE
+    using SQLExpression::eval;
     double eval(bool& missing) const override {
         missing = missing_;
         return value_;

--- a/src/eckit/sql/expression/NumberExpression.cc
+++ b/src/eckit/sql/expression/NumberExpression.cc
@@ -17,9 +17,11 @@ namespace eckit::sql::expression {
 //----------------------------------------------------------------------------------------------------------------------
 
 NumberExpression::NumberExpression(double value) :
+    SQLExpression(),
     value_(value) {}
 
 NumberExpression::NumberExpression(const NumberExpression& other) :
+    SQLExpression(),
     value_(other.value_) {}
 
 std::shared_ptr<SQLExpression> NumberExpression::clone() const {

--- a/src/eckit/sql/expression/NumberExpression.h
+++ b/src/eckit/sql/expression/NumberExpression.h
@@ -44,6 +44,7 @@ private:
     void cleanup(SQLSelect& sql) override;
 
     const type::SQLType* type() const override;
+    using SQLExpression::eval;
     double eval(bool& missing) const override;
     bool isConstant() const override { return true; }
     bool isNumber() const override { return true; }

--- a/src/eckit/sql/expression/ParameterExpression.cc
+++ b/src/eckit/sql/expression/ParameterExpression.cc
@@ -18,12 +18,14 @@ namespace eckit::sql::expression {
 //----------------------------------------------------------------------------------------------------------------------
 
 ParameterExpression::ParameterExpression(int which) :
+    SQLExpression(),
     value_(0), which_(which) {
     // don't use any Log::* here
     //	std::cout << "new ParameterExpression " << name << std::endl;
 }
 
 ParameterExpression::ParameterExpression(const ParameterExpression& other) :
+    SQLExpression(),
     value_(other.value_), which_(other.which_) {}
 
 

--- a/src/eckit/sql/expression/ParameterExpression.h
+++ b/src/eckit/sql/expression/ParameterExpression.h
@@ -43,6 +43,7 @@ private:
     void prepare(SQLSelect& sql) override;
     void cleanup(SQLSelect& sql) override;
 
+    using SQLExpression::eval;
     double eval(bool& missing) const override;
     const type::SQLType* type() const override;
     bool isConstant() const override;

--- a/src/eckit/sql/expression/ShiftedColumnExpression.h
+++ b/src/eckit/sql/expression/ShiftedColumnExpression.h
@@ -65,6 +65,7 @@ protected:
     // -- Overridden methods
     void print(std::ostream& s) const override;
     void cleanup(SQLSelect& sql) override;
+    using T::eval;
     double eval(bool& missing) const override;
     void output(SQLOutput& s) const override;
 

--- a/src/eckit/sql/expression/function/DoubleFunctions.cc
+++ b/src/eckit/sql/expression/function/DoubleFunctions.cc
@@ -32,6 +32,7 @@ public:
 template <double (*FN)(double)>
 class UnaryFunction : public ArityFunction<UnaryFunction<FN>, 1> {
 
+    using FunctionExpression::eval;
     double eval(bool& m) const {
 
         double a0 = this->args_[0]->eval(m);
@@ -49,6 +50,7 @@ public:
 template <double (*FN)(double, double)>
 class BinaryFunction : public ArityFunction<BinaryFunction<FN>, 2> {
 
+    using FunctionExpression::eval;
     double eval(bool& m) const {
 
         double a0 = this->args_[0]->eval(m);
@@ -70,6 +72,7 @@ public:
 template <double (*FN)(double, double, double)>
 class TertiaryFunction : public ArityFunction<TertiaryFunction<FN>, 3> {
 
+    using FunctionExpression::eval;
     double eval(bool& m) const {
 
         double a0 = this->args_[0]->eval(m);
@@ -95,6 +98,7 @@ public:
 template <double (*FN)(double, double, double, double)>
 class QuaternaryFunction : public ArityFunction<QuaternaryFunction<FN>, 4> {
 
+    using FunctionExpression::eval;
     double eval(bool& m) const {
 
         double a0 = this->args_[0]->eval(m);
@@ -124,6 +128,7 @@ public:
 template <double (*FN)(double, double, double, double, double)>
 class QuinaryFunction : public ArityFunction<QuinaryFunction<FN>, 5> {
 
+    using FunctionExpression::eval;
     double eval(bool& m) const {
 
         double a0 = this->args_[0]->eval(m);
@@ -364,6 +369,7 @@ double ldexp_double(double l, double r) {
 
 class MultiplyFunction : public ArityFunction<MultiplyFunction, 2> {
 
+    using FunctionExpression::eval;
     double eval(bool& m) const {
 
         bool m0   = false;

--- a/src/eckit/sql/expression/function/FunctionAND.h
+++ b/src/eckit/sql/expression/function/FunctionAND.h
@@ -38,6 +38,7 @@ private:
     FunctionAND& operator=(const FunctionAND&);
 
     const eckit::sql::type::SQLType* type() const override;
+    using FunctionExpression::eval;
     double eval(bool& missing) const override;
     std::shared_ptr<SQLExpression> simplify(bool&) override;
     bool andSplit(expression::Expressions&) override;

--- a/src/eckit/sql/expression/function/FunctionAVG.h
+++ b/src/eckit/sql/expression/function/FunctionAVG.h
@@ -42,6 +42,7 @@ private:
     void prepare(SQLSelect&) override;
     void cleanup(SQLSelect&) override;
     void partialResult() override;
+    using FunctionExpression::eval;
     double eval(bool& missing) const override;
 
     bool isAggregate() const override { return true; }

--- a/src/eckit/sql/expression/function/FunctionCOUNT.h
+++ b/src/eckit/sql/expression/function/FunctionCOUNT.h
@@ -40,6 +40,7 @@ private:
     void prepare(SQLSelect&) override;
     void cleanup(SQLSelect&) override;
     void partialResult() override;
+    using FunctionExpression::eval;
     double eval(bool& missing) const override;
 
     bool isAggregate() const override { return true; }

--- a/src/eckit/sql/expression/function/FunctionDOTP.h
+++ b/src/eckit/sql/expression/function/FunctionDOTP.h
@@ -39,6 +39,7 @@ private:
     void prepare(SQLSelect&) override;
     void cleanup(SQLSelect&) override;
     void partialResult() override;
+    using FunctionExpression::eval;
     double eval(bool& missing) const override;
 
     bool isAggregate() const override { return true; }

--- a/src/eckit/sql/expression/function/FunctionEQ.h
+++ b/src/eckit/sql/expression/function/FunctionEQ.h
@@ -39,6 +39,7 @@ private:
 
     // -- Overridden methods
     const eckit::sql::type::SQLType* type() const override;
+    using FunctionExpression::eval;
     double eval(bool& missing) const override;
     std::shared_ptr<SQLExpression> simplify(bool&) override;
 

--- a/src/eckit/sql/expression/function/FunctionFIRST.h
+++ b/src/eckit/sql/expression/function/FunctionFIRST.h
@@ -40,6 +40,7 @@ private:
     void prepare(SQLSelect&) override;
     void cleanup(SQLSelect&) override;
     void partialResult() override;
+    using FunctionExpression::eval;
     double eval(bool& missing) const override;
     bool isAggregate() const override { return true; }
 

--- a/src/eckit/sql/expression/function/FunctionIN.h
+++ b/src/eckit/sql/expression/function/FunctionIN.h
@@ -35,6 +35,7 @@ private:
     size_t size_;
 
     const eckit::sql::type::SQLType* type() const override;
+    using FunctionExpression::eval;
     double eval(bool& missing) const override;
 
     // -- Friends

--- a/src/eckit/sql/expression/function/FunctionIntegerExpression.cc
+++ b/src/eckit/sql/expression/function/FunctionIntegerExpression.cc
@@ -52,6 +52,7 @@ public:  // methods
     }
 
 private:  // methods
+    using FunctionIntegerExpression::eval;
     double eval(bool& m) const {
         bool missing = false;
         double v     = args_[0]->eval(missing);

--- a/src/eckit/sql/expression/function/FunctionJOIN.h
+++ b/src/eckit/sql/expression/function/FunctionJOIN.h
@@ -34,6 +34,7 @@ private:
 
     // -- Overridden methods
     const eckit::sql::type::SQLType* type() const override;
+    using FunctionExpression::eval;
     double eval(bool& missing) const override;
 
     // -- Friends

--- a/src/eckit/sql/expression/function/FunctionJULIAN.h
+++ b/src/eckit/sql/expression/function/FunctionJULIAN.h
@@ -34,6 +34,7 @@ private:
 
     // -- Overridden methods
     const eckit::sql::type::SQLType* type() const override;
+    using FunctionExpression::eval;
     double eval(bool& missing) const override;
 
     // -- Friends

--- a/src/eckit/sql/expression/function/FunctionJULIAN_SECONDS.h
+++ b/src/eckit/sql/expression/function/FunctionJULIAN_SECONDS.h
@@ -35,6 +35,7 @@ private:
 
     // -- Overridden methods
     const eckit::sql::type::SQLType* type() const override;
+    using FunctionExpression::eval;
     double eval(bool& missing) const override;
 
     // -- Friends

--- a/src/eckit/sql/expression/function/FunctionLAST.h
+++ b/src/eckit/sql/expression/function/FunctionLAST.h
@@ -40,6 +40,7 @@ private:
     void prepare(SQLSelect&) override;
     void cleanup(SQLSelect&) override;
     void partialResult() override;
+    using FunctionExpression::eval;
     double eval(bool& missing) const override;
     bool isAggregate() const override { return true; }
 

--- a/src/eckit/sql/expression/function/FunctionMAX.h
+++ b/src/eckit/sql/expression/function/FunctionMAX.h
@@ -39,6 +39,7 @@ private:
     void prepare(SQLSelect&) override;
     void cleanup(SQLSelect&) override;
     void partialResult() override;
+    using FunctionExpression::eval;
     double eval(bool& missing) const override;
     bool isAggregate() const override { return true; }
 

--- a/src/eckit/sql/expression/function/FunctionMIN.h
+++ b/src/eckit/sql/expression/function/FunctionMIN.h
@@ -39,6 +39,7 @@ private:
     void prepare(SQLSelect&) override;
     void cleanup(SQLSelect&) override;
     void partialResult() override;
+    using FunctionExpression::eval;
     double eval(bool& missing) const override;
     bool isAggregate() const override { return true; }
 

--- a/src/eckit/sql/expression/function/FunctionNE.h
+++ b/src/eckit/sql/expression/function/FunctionNE.h
@@ -38,6 +38,7 @@ private:
 
     // -- Overridden methods
     const eckit::sql::type::SQLType* type() const override;
+    using FunctionExpression::eval;
     double eval(bool& missing) const override;
 
     // -- Friends

--- a/src/eckit/sql/expression/function/FunctionNORM.h
+++ b/src/eckit/sql/expression/function/FunctionNORM.h
@@ -39,6 +39,7 @@ private:
     void prepare(SQLSelect&) override;
     void cleanup(SQLSelect&) override;
     void partialResult() override;
+    using FunctionExpression::eval;
     double eval(bool& missing) const override;
 
     bool isAggregate() const override { return true; }

--- a/src/eckit/sql/expression/function/FunctionNOT_IN.h
+++ b/src/eckit/sql/expression/function/FunctionNOT_IN.h
@@ -36,6 +36,7 @@ private:
 
     // -- Overridden methods
     const eckit::sql::type::SQLType* type() const override;
+    using FunctionExpression::eval;
     double eval(bool& missing) const override;
 
     // -- Friends

--- a/src/eckit/sql/expression/function/FunctionNOT_NULL.h
+++ b/src/eckit/sql/expression/function/FunctionNOT_NULL.h
@@ -34,6 +34,7 @@ private:
     FunctionNOT_NULL& operator=(const FunctionNOT_NULL&);
 
     // -- Overridden methods
+    using FunctionExpression::eval;
     double eval(bool& missing) const override;
 
     // -- Friends

--- a/src/eckit/sql/expression/function/FunctionNULL.h
+++ b/src/eckit/sql/expression/function/FunctionNULL.h
@@ -34,6 +34,7 @@ private:
     FunctionNULL& operator=(const FunctionNULL&);
 
     // -- Overridden methods
+    using FunctionExpression::eval;
     double eval(bool& missing) const override;
     // -- Friends
     // friend std::ostream& operator<<(std::ostream& s,const FunctionNULL& p)

--- a/src/eckit/sql/expression/function/FunctionNVL.h
+++ b/src/eckit/sql/expression/function/FunctionNVL.h
@@ -34,6 +34,7 @@ private:
 
     // -- Overridden methods
     const eckit::sql::type::SQLType* type() const override;
+    using FunctionExpression::eval;
     double eval(bool& missing) const override;
 
     // -- Friends

--- a/src/eckit/sql/expression/function/FunctionOR.h
+++ b/src/eckit/sql/expression/function/FunctionOR.h
@@ -27,6 +27,7 @@ public:
     // -- Overridden methods
     std::shared_ptr<SQLExpression> clone() const override;
 
+    using FunctionExpression::eval;
     double eval(bool& missing) const override;
     const eckit::sql::type::SQLType* type() const override;
     std::shared_ptr<SQLExpression> simplify(bool&) override;

--- a/src/eckit/sql/expression/function/FunctionRLIKE.h
+++ b/src/eckit/sql/expression/function/FunctionRLIKE.h
@@ -43,6 +43,7 @@ private:
 
     // -- Overridden methods
     const eckit::sql::type::SQLType* type() const override;
+    using FunctionExpression::eval;
     double eval(bool& missing) const override;
 
     // -- Friends

--- a/src/eckit/sql/expression/function/FunctionRMS.h
+++ b/src/eckit/sql/expression/function/FunctionRMS.h
@@ -25,6 +25,7 @@ public:
     ~FunctionRMS();
 
     // -- Overridden methods
+    using FunctionExpression::eval;
     double eval(bool& missing) const override;
 
     std::shared_ptr<SQLExpression> clone() const override;

--- a/src/eckit/sql/expression/function/FunctionROWNUMBER.h
+++ b/src/eckit/sql/expression/function/FunctionROWNUMBER.h
@@ -38,6 +38,7 @@ protected:
     void cleanup(SQLSelect&) override;
     bool isConstant() const override;
     void partialResult() override;
+    using FunctionIntegerExpression::eval;
     double eval(bool& missing) const override;
     std::shared_ptr<SQLExpression> simplify(bool&) override;
     bool isAggregate() const override { return false; }

--- a/src/eckit/sql/expression/function/FunctionSTDEV.h
+++ b/src/eckit/sql/expression/function/FunctionSTDEV.h
@@ -30,6 +30,7 @@ private:
     // No copy allowed
     FunctionSTDEV& operator=(const FunctionSTDEV&);
 
+    using FunctionVAR::eval;
     double eval(bool& missing) const override;
     const eckit::sql::type::SQLType* type() const override;
 

--- a/src/eckit/sql/expression/function/FunctionSUM.h
+++ b/src/eckit/sql/expression/function/FunctionSUM.h
@@ -40,6 +40,7 @@ private:
     void prepare(SQLSelect&) override;
     void cleanup(SQLSelect&) override;
     void partialResult() override;
+    using FunctionExpression::eval;
     double eval(bool& missing) const override;
     bool isAggregate() const override { return true; }
     bool resultNULL_;

--- a/src/eckit/sql/expression/function/FunctionTDIFF.h
+++ b/src/eckit/sql/expression/function/FunctionTDIFF.h
@@ -37,6 +37,7 @@ private:
 
     // -- Overridden methods
     const eckit::sql::type::SQLType* type() const override;
+    using FunctionIntegerExpression::eval;
     double eval(bool& missing) const override;
 
     // -- Friends

--- a/src/eckit/sql/expression/function/FunctionTHIN.h
+++ b/src/eckit/sql/expression/function/FunctionTHIN.h
@@ -37,6 +37,7 @@ protected:
     void prepare(SQLSelect&) override;
     void cleanup(SQLSelect&) override;
     bool isConstant() const override;
+    using FunctionIntegerExpression::eval;
     double eval(bool& missing) const override;
     std::shared_ptr<SQLExpression> simplify(bool&) override;
     bool isAggregate() const override { return false; }

--- a/src/eckit/sql/expression/function/FunctionTIMESTAMP.h
+++ b/src/eckit/sql/expression/function/FunctionTIMESTAMP.h
@@ -35,6 +35,7 @@ private:
     FunctionTIMESTAMP& operator=(const FunctionTIMESTAMP&);
 
     // -- Overridden methods
+    using FunctionIntegerExpression::eval;
     double eval(bool& missing) const override;
 
     // -- Friends

--- a/src/eckit/sql/expression/function/FunctionVAR.h
+++ b/src/eckit/sql/expression/function/FunctionVAR.h
@@ -38,6 +38,7 @@ public:
 
 protected:
     // -- Overridden methods
+    using FunctionExpression::eval;
     double eval(bool& missing) const override;
 
 private:

--- a/src/eckit/sql/type/SQLBit.h
+++ b/src/eckit/sql/type/SQLBit.h
@@ -38,6 +38,7 @@ private:
     // None
 
     size_t size() const override;
+    using SQLType::output;
     void output(SQLOutput&, double, bool) const override;
     int getKind() const override { return integerType; }
     std::string asString(const double* val) const override;

--- a/src/eckit/sql/type/SQLBitfield.h
+++ b/src/eckit/sql/type/SQLBitfield.h
@@ -44,6 +44,7 @@ private:
     std::map<std::string, unsigned long> shift_;
 
     size_t size() const override;
+    using SQLType::output;
     void output(SQLOutput& s, double, bool) const override;
     std::string asString(const double* val) const override;
     const SQLType* subType(const std::string&) const override;

--- a/src/eckit/sql/type/SQLDouble.h
+++ b/src/eckit/sql/type/SQLDouble.h
@@ -28,6 +28,7 @@ public:
     ~SQLDouble();
 
     // -- Overridden methods
+    using SQLType::output;
     void output(SQLOutput&, double, bool) const override;
 
 private:

--- a/src/eckit/sql/type/SQLInt.h
+++ b/src/eckit/sql/type/SQLInt.h
@@ -33,6 +33,7 @@ private:
     SQLInt& operator=(const SQLInt&);
 
     size_t size() const override;
+    using SQLType::output;
     void output(SQLOutput& s, double, bool) const override;
     int getKind() const override { return integerType; }
     std::string asString(const double* val) const override;

--- a/src/eckit/sql/type/SQLReal.h
+++ b/src/eckit/sql/type/SQLReal.h
@@ -45,6 +45,7 @@ public:
     // None
 
     // -- Overridden methods
+    using SQLType::output;
     void output(SQLOutput&, double, bool) const override;
 
     // -- Class members

--- a/src/eckit/types/Fraction.cc
+++ b/src/eckit/types/Fraction.cc
@@ -103,7 +103,7 @@ Fraction::Fraction(double x) {
 
         x = 1.0 / (x - a);
 
-        if (x > std::numeric_limits<Fraction::value_type>::max()) {
+        if (x > static_cast<double>(std::numeric_limits<Fraction::value_type>::max())) {
             break;
         }
 

--- a/src/eckit/utils/MD4.h
+++ b/src/eckit/utils/MD4.h
@@ -16,7 +16,7 @@
 #if eckit_HAVE_SSL
 #include <openssl/md4.h>
 #else
-#error "eckit was not configured with OpenSSL, SHA1 is disabled. Use conditional eckit_HAVE_SSL from eckit/eckit.h"
+#error "eckit was not configured with OpenSSL, MD4 is disabled. Use conditional eckit_HAVE_SSL from eckit/eckit.h"
 #endif
 
 #ifndef MD4_DIGEST_LENGTH

--- a/src/eckit/utils/RLE.cc
+++ b/src/eckit/utils/RLE.cc
@@ -8,6 +8,8 @@
  * does it submit to any jurisdiction.
  */
 
+#include <cstddef>
+#include <iterator>
 #include <vector>
 
 #include "eckit/log/Log.h"
@@ -21,10 +23,16 @@ namespace eckit {
 // Version 2: warning all numbers must be signed but positive...
 
 template <class T>
-class dummy_iterator : public std::iterator<std::output_iterator_tag, T> {
+class dummy_iterator {
 public:
+    using iterator_category = std::output_iterator_tag;
+    using value_type        = T;
+    using difference_type   = std::ptrdiff_t;
+    using pointer           = value_type*;
+    using reference         = value_type&;
+
     dummy_iterator() {}
-    dummy_iterator<T>& operator=(const T& value) { return *this; }
+    dummy_iterator<T>& operator=(const value_type&) { return *this; }
     dummy_iterator<T>& operator*() { return *this; }
     dummy_iterator<T>& operator++() { return *this; }
     dummy_iterator<T>& operator++(int) { return *this; }

--- a/src/eckit/value/Params.h
+++ b/src/eckit/value/Params.h
@@ -124,8 +124,8 @@ private:  // internal classes
     typedef std::map<std::string, factory_t> factory_map;
     static factory_map& factories();
 
-    Params(Concept* concept) :
-        self_(concept) {}
+    Params(Concept* _concept) :
+        self_(_concept) {}
 
     struct Concept {
         virtual ~Concept() {}

--- a/src/eckit/web/HttpResource.cc
+++ b/src/eckit/web/HttpResource.cc
@@ -229,13 +229,10 @@ void HttpResource::dispatch(eckit::Stream&, std::istream&, HttpStream& out, Url&
 
                 std::ostringstream oss;
                 oss << "Unsupported HTTP method " << method << " url=" << url;
-                throw eckit::MethodNotYetImplemented(oss.str());
+                throw eckit::NotImplemented(oss.str());
             }
             catch (eckit::HttpError& e) {
                 error(url, out, e, e.status());
-            }
-            catch (eckit::MethodNotYetImplemented& e) {
-                error(url, out, e, HttpError::NOT_IMPLEMENTED);
             }
             catch (eckit::NotImplemented& e) {
                 error(url, out, e, HttpError::NOT_IMPLEMENTED);

--- a/src/eckit/web/HttpStream.cc
+++ b/src/eckit/web/HttpStream.cc
@@ -8,7 +8,9 @@
  * does it submit to any jurisdiction.
  */
 
+#include <cstddef>
 #include <cstring>
+#include <iterator>
 
 #include "eckit/exception/Exceptions.h"
 #include "eckit/io/DataHandle.h"
@@ -50,18 +52,23 @@ static int xindex = std::ios::xalloc();
 
 typedef std::vector<char> VC;
 
-class back_encoder_iterator : public std::iterator<std::output_iterator_tag, char> {
+class back_encoder_iterator {
     VC& container;
     void push(const char* p) {
-        while (*p) {
+        while (*p != static_cast<char>(0)) {
             container.push_back(*p++);
         }
     }
 
 public:
-    back_encoder_iterator(VC& v) :
-        container(v) {}
-    back_encoder_iterator& operator=(char);
+    using iterator_category = std::output_iterator_tag;
+    using value_type        = VC::value_type;
+    using difference_type   = std::ptrdiff_t;
+    using pointer           = value_type*;
+    using reference         = value_type&;
+
+    explicit back_encoder_iterator(VC& v) : container(v) {}
+    back_encoder_iterator& operator=(value_type);
     back_encoder_iterator& operator*() { return *this; }
     back_encoder_iterator& operator++() { return *this; }
     back_encoder_iterator& operator++(int) { return *this; }
@@ -153,15 +160,15 @@ void HttpBuf::write(std::ostream& out, Url& url) {
     //	out << "</HTML>";
 
 #if 0
-	Log::debug() << "Data: " << std::endl;
+    Log::debug() << "Data: " << std::endl;
 
-	for (std::vector<char>::iterator i = buffer_.begin(); i != buffer_.end(); ++i)
-		if (isprint(*i) || isspace(*i))
-			Log::debug() << *i;
-		else
-			break;
+    for (std::vector<char>::iterator i = buffer_.begin(); i != buffer_.end(); ++i)
+        if (isprint(*i) || isspace(*i))
+            Log::debug() << *i;
+        else
+            break;
 
-	Log::debug() << std::endl;
+    Log::debug() << std::endl;
 #endif
 }
 

--- a/tests/exception/test_exceptions.cc
+++ b/tests/exception/test_exceptions.cc
@@ -20,6 +20,10 @@ std::string evaluate_message(bool answer_is_correct) {
     if (answer_is_correct) {
         // this should never execute, and therefore the code below never reached
         throw NotImplemented(Here());
+// Suppress warning "statement is unreachable"
+#if defined(__NVCOMPILER)
+#pragma diag_suppress 111
+#endif
         return "NON REACHABLE CODE";
     }
 

--- a/tests/option/eckit_test_option_cmdargs.cc
+++ b/tests/option/eckit_test_option_cmdargs.cc
@@ -1015,6 +1015,11 @@ CASE("test_eckit_option_cmdargs_value_with_equals") {
 #ifdef __clang__
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
+#elif defined(__INTEL_COMPILER)
+#pragma warning ( push )
+#pragma warning ( disable:1786 )
+#elif defined(__NVCOMPILER)
+#pragma diag_suppress 1445
 #endif
 CASE("test_eckit_option__allows_to_set_default_value_for_options") {
     options_t options;
@@ -1064,6 +1069,8 @@ CASE("test_eckit_option__allows_to_set_default_value_for_options") {
 }
 #ifdef __clang__
 #pragma clang diagnostic pop
+#elif defined(__INTEL_COMPILER)
+#pragma warning ( pop )
 #endif
 #endif
 

--- a/tests/utils/test_optional.cc
+++ b/tests/utils/test_optional.cc
@@ -122,18 +122,26 @@ CASE("copy and move assign") {
         EXPECT(!opt3);
 
         // Self move-assignement
+#ifdef __clang__
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wself-move"
+#endif
         opt2 = std::move(opt2);
+#ifdef __clang__
 #pragma clang diagnostic pop
+#endif
         EXPECT(opt2);
         EXPECT(opt2.value() == 2);
 
         // Self copy-assignement
+#ifdef __clang__
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wself-assign-overloaded"
+#endif
         opt2 = opt2;
+#ifdef __clang__
 #pragma clang diagnostic pop
+#endif
         EXPECT(opt2);
         EXPECT(opt2.value() == 2);
 
@@ -198,10 +206,14 @@ CASE("non-trivial object: std::string") {
 
         // Test move assign to self
         Optional<std::string> optTmp4("tmp4");
+#ifdef __clang__
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wself-move"
+#endif
         optTmp4 = std::move(optTmp4);
+#ifdef __clang__
 #pragma clang diagnostic pop
+#endif
         EXPECT(optTmp4);
         EXPECT_EQUAL(optTmp4.value(), std::string("tmp4"));
 

--- a/tests/value/test_value_integer.cc
+++ b/tests/value/test_value_integer.cc
@@ -8,6 +8,12 @@
  * does it submit to any jurisdiction.
  */
 
+// Disable warning change of sign which is triggered on purpose
+#if defined(__INTEL_COMPILER)
+#pragma warning ( disable:68 )
+#elif defined(__NVCOMPILER)
+#pragma diag_suppress 68
+#endif
 
 #include "eckit/testing/Test.h"
 #include "eckit/types/FloatCompare.h"


### PR DESCRIPTION
Fix warnings with Intel compiler.
Many are also in common with other compilers (e.g. related to partially overridden method).
Some are related to unrecognised clang pragmas with Intel compiler.

Getting compilation of eckit without all the warnings should be beneficial with Intel compiler as this is our main targeted compiler at ECMWF.

For reviewers: It would be best to look at the changes on a commit-per-commit basis.