### PR TITLE
Use std::string_view in eckit_mpi

### DIFF
--- a/src/eckit/mpi/Comm.h
+++ b/src/eckit/mpi/Comm.h
@@ -14,6 +14,7 @@
 #include <cstddef>
 #include <iterator>
 #include <string>
+#include <string_view>
 #include <vector>
 
 #include "eckit/filesystem/PathName.h"
@@ -35,25 +36,25 @@ class Environment;
 
 /// @returns the communicator registered with associated name, or default communicator when NULL is
 /// passed
-Comm& comm(const char* name = nullptr);
+Comm& comm(std::string_view name = {});
 
 Comm& self();
 
 /// Set a communicator as default
-void setCommDefault(const char* name);
+void setCommDefault(std::string_view name);
 
 /// Register a communicator comming from Fortran code
-void addComm(const char* name, int comm);
+void addComm(std::string_view name, int comm);
 
 /// Register an existing communicator
-void addComm(const char* name, Comm* comm);
+void addComm(std::string_view name, Comm* comm);
 
 /// Unregister and delete specific comm
 /// @pre Comm is registered in the environment
-void deleteComm(const char* name);
+void deleteComm(std::string_view name);
 
 /// Check if a communicator is registered
-bool hasComm(const char* name);
+bool hasComm(std::string_view name);
 
 std::vector<std::string> listComms();
 
@@ -78,7 +79,7 @@ class Comm : private eckit::NonCopyable {
     friend class Environment;
 
 public:  // class methods
-    static Comm& comm(const char* name = nullptr);
+    static Comm& comm(std::string_view name = {});
 
 public:  // methods
     std::string name() const { return name_; }
@@ -477,7 +478,7 @@ private:  // methods
     }
 
 protected:  // methods
-    Comm(const std::string& name);
+    Comm(std::string_view name);
 
     virtual ~Comm();
 
@@ -492,21 +493,21 @@ class CommFactory {
     friend class eckit::mpi::Environment;
 
     std::string builder_;
-    virtual Comm* make(const std::string& name)      = 0;
-    virtual Comm* make(const std::string& name, int) = 0;
+    virtual Comm* make(std::string_view name)      = 0;
+    virtual Comm* make(std::string_view name, int) = 0;
 
 protected:
-    CommFactory(const std::string& builder);
+    CommFactory(std::string_view builder);
     virtual ~CommFactory();
 
-    static Comm* build(const std::string& name, const std::string& builder);
-    static Comm* build(const std::string& name, const std::string& builder, int);
+    static Comm* build(std::string_view name, std::string_view builder);
+    static Comm* build(std::string_view name, std::string_view builder, int);
 };
 
 template <class T>
 class CommBuilder : public CommFactory {
-    Comm* make(const std::string& name) override { return new T(name); }
-    Comm* make(const std::string& name, int comm) override { return new T(name, comm); }
+    Comm* make(std::string_view name) override { return new T(name); }
+    Comm* make(std::string_view name, int comm) override { return new T(name, comm); }
 
 public:
     CommBuilder(const std::string& builder) :

--- a/src/eckit/mpi/Parallel.cc
+++ b/src/eckit/mpi/Parallel.cc
@@ -55,7 +55,7 @@ public:
 
 //----------------------------------------------------------------------------------------------------------------------
 
-void MPICall(int code, const char* mpifunc, const eckit::CodeLocation& loc) {
+void MPICall(int code, std::string_view mpifunc, const eckit::CodeLocation& loc) {
     if (code != MPI_SUCCESS) {
 
         char error[10240];
@@ -169,7 +169,7 @@ size_t getSize(MPI_Comm comm) {
 
 //----------------------------------------------------------------------------------------------------------------------
 
-Parallel::Parallel(const std::string& name) :
+Parallel::Parallel(std::string_view name) :
     Comm(name) /* don't use member initialisation list */ {
 
     pthread_once(&once, init);
@@ -185,7 +185,7 @@ Parallel::Parallel(const std::string& name) :
     size_ = getSize(comm_);
 }
 
-Parallel::Parallel(const std::string& name, MPI_Comm comm, bool) :
+Parallel::Parallel(std::string_view name, MPI_Comm comm, bool) :
     Comm(name) /* don't use member initialisation list */ {
 
     pthread_once(&once, init);
@@ -201,7 +201,7 @@ Parallel::Parallel(const std::string& name, MPI_Comm comm, bool) :
     size_ = getSize(comm_);
 }
 
-Parallel::Parallel(const std::string& name, int comm) :
+Parallel::Parallel(std::string_view name, int comm) :
     Comm(name) {
 
     pthread_once(&once, init);

--- a/src/eckit/mpi/Parallel.h
+++ b/src/eckit/mpi/Parallel.h
@@ -29,9 +29,9 @@ protected:  // methods
     template <class T>
     friend class CommBuilder;
 
-    Parallel(const std::string& name);
-    Parallel(const std::string& name, MPI_Comm comm, bool);
-    Parallel(const std::string& name, int comm);
+    Parallel(std::string_view name);
+    Parallel(std::string_view name, MPI_Comm comm, bool);
+    Parallel(std::string_view name, int comm);
 
     ~Parallel() override;
 

--- a/src/eckit/mpi/ParallelGroup.cc
+++ b/src/eckit/mpi/ParallelGroup.cc
@@ -8,6 +8,8 @@
  * does it submit to any jurisdiction.
  */
 
+#include <string_view>
+
 #include "eckit/mpi/ParallelGroup.h"
 #include "eckit/log/CodeLocation.h"
 #include "eckit/mpi/Parallel.h"
@@ -16,7 +18,7 @@ namespace eckit {
 namespace mpi {
 
 
-void MPICall(int code, const char* mpifunc, const eckit::CodeLocation& loc);
+void MPICall(int code, std::string_view mpifunc, const eckit::CodeLocation& loc);
 #define MPI_CALL(a) MPICall(a, #a, Here())
 
 //----------------------------------------------------------------------------------------------------------------------
@@ -35,8 +37,7 @@ ParallelGroup::ParallelGroup(MPI_Group group) :
     group_(group) {}
 
 void ParallelGroup::print(std::ostream& os) const {
-    os << "ParallelGroup("
-       << ")";
+    os << "ParallelGroup()";
 }
 
 int ParallelGroup::group() const {

--- a/src/eckit/mpi/ParallelRequest.cc
+++ b/src/eckit/mpi/ParallelRequest.cc
@@ -8,6 +8,8 @@
  * does it submit to any jurisdiction.
  */
 
+#include <string_view>
+
 #include "eckit/mpi/ParallelRequest.h"
 #include "eckit/log/CodeLocation.h"
 #include "eckit/mpi/Parallel.h"
@@ -16,7 +18,7 @@ namespace eckit {
 namespace mpi {
 
 
-void MPICall(int code, const char* mpifunc, const eckit::CodeLocation& loc);
+void MPICall(int code, std::string_view mpifunc, const eckit::CodeLocation& loc);
 #define MPI_CALL(a) MPICall(a, #a, Here())
 
 //----------------------------------------------------------------------------------------------------------------------

--- a/src/eckit/mpi/Serial.cc
+++ b/src/eckit/mpi/Serial.cc
@@ -134,13 +134,13 @@ private:
 
 //----------------------------------------------------------------------------------------------------------------------
 
-Serial::Serial(const std::string& name) :
+Serial::Serial(std::string_view name) :
     Comm(name) {
     rank_ = 0;
     size_ = 1;
 }
 
-Serial::Serial(const std::string& name, int) :
+Serial::Serial(std::string_view name, int) :
     Comm(name) {
     rank_ = 0;
     size_ = 1;

--- a/src/eckit/mpi/Serial.h
+++ b/src/eckit/mpi/Serial.h
@@ -30,8 +30,8 @@ protected:  // methods
     template <class T>
     friend class CommBuilder;
 
-    Serial(const std::string& name);
-    Serial(const std::string& name, int);
+    Serial(std::string_view name);
+    Serial(std::string_view name, int);
 
     ~Serial() override;
 


### PR DESCRIPTION
This PR changes `const char*` arguments into `std::string_view`, so that we can now downstream replace amongst others
```eckit::mpi::setCommDefault( string.c_str() )``` and ```eckit::mpi::comm( string.c_str() )```
with 
```eckit::mpi::setCommDefault( string )``` and ```eckit::mpi::comm( string )```.

It should still be compatible with callers passing `const char*`.