### PR TITLE
Correctly delegate BitColumnExpression::eval(*double out, bool& missing)

### DIFF
--- a/src/eckit/sql/expression/BitColumnExpression.h
+++ b/src/eckit/sql/expression/BitColumnExpression.h
@@ -45,7 +45,12 @@ protected:
     // -- Overridden methods
     void prepare(SQLSelect& sql) override;
     void updateType(SQLSelect& sql) override;
-    using ColumnExpression::eval;
+
+    // Use SQLExpression's eval rather than ColumnExpression's
+    void eval(double* out, bool& missing) const override {
+        SQLExpression::eval(out, missing);
+    }
+
     double eval(bool& missing) const override;
     virtual void expandStars(const std::vector<std::reference_wrapper<const SQLTable>>&,
                              expression::Expressions&) override;


### PR DESCRIPTION
## The Problem

When an odc sql statement includes both aggregate functions and bitfield columns, the bitfield columns are not printed (or aggregated) correctly.
```
>>> odc sql -i odc/docs/_static/data-1.odb -q "select avg(bitfield_column.flag_a),bitfield_column.flag_a,bitfield_column.flag_b"
avg(bitfield_column.flag_a)     bitfield_column.flag_a  bitfield_column.flag_b
                   0.000000                          0                       0
                   1.000000                        111                     111
                   0.000000                        222                     222
                   1.000000                        333                     333
                   0.000000                        444                     444
                   1.000000                        555                     555
                   0.000000                        666                     666
                   1.000000                        777                     777
                   0.000000                        888                     888
                   1.000000                        999                     999
```

## The Fix

In the original code, on the code path where we mix aggregated and non-aggregated columns, `SQLExpressionEvaluated` calls`e.eval(&value_[0], missing_);` whihc, when `e` is a bitfield column would actually call `ColumnExpression::eval(*double out, bool& missing)` which does not delegate to `BitColumnExpression::eval(bool& missing)`

This change overrides `BitColumnExpression::eval(*double out, bool& missing)` to use `SQLExpression:eval(*double out, bool& missing)` which correctly delegates to `BitColumnExpression::eval(bool& missing)`.

After this fix:
```
avg(bitfield_column.flag_a)     bitfield_column.flag_a  bitfield_column.flag_b
                   0.000000                          0                       0
                   0.000000                          0                       1
                   0.000000                          0                       2
                   0.000000                          0                       3
                   1.000000                          1                       0
                   1.000000                          1                       1
                   1.000000                          1                       2
                   1.000000                          1                       3
```