### PR TITLE
Sort output for test_iProbe.

### DIFF
--- a/tests/mpi/eckit_test_mpi.cc
+++ b/tests/mpi/eckit_test_mpi.cc
@@ -8,6 +8,7 @@
  * does it submit to any jurisdiction.
  */
 
+#include <algorithm>
 #include <fstream>
 #include <numeric>
 
@@ -999,6 +1000,8 @@ CASE("test_iProbe") {
 
         --count;
     }
+
+    std::sort(data.begin(), data.begin() + nproc);
 
     for (int i = 0; i < nproc; i++) {
         EXPECT(i == data[i]);

--- a/tests/mpi/eckit_test_mpi.cc
+++ b/tests/mpi/eckit_test_mpi.cc
@@ -956,6 +956,8 @@ CASE("test_probe") {
         --count;
     }
 
+    std::sort(begin(data), end(data));
+
     for (int i = 0; i < nproc; i++) {
         EXPECT(i == data[i]);
     }
@@ -1001,7 +1003,7 @@ CASE("test_iProbe") {
         --count;
     }
 
-    std::sort(data.begin(), data.begin() + nproc);
+    std::sort(begin(data), end(data));
 
     for (int i = 0; i < nproc; i++) {
         EXPECT(i == data[i]);


### PR DESCRIPTION
Would this be a potential fix for #47?  It seems that sometimes the output is not in the correct order for the ASSERT.  I'm not sure whether this is a situation that the output is required to be in a particular order or not.  If not, then sorting the output might be a solution.