### PR TITLE
Feature/syslog structured data

### DIFF
--- a/src/eckit/log/SysLog.cc
+++ b/src/eckit/log/SysLog.cc
@@ -23,8 +23,8 @@
 namespace eckit {
 
 
-SysLog::SysLog(const std::string& msg, int msgid, Facility f, Severity s)
-    : facility_(f), severity_(s), appName_(Main::instance().name()), msgid_(msgid), msg_(msg) {
+SysLog::SysLog(const std::string& msg, int msgid, Facility f, Severity s) :
+    facility_(f), severity_(s), appName_(Main::instance().name()), msgid_(msgid), msg_(msg) {
     timestamp_ = TimeStamp("%Y-%m-%dT%H:%M:%SZ");  ///< assumes we are in UTC
 }
 

--- a/src/eckit/log/SysLog.cc
+++ b/src/eckit/log/SysLog.cc
@@ -75,7 +75,7 @@ SysLog::operator std::string() const {
     static char sep = ' ';
 
     os  // RFC 5424 section 6.2 (Header)
-        << "<" << priotity() << ">" << version() << sep << timestamp() << sep << fqdn() << sep << appName() << sep
+        << "<" << priority() << ">" << version() << sep << timestamp() << sep << fqdn() << sep << appName() << sep
         << procid() << sep << msgid()
         << sep
         // RFC 5424 section 6.3

--- a/src/eckit/log/SysLog.h
+++ b/src/eckit/log/SysLog.h
@@ -99,6 +99,11 @@ public:  // methods
         return s;
     }
 
+    /// Optional fields for structured data (RFC 5424 section 6.3)
+    void software(const std::string& software) { software_ = software; }
+    void swVersion(const std::string& version) { swVersion_ = version; }
+    void enterpriseId(const std::string& id) { enterpriseId_ = id; }
+
 private:  // methods
     void print(std::ostream& out) const;
 
@@ -112,6 +117,11 @@ private:  // members
     int msgid_;
 
     std::string msg_;
+
+    // optional fields for structured data
+    std::string software_;
+    std::string swVersion_;
+    std::string enterpriseId_;
 };
 
 }  // namespace eckit

--- a/src/eckit/log/SysLog.h
+++ b/src/eckit/log/SysLog.h
@@ -72,7 +72,7 @@ public:  // methods
 
     SysLog(const std::string& msg, int msgid = 0, Facility f = SysLog::User, Severity s = SysLog::Info);
 
-    unsigned priotity() const { return facility_ * 8 + severity_; }
+    unsigned priority() const { return facility_ * 8 + severity_; }
 
     unsigned version() const { return 1; }
 

--- a/tests/log/CMakeLists.txt
+++ b/tests/log/CMakeLists.txt
@@ -27,3 +27,7 @@ ecbuild_add_test( TARGET      eckit_test_log_user_channels
                   ENABLED     OFF
                   SOURCES     test_log_user_channels.cc
                   LIBS        eckit )
+
+ecbuild_add_test( TARGET      eckit_test_syslog
+                  SOURCES     test_syslog.cc
+                  LIBS        eckit )

--- a/tests/log/test_syslog.cc
+++ b/tests/log/test_syslog.cc
@@ -1,0 +1,84 @@
+/*
+ * (C) Copyright 1996- ECMWF.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation nor
+ * does it submit to any jurisdiction.
+ */
+
+#include <iostream>
+
+#include "eckit/log/SysLog.h"
+#include "eckit/testing/Test.h"
+
+using namespace std;
+using namespace eckit;
+using namespace eckit::testing;
+
+namespace eckit::test {
+
+//----------------------------------------------------------------------------------------------------------------------
+
+CASE("test_priority") {
+    SysLog log("Test message", 0, SysLog::Local7, SysLog::Info);
+    std::string logString        = static_cast<std::string>(log);
+    std::string expectedPriority = "<" + std::to_string(log.priority()) + ">";
+    EXPECT(logString.find(expectedPriority) != std::string::npos);
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+
+CASE("test_timezone") {
+    SysLog log("Test message", 0, SysLog::Local7, SysLog::Info);
+    std::string logString = static_cast<std::string>(log);
+    // Check if 'Z' UTC indicator is present
+    EXPECT(logString.find("Z") != std::string::npos);
+    // Check if 'T' separator is present
+    EXPECT(logString.find("T") != std::string::npos);
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+
+CASE("test_appname") {
+    SysLog log("Test message", 0, SysLog::Local7, SysLog::Info);
+    EXPECT(log.appName() == Main::instance().name());
+
+    // Change the appName and check if it persists
+    log.appName("test_app");
+    std::string logString = static_cast<std::string>(log);
+    EXPECT(logString.find("test_app") != std::string::npos);
+
+    // Create a new SysLog instance and check if it retains the original appName
+    SysLog newLog("New message", 2, SysLog::Local7, SysLog::Info);
+    EXPECT(newLog.appName() == Main::instance().name());
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+
+CASE("test_without_structured_data") {
+    SysLog log("Test message", 0, SysLog::Local7, SysLog::Info);
+    std::string logString = static_cast<std::string>(log);
+    // Check if structured data is not present
+    EXPECT(logString.find("[origin") == std::string::npos);
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+CASE("test_with_structured_data") {
+    SysLog log("Test message", 0, SysLog::Local7, SysLog::Info);
+    log.software("log_test");
+    log.swVersion("1.0.0");
+    log.enterpriseId("7464");
+    std::string logString = static_cast<std::string>(log);
+    EXPECT(logString.find("enterpriseId=\"7464\"") != std::string::npos);
+    EXPECT(logString.find("software=\"log_test\"") != std::string::npos);
+    EXPECT(logString.find("swVersion=\"1.0.0\"") != std::string::npos);
+}
+//----------------------------------------------------------------------------------------------------------------------
+
+}  // namespace eckit::test
+
+int main(int argc, char** argv) {
+    return run_tests(argc, argv);
+}


### PR DESCRIPTION
This PR implements the "origin" component of the syslog structural data as described in RFC5424, specifically in sections 6.2 and 7.2 ([RFC5424 Section 7.2](https://datatracker.ietf.org/doc/html/rfc5424#section-7.2)). Implementation also ensures that the current functionality remains unaffected if the newly introduced variables are not set. I am tagging @tlmquintino here as he may also want to take a look at this implementation.

Note: This is not a full implementation of structural data of the syslog, only implements the bits that necessary to add logserver-compatible logging. Logserver repo can be found [here](https://github.com/ecmwf/logserver-ansible)