### PR TITLE
Fix test macros

### DIFF
--- a/src/eckit/testing/Test.h
+++ b/src/eckit/testing/Test.h
@@ -453,8 +453,8 @@ int run_tests(int argc, char* argv[], bool initEckitMain = true) {
 #define EXPECT_MSG(expr, msg_callback)                                               \
     do {                                                                             \
         if (!(expr)) {                                                               \
-            auto msg = msg_callback;                                                 \
-            msg();                                                                   \
+            auto _msg = msg_callback;                                                \
+            _msg();                                                                  \
             throw eckit::testing::TestException("Condition failed: " #expr, Here()); \
         }                                                                            \
     } while (false)

--- a/src/eckit/testing/Test.h
+++ b/src/eckit/testing/Test.h
@@ -460,13 +460,13 @@ int run_tests(int argc, char* argv[], bool initEckitMain = true) {
     } while (false)
 
 #define EXPECT_EQUAL(a, b)                                                                                         \
-    EXPECT_MSG(a == b, [=]() {                                                                                     \
+    EXPECT_MSG(a == b, [&]() {                                                                                     \
         std::cerr << eckit::Colour::red << "FAILED " << #a " == " << #b << " evaluated as [" << a << "] == [" << b \
                   << "]" << eckit::Colour::reset << std::endl;                                                     \
     };)
 
 #define EXPECT_NOT_EQUAL(a, b)                                                                                     \
-    EXPECT_MSG(a != b, [=]() {                                                                                     \
+    EXPECT_MSG(a != b, [&]() {                                                                                     \
         std::cerr << eckit::Colour::red << "FAILED " << #a " != " << #b << " evaluated as [" << a << "] != [" << b \
                   << "]" << eckit::Colour::reset << std::endl;                                                     \
     };)


### PR DESCRIPTION
Use ref for lambda instead of value, which copies