### PR TITLE
Fixes StringContent::compareString issue on aarch64 arch

### DIFF
--- a/src/eckit/value/StringContent.cc
+++ b/src/eckit/value/StringContent.cc
@@ -66,7 +66,7 @@ int StringContent::compare(const Content& other) const {
 }
 
 int StringContent::compareString(const StringContent& other) const {
-    return ::strcmp(value_.c_str(), other.value_.c_str());
+    return value_.compare(other.value_);
 }
 
 void StringContent::value(std::string& s) const {


### PR DESCRIPTION
`strcmp` (called in StringContent::compareString method) returns wrong results on aarch64