### PR TITLE
Add Regex::escape function to escape special regex chars from a string

### DIFF
--- a/src/eckit/utils/Regex.cc
+++ b/src/eckit/utils/Regex.cc
@@ -114,6 +114,39 @@ Regex& Regex::operator=(const Regex& other) {
     return *this;
 }
 
+std::string Regex::escape(std::string_view str) {
+    std::string ret;
+    // Reserve twice the size of str for worst-case
+    ret.reserve(str.size()*2);
+
+    for (const char& c: str) {
+        switch(c) {
+            case '.':
+            case '^':
+            case '$':
+            case '*':
+            case '+':
+            case '-':
+            case '?':
+            case '(':
+            case ')':
+            case '[':
+            case ']':
+            case '{':
+            case '}':
+            case '\\':
+            case '|':
+                ret.insert(ret.end(), '\\');
+                [[fallthrough]];
+            default:
+                ret.insert(ret.end(), c);
+        }
+    }
+
+    return ret;
+}
+
+
 //----------------------------------------------------------------------------------------------------------------------
 
 }  // namespace eckit

--- a/src/eckit/utils/Regex.h
+++ b/src/eckit/utils/Regex.h
@@ -17,6 +17,7 @@
 #include <regex.h>
 
 #include <string>
+#include <string_view>
 
 
 namespace eckit {
@@ -41,6 +42,8 @@ public:
     operator const std::string&() const { return str_; }
 
     bool operator==(const Regex& other) const { return str_ == other.str_; }
+    
+    static std::string escape(std::string_view);
 
 protected:  // methods
     void print(std::ostream&) const;

--- a/tests/utils/CMakeLists.txt
+++ b/tests/utils/CMakeLists.txt
@@ -66,3 +66,7 @@ ecbuild_add_test( TARGET      eckit_test_rsync
                   CONDITION   HAVE_RSYNC
                   SOURCES     test_rsync.cc
                   LIBS        eckit rsync )
+
+ecbuild_add_test( TARGET      eckit_test_regex
+                  SOURCES     test_regex.cc
+                  LIBS        eckit )

--- a/tests/utils/test_regex.cc
+++ b/tests/utils/test_regex.cc
@@ -1,0 +1,38 @@
+/*
+ * (C) Copyright 1996- ECMWF.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation nor
+ * does it submit to any jurisdiction.
+ */
+
+#include "eckit/eckit.h"
+
+#include "eckit/exception/Exceptions.h"
+#include "eckit/utils/Regex.h"
+
+#include "eckit/testing/Test.h"
+
+using namespace std;
+using namespace eckit;
+using namespace eckit::testing;
+
+namespace eckit::test {
+
+//----------------------------------------------------------------------------------------------------------------------
+
+CASE("Escape special regex chars in string") {
+    EXPECT(Regex::escape(".^$*+-?()[]{}\\|") == "\\.\\^\\$\\*\\+\\-\\?\\(\\)\\[\\]\\{\\}\\\\\\|"); 
+}
+
+
+
+//----------------------------------------------------------------------------------------------------------------------
+
+}  // namespace eckit::test
+
+int main(int argc, char* argv[]) {
+    return run_tests(argc, argv);
+}


### PR DESCRIPTION
In addition to a bug fix with FDB5 we need a mechanism to properly escape regex char from a string.

FDB5 uses paths in regex without escaping special chars. This causes problems for paths with characters like + or *.