### PR TITLE
Replaces magic numbers with compile-time variables

### DIFF
--- a/src/eckit/log/RotationTarget.cc
+++ b/src/eckit/log/RotationTarget.cc
@@ -65,7 +65,7 @@ private:
 
     std::ostream& rotout() {
 
-        time_t now = ::time(nullptr) / 86400;
+        time_t now = ::time(nullptr) / Time::secondsInDay;
 
         if (now != lastTime_ || last_ == nullptr) {
 

--- a/src/eckit/types/Time.h
+++ b/src/eckit/types/Time.h
@@ -16,6 +16,8 @@
 #ifndef eckit_Time_h
 #define eckit_Time_h
 
+#include <cstdint>
+
 #include "eckit/exception/Exceptions.h"
 #include "eckit/persist/Bless.h"
 
@@ -32,10 +34,10 @@ using Second = double;
 class Time {
 
 public: // types
-    static constexpr Second secondsInMinute = 60;
-    static constexpr Second secondsInHour   = 60 * secondsInMinute;  // 3600
-    static constexpr Second secondsInDay    = 24 * secondsInHour;    // 86400
-    static constexpr Second secondsInWeek   = 7 * secondsInDay;      // 604800
+    static constexpr std::uint64_t secondsInMinute = 60;
+    static constexpr std::uint64_t secondsInHour   = 60 * secondsInMinute;  // 3600
+    static constexpr std::uint64_t secondsInDay    = 24 * secondsInHour;    // 86400
+    static constexpr std::uint64_t secondsInWeek   = 7 * secondsInDay;      // 604800
 
 public:  // methods
     Time(long hours, long minutes, long seconds, bool extended = false);

--- a/src/eckit/types/Time.h
+++ b/src/eckit/types/Time.h
@@ -31,6 +31,12 @@ using Second = double;
 
 class Time {
 
+public: // types
+    static constexpr double secondsInMinute = 60;
+    static constexpr double secondsInHour   = 60 * secondsInMinute;  // 3600
+    static constexpr double secondsInDay    = 24 * secondsInHour;    // 86400
+    static constexpr double secondsInWeek   = 7 * secondsInDay;      // 604800
+
 public:  // methods
     Time(long hours, long minutes, long seconds, bool extended = false);
     Time(long seconds = 0, bool extended = false);

--- a/src/eckit/types/Time.h
+++ b/src/eckit/types/Time.h
@@ -32,10 +32,10 @@ using Second = double;
 class Time {
 
 public: // types
-    static constexpr double secondsInMinute = 60;
-    static constexpr double secondsInHour   = 60 * secondsInMinute;  // 3600
-    static constexpr double secondsInDay    = 24 * secondsInHour;    // 86400
-    static constexpr double secondsInWeek   = 7 * secondsInDay;      // 604800
+    static constexpr Second secondsInMinute = 60;
+    static constexpr Second secondsInHour   = 60 * secondsInMinute;  // 3600
+    static constexpr Second secondsInDay    = 24 * secondsInHour;    // 86400
+    static constexpr Second secondsInWeek   = 7 * secondsInDay;      // 604800
 
 public:  // methods
     Time(long hours, long minutes, long seconds, bool extended = false);


### PR DESCRIPTION
example: seconds in a day would be `eckit::Time::secondsInDay` instead of `86400`