### PR TITLE
Correct install location for codec file.

### DIFF
--- a/src/eckit/codec/CMakeLists.txt
+++ b/src/eckit/codec/CMakeLists.txt
@@ -2,7 +2,7 @@
 configure_file( eckit_codec_config.h.in ${CMAKE_CURRENT_BINARY_DIR}/eckit_codec_config.h @ONLY )
 install(
     FILES ${CMAKE_CURRENT_BINARY_DIR}/eckit_codec_config.h
-    DESTINATION ${INSTALL_INCLUDE_DIR}/eckit
+    DESTINATION ${INSTALL_INCLUDE_DIR}/eckit/codec
 )
 
 ecbuild_add_library(


### PR DESCRIPTION
This addresses https://github.com/ecmwf/eckit/issues/114 by installing eckit_codec_config.h in the correct place in the install directory.