### PR TITLE
Fix missing header in ResourceUsage.h

### DIFF
--- a/src/eckit/system/ResourceUsage.h
+++ b/src/eckit/system/ResourceUsage.h
@@ -18,6 +18,7 @@
 #include <sys/resource.h>
 #include <cstddef>
 #include <iosfwd>
+#include <stddef.h>
 
 namespace eckit::system {
 


### PR DESCRIPTION
`ResourceUsage.h` used `size_t`, but did not include the stddef header. This lead to some compilation errors in atlas4py.