### PR TITLE
Buffer zero size alloc

### DIFF
--- a/src/eckit/io/Buffer.cc
+++ b/src/eckit/io/Buffer.cc
@@ -19,8 +19,8 @@ namespace eckit {
 
 namespace {
 
-static char* allocate(size_t size) {
-    return new char[size];
+static char* allocate(const size_t size) {
+    return size == 0 ? nullptr : new char[size];
 }
 
 static void deallocate(char* buffer) {
@@ -98,8 +98,8 @@ void Buffer::copy(const std::string& s) {
 }
 
 void Buffer::copy(const void* p, size_t size, size_t pos) {
-    ASSERT(buffer_ && size_ >= pos + size);
-    if (size) {
+    ASSERT(size_ >= pos + size);
+    if (buffer_ && size > 0) {
         ::memcpy(buffer_ + pos, p, size);
     }
 }

--- a/src/eckit/io/Buffer.cc
+++ b/src/eckit/io/Buffer.cc
@@ -23,7 +23,7 @@ static char* allocate(const size_t size) {
     return size == 0 ? nullptr : new char[size];
 }
 
-static void deallocate(char* buffer) {
+static void deallocate(const char* buffer) {
     delete[] buffer;
     buffer = nullptr;
 }
@@ -32,7 +32,7 @@ static void deallocate(char* buffer) {
 
 //----------------------------------------------------------------------------------------------------------------------
 
-Buffer::Buffer(size_t size) :
+Buffer::Buffer(const size_t size) :
     buffer_{nullptr}, size_{size} {
     create();
 }
@@ -94,14 +94,14 @@ void Buffer::copy(const std::string& s) {
     if (buffer_) { ::strncpy(buffer_, s.c_str(), std::min(size_, s.size() + 1)); }
 }
 
-void Buffer::copy(const void* p, size_t size, size_t pos) {
+void Buffer::copy(const void* p, const size_t size, const size_t pos) {
     ASSERT(size_ >= pos + size);
     if (buffer_ && size > 0) {
         ::memcpy(buffer_ + pos, p, size);
     }
 }
 
-void Buffer::resize(size_t size, bool preserveData) {
+void Buffer::resize(const size_t size, const bool preserveData) {
     if (size != size_) {
         if (preserveData) {
             char* newbuffer = allocate(size);

--- a/src/eckit/io/Buffer.cc
+++ b/src/eckit/io/Buffer.cc
@@ -25,6 +25,7 @@ static char* allocate(const size_t size) {
 
 static void deallocate(char* buffer) {
     delete[] buffer;
+    buffer = nullptr;
 }
 
 }  // namespace
@@ -85,16 +86,13 @@ void Buffer::create() {
 }
 
 void Buffer::destroy() {
-    if (buffer_) {
-        deallocate(buffer_);
-        buffer_ = nullptr;
-        size_   = 0;
-    }
+    deallocate(buffer_);
+    size_ = 0;
 }
 
 void Buffer::copy(const std::string& s) {
     ASSERT(buffer_);
-    ::strncpy(buffer_, s.c_str(), std::min(size_, s.size() + 1));
+    if (buffer_) { ::strncpy(buffer_, s.c_str(), std::min(size_, s.size() + 1)); }
 }
 
 void Buffer::copy(const void* p, size_t size, size_t pos) {

--- a/src/eckit/io/Buffer.cc
+++ b/src/eckit/io/Buffer.cc
@@ -91,7 +91,6 @@ void Buffer::destroy() {
 }
 
 void Buffer::copy(const std::string& s) {
-    ASSERT(buffer_);
     if (buffer_) { ::strncpy(buffer_, s.c_str(), std::min(size_, s.size() + 1)); }
 }
 

--- a/src/eckit/io/Buffer.cc
+++ b/src/eckit/io/Buffer.cc
@@ -23,7 +23,7 @@ static char* allocate(const size_t size) {
     return size == 0 ? nullptr : new char[size];
 }
 
-static void deallocate(const char* buffer) {
+static void deallocate(char*& buffer) {
     delete[] buffer;
     buffer = nullptr;
 }

--- a/src/eckit/io/Buffer.cc
+++ b/src/eckit/io/Buffer.cc
@@ -8,6 +8,7 @@
  * does it submit to any jurisdiction.
  */
 
+#include <algorithm>
 #include <cstring>
 
 #include "eckit/exception/Exceptions.h"
@@ -32,19 +33,16 @@ static void deallocate(char*& buffer) {
 
 //----------------------------------------------------------------------------------------------------------------------
 
-Buffer::Buffer(const size_t size) :
-    buffer_{nullptr}, size_{size} {
+Buffer::Buffer(const size_t size): size_ {size} {
     create();
 }
 
-Buffer::Buffer(const void* p, size_t len) :
-    buffer_{nullptr}, size_{len} {
+Buffer::Buffer(const void* p, size_t len): size_ {len} {
     create();
     copy(p, len);
 }
 
-Buffer::Buffer(const std::string& s) :
-    buffer_{nullptr}, size_{s.length() + 1} {
+Buffer::Buffer(const std::string& s): size_ {s.length() + 1} {
     create();
     copy(s);
 }

--- a/tests/io/test_buffer.cc
+++ b/tests/io/test_buffer.cc
@@ -69,7 +69,8 @@ CASE("Test eckit Buffer move constructor") {
     const char* out = buf2;
     EXPECT(std::strcmp(msg, out) == 0);
 
-    EXPECT(static_cast<const char*>(buf1) == nullptr && buf1.size() == 0);
+    EXPECT_EQUAL(static_cast<const char*>(buf1), nullptr);
+    EXPECT_EQUAL(buf1.size(), 0);
 }
 
 CASE("Test eckit Buffer move assignment") {
@@ -82,8 +83,8 @@ CASE("Test eckit Buffer move assignment") {
     const char* out = buf2;
     EXPECT(std::strcmp(msg, out) == 0);
 
-    // EXPECT(static_cast<const char*>(buf1) == nullptr)
-    EXPECT(buf1.size() == 0);
+    EXPECT_EQUAL(static_cast<const char*>(buf1), nullptr);
+    EXPECT_EQUAL(buf1.size(), 0);
 }
 
 // This includes a self-move but is legitimate, if pointless, so it should be tested
@@ -122,7 +123,10 @@ CASE("Test eckit Buffer resize") {
     EXPECT_THROWS(buf.copy(msg, sz));
 
     EXPECT_NO_THROW(buf.resize(sz));
+    EXPECT_EQUAL(buf.size(), sz);
+
     EXPECT_NO_THROW(buf.copy(msg, sz));
+    EXPECT_EQUAL(std::strncmp(msg, static_cast<const char*>(buf), sz), 0);
 
     size_t newSize = 41;
     buf.resize(newSize, true);
@@ -140,6 +144,10 @@ CASE("Test eckit Buffer resize") {
     newSize = 41;
     buf.resize(newSize, false);
     EXPECT(buf.size() == newSize);
+
+    buf.resize(0, false);
+    EXPECT_EQUAL(buf.size(), 0);
+    EXPECT_EQUAL(buf.data(), nullptr);
 }
 
 CASE("Test construct from an empty") {

--- a/tests/io/test_buffer.cc
+++ b/tests/io/test_buffer.cc
@@ -69,7 +69,7 @@ CASE("Test eckit Buffer move constructor") {
     const char* out = buf2;
     EXPECT(std::strcmp(msg, out) == 0);
 
-    EXPECT_EQUAL(static_cast<const char*>(buf1), nullptr);
+    EXPECT(static_cast<const char*>(buf1) == nullptr);
     EXPECT_EQUAL(buf1.size(), 0);
 }
 
@@ -83,7 +83,7 @@ CASE("Test eckit Buffer move assignment") {
     const char* out = buf2;
     EXPECT(std::strcmp(msg, out) == 0);
 
-    EXPECT_EQUAL(static_cast<const char*>(buf1), nullptr);
+    EXPECT(static_cast<const char*>(buf1) == nullptr);
     EXPECT_EQUAL(buf1.size(), 0);
 }
 
@@ -147,14 +147,18 @@ CASE("Test eckit Buffer resize") {
 
     buf.resize(0, false);
     EXPECT_EQUAL(buf.size(), 0);
-    EXPECT_EQUAL(buf.data(), nullptr);
+    EXPECT(buf.data() == nullptr);
+
+    buf.resize(0, true);
+    EXPECT_EQUAL(buf.size(), 0);
+    EXPECT(buf.data() == nullptr);
 }
 
 CASE("Test construct from an empty") {
     std::unique_ptr<Buffer> buf;
     EXPECT_NO_THROW(buf = std::make_unique<Buffer>(Buffer {0}));
     EXPECT_EQUAL(buf->size(), 0);
-    EXPECT_EQUAL(buf->data(), nullptr);
+    EXPECT(buf->data() == nullptr);
 }
 
 CASE("Test copying and construction from of std::string") {

--- a/tests/io/test_buffer.cc
+++ b/tests/io/test_buffer.cc
@@ -4,6 +4,7 @@
 #include <ctime>
 
 #include <algorithm>
+#include <memory>
 
 #include "eckit/io/Buffer.h"
 #include "eckit/testing/Test.h"
@@ -32,7 +33,7 @@ const char* msg = "Once upon a midnight dreary";
 CASE("Test eckit Buffer default constructor") {
     Buffer buf;
     EXPECT(buf.size() == 0);
-    EXPECT(buf.data() != nullptr);
+    EXPECT(buf.data() == nullptr);
 }
 
 CASE("Test eckit Buffer constructor 1") {
@@ -139,6 +140,13 @@ CASE("Test eckit Buffer resize") {
     newSize = 41;
     buf.resize(newSize, false);
     EXPECT(buf.size() == newSize);
+}
+
+CASE("Test construct from an empty") {
+    std::unique_ptr<Buffer> buf;
+    EXPECT_NO_THROW(buf = std::make_unique<Buffer>(Buffer {0}));
+    EXPECT_EQUAL(buf->size(), 0);
+    EXPECT_EQUAL(buf->data(), nullptr);
 }
 
 CASE("Test copying and construction from of std::string") {

--- a/tests/io/test_buffer.cc
+++ b/tests/io/test_buffer.cc
@@ -19,8 +19,8 @@ namespace eckit::test {
 
 //----------------------------------------------------------------------------------------------------------------------
 
-unsigned char* random_bytestream(size_t sz) {
-    ::srand((unsigned int)::time(0));
+unsigned char* random_bytestream(const size_t sz) {
+    ::srand(static_cast<unsigned int>(::time(nullptr)));
     unsigned char* stream = static_cast<unsigned char*>(::malloc(sz));
     auto rnd              = []() -> unsigned char { return ::rand(); };
     std::generate(stream, stream + sz, rnd);
@@ -28,7 +28,7 @@ unsigned char* random_bytestream(size_t sz) {
     return stream;
 }
 
-const char* msg = "Once upon a midnight dreary";
+constexpr auto msg = "Once upon a midnight dreary";
 
 CASE("Test eckit Buffer default constructor") {
     Buffer buf;
@@ -116,7 +116,7 @@ CASE("Test eckit Buffer Zero") {
 
 // NOTE: resize allocates a new buffer whenever the new size is different -- this is inefficient
 CASE("Test eckit Buffer resize") {
-    const size_t sz = std::strlen(msg) + 1;
+    constexpr auto sz = std::char_traits<char>::length(msg) + 1;
     Buffer buf;
     EXPECT(buf.size() == 0);
 


### PR DESCRIPTION
In eckit::Buffer default ctor (size=0), buffer_ is allocated as 'new char[0]'.

'buffer.data() != nullptr', which is not a correct state for an uninitialized buffer