### PR TITLE
Update FindAEC and add to CI

### DIFF
--- a/.github/ci-config.yml
+++ b/.github/ci-config.yml
@@ -1,5 +1,6 @@
 cmake_options: -DENABLE_ECKIT_GEO=ON
 dependencies: |
   ecmwf/ecbuild
+  MathisRosenhauer/libaec@master
 dependency_branch: develop
 parallelism_factor: 8

--- a/cmake/FindAEC.cmake
+++ b/cmake/FindAEC.cmake
@@ -18,14 +18,19 @@
 #
 #  AEC_DIR          - prefix path of the AEC installation
 #  AEC_PATH         - prefix path of the AEC installation
+#  LIBAEC_DIR
+#  libaec_DIR
+#  LIBAEC_PATH
+#  libaec_PATH
+#  libaec_ROOT
 
-find_path( AEC_INCLUDE_DIR szlib.h
-           PATHS ${AEC_DIR} ${AEC_PATH} ENV AEC_DIR ENV AEC_PATH
+find_path( AEC_INCLUDE_DIR libaec.h
+           PATHS ${AEC_DIR} ${AEC_PATH} ${LIBAEC_DIR} ${libaec_DIR} ${LIBAEC_PATH} ${libaec_PATH} ${libaec_ROOT} ENV AEC_DIR ENV AEC_PATH ENV LIBAEC_DIR ENV libaec_DIR ENV LIBAEC_PATH ENV libaec_PATH ENV libaec_ROOT
            PATH_SUFFIXES include include/aec NO_DEFAULT_PATH )
-find_path( AEC_INCLUDE_DIR szlib.h PATH_SUFFIXES include include/aec )
+find_path( AEC_INCLUDE_DIR libaec.h PATH_SUFFIXES include include/aec )
 
 find_library( AEC_LIBRARY  NAMES aec
-              PATHS ${AEC_DIR} ${AEC_PATH} ENV AEC_DIR ENV AEC_PATH
+              PATHS ${AEC_DIR} ${AEC_PATH} ${LIBAEC_DIR} ${libaec_DIR} ${LIBAEC_PATH} ${libaec_PATH} ${libaec_ROOT} ENV AEC_DIR ENV AEC_PATH ENV LIBAEC_DIR ENV libaec_DIR ENV LIBAEC_PATH ENV libaec_PATH ENV libaec_ROOT
               PATH_SUFFIXES lib lib64 lib/aec lib64/aec NO_DEFAULT_PATH )
 find_library( AEC_LIBRARY NAMES aec PATH_SUFFIXES lib lib64 lib/aec lib64/aec )
 

--- a/src/eckit/system/LibraryManager.cc
+++ b/src/eckit/system/LibraryManager.cc
@@ -209,7 +209,9 @@ public:  // methods
             return plib;
         }
 
-        Log::warning() << "Failed to load library " << dynamicLibraryName << std::endl;
+        Log::warning() << "Failed to load library " << dynamicLibraryName
+                       << " dlerror: " << ::dlerror() << std::endl;
+
         return nullptr;
     }
 
@@ -233,6 +235,12 @@ public:  // methods
 
             // lets load since the associated library isn't registered
             void* libhandle = loadDynamicLibrary(lib);
+
+            if (!libhandle) {
+                std::ostringstream ss;
+                ss << "Failed to load library " << lib;
+                throw FailedSystemCall(ss.str().c_str(), Here());
+            }
 
             // the plugin should self-register when the library loads
             Plugin* plugin = lookupPlugin(name);


### PR DESCRIPTION
Three changes:
- Report `dlerror` on a failed `dlopen` call.
- Update findAEC.cmake to be consistent with `eccodes`' findAEC.cmake. This searches more paths, and also looks for libaec.h rather than libsz.h
- Add AEC to the CI dependencies so that it uses a recent AEC, rather than whatever happens to be on the runners' systems.

Context:
Downstream dependency `gribjump` generates a plugin that depends on libaec/1.1.1 which is not backwards compatible. However, if eckit is linked against the system AEC (which is generally quite old), this old AEC will be loaded before the AEC gribjump is linked against. As such, whenever eckit loads the gribjump plugin at runtime, there is a missing symbol error. 

This PR updates the CI to build AEC from source, and updates the findAEC search path to find it. We also now throw an error in `loadPlugin` if `loadDynamicLibrary` returns nullptr. Without this, an incorrect error message is thrown instead (plugin object not registered).