### PR TITLE
Fix compilation warnings on LUMI with cce/17

### DIFF
--- a/src/eckit/codec/Stream.cc
+++ b/src/eckit/codec/Stream.cc
@@ -25,8 +25,6 @@ Stream::Stream(DataHandle* datahandle) : shared_(datahandle), ptr_(shared_.get()
 
 Stream::Stream(std::shared_ptr<DataHandle> datahandle) : shared_(datahandle), ptr_(shared_.get()) {}
 
-Stream::Stream(const Stream& other) = default;
-
 DataHandle& Stream::datahandle() {
     ASSERT(ptr_ != nullptr);
     return *ptr_;

--- a/src/eckit/codec/Stream.h
+++ b/src/eckit/codec/Stream.h
@@ -46,8 +46,11 @@ public:
     ///       the referenced datahandle
     Stream(DataHandle&);
 
-    /// Assignment constructor sharing datahandle with other Stream
-    Stream(const Stream&);
+    /// Assignment/Copy constructor sharing datahandle with other Stream
+    Stream(const Stream&) = default;
+    Stream(Stream&&) = default;
+    Stream& operator=(const Stream&) = default;
+    Stream& operator=(Stream&&) = default;
 
     /// Access internal DataHandle
     DataHandle& datahandle();

--- a/tests/value/CMakeLists.txt
+++ b/tests/value/CMakeLists.txt
@@ -29,7 +29,7 @@ foreach( valueType nil boolean integer double string valuemap valuelist date ord
                      LIBS     eckit )
 endforeach()
 
-if( CMAKE_CXX_COMPILER_ID MATCHES "Cray" )
+if( CMAKE_CXX_COMPILER_ID STREQUAL "Cray" )
    # Disable warnings for test_value_integer due to following:
    #    "Integer conversion resulted in a change of sign."
    set_source_files_properties(test_value_integer.cc PROPERTIES COMPILE_FLAGS "-hmsglevel_4" )


### PR DESCRIPTION
This fixes a few warnings when compiling eckit on LUMI with CrayClang compiler cce/17.
One warning was for unrecognised flag for CrayClang as opposed to "just" Cray.
Another related to deprecated implicit assignment operator.