### PR TITLE
Add support for colon seperated list of library homes

### DIFF
--- a/src/eckit/system/Library.h
+++ b/src/eckit/system/Library.h
@@ -77,7 +77,8 @@ public:  // methods
     void unlock() { mutex_.unlock(); }
 
 protected:  // methods
-    virtual std::string home() const;
+    
+    virtual const std::vector<std::string>& homes() const;
 
     virtual const void* addr() const;
 
@@ -94,7 +95,7 @@ private:  // methods
 private:  // members
     std::string name_;
     std::string prefix_;
-    std::string home_;  // if not set explicitly, will be empty
+    mutable std::vector<std::string> homes_;
 
     bool debug_;
 


### PR DESCRIPTION
Allows setting multiple homes in a colon seperated string. e.g. `ECKIT_HOME=/path/to/home1:/path/to/home2`
This is useful for libraries which like to search for multiple configs, which may be in distinct directories. LocalPathName's tilde expansion `~eckit/file` will match the first existing file from `[/path/to/home1/file1, /path/to/home2/file]`. If none exist, the first is used.

No change in behaviour is intended if a single home is set.

If LIB_HOME is not set, there is a change in behaviour in the tilde expansion:
 - Before: eckit would search recursively upwards from the prefix directory all the way to the root directory.
   - e.g. `~eckit/file1` -> `libraryprefix/file1`, `libraryprefix/../file1`, `libraryprefix/../../file1`, `libraryprefix/../../../file1`... `/file1`
 - Now: eckit will search the prefix directories and one and two levels above it, then go straight to the root. (exactly four directories)
    - e.g. `~eckit/file1` -> `libraryprefix/file1`, `libraryprefix/../file1`, `libraryprefix/../../file1`, `libraryprefix/../../file1`, `/file1`

**note** This does mean that LIB_HOME cannot be set to directories whose path contains a colon.