### PR TITLE
Add isNull to eckit::Configuration

### DIFF
--- a/src/eckit/config/Configuration.cc
+++ b/src/eckit/config/Configuration.cc
@@ -500,6 +500,12 @@ bool Configuration::isSubConfiguration(const std::string& name) const {
     return found && (v.isMap() || v.isOrderedMap());
 }
 
+bool Configuration::isNull(const std::string& name) const {
+    bool found     = false;
+    eckit::Value v = lookUp(name, found);
+    return found && (v.isNil());
+}
+
 bool Configuration::isIntegralList(const std::string& name) const {
     bool found = false;
     eckit::Value v = lookUp(name, found);

--- a/src/eckit/config/Configuration.h
+++ b/src/eckit/config/Configuration.h
@@ -157,6 +157,8 @@ public:  // methods
     bool isFloatingPointList(const std::string& name) const;
 
     bool isStringList(const std::string& name) const;
+    
+    bool isNull(const std::string& name) const;
 
     template <typename T>
     bool isConvertible(const std::string& name) const {

--- a/tests/config/test_configuration.cc
+++ b/tests/config/test_configuration.cc
@@ -347,6 +347,29 @@ base:
 
 //----------------------------------------------------------------------------------------------------------------------
 
+
+CASE("YAML configuration with null value") {
+    const char* text = R"YAML(
+---
+base:
+  nothing : null
+)YAML";
+
+    std::string cfgtxt(text);
+
+    YAMLConfiguration conf(cfgtxt);
+
+    LocalConfiguration local;
+
+    EXPECT_NO_THROW(conf.get("base", local));
+
+    std::cerr << Colour::green << local << Colour::reset << std::endl;
+
+    EXPECT(local.isNull("nothing"));
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+
 CASE("test_local_configuration") {
     LocalConfiguration local;
     {


### PR DESCRIPTION
I would like to check properly if a value ina yaml configuration is NULL.
Otherwise I can just guess that a value is null by exclusion (when all the other introspective calls are false).
