### PR TITLE
Reset init guard flag in destructor

### DIFF
--- a/src/eckit/thread/ThreadSingleton.h
+++ b/src/eckit/thread/ThreadSingleton.h
@@ -83,6 +83,7 @@ ThreadSingleton<T, A>::~ThreadSingleton() {
     T* value = (T*)::pthread_getspecific(key_);
     if (value) {
         ::pthread_key_delete(key_);
+        once_ = PTHREAD_ONCE_INIT;
         delete value;
     }
 }


### PR DESCRIPTION
Allows resurrection of dead singletons by enabling  pthread_once to execute after the current instance has been destroyed.