### PR TITLE
Python wheel: add curl and proj dependencies

### DIFF
--- a/python_wrapper/buildconfig
+++ b/python_wrapper/buildconfig
@@ -11,6 +11,6 @@
 # TODO we duplicate information -- pyproject.toml's `name` and `packages` are derivable from $NAME and must stay consistent
 
 NAME="eckit"
-CMAKE_PARAMS="-DENABLE_MPI=0  -DENABLE_ECKIT_GEO=1 -DENABLE_BUILD_TOOLS=OFF"
+CMAKE_PARAMS="-DENABLE_MPI=0  -DENABLE_ECKIT_GEO=1 -DENABLE_BUILD_TOOLS=OFF -DENABLE_CURL=ON -DCURL_ROOT=/tmp/curl"
 PYPROJECT_DIR="python_wrapper"
 DEPENDENCIES='[]'

--- a/python_wrapper/buildconfig
+++ b/python_wrapper/buildconfig
@@ -11,6 +11,6 @@
 # TODO we duplicate information -- pyproject.toml's `name` and `packages` are derivable from $NAME and must stay consistent
 
 NAME="eckit"
-CMAKE_PARAMS="-DENABLE_MPI=0  -DENABLE_ECKIT_GEO=1 -DENABLE_BUILD_TOOLS=OFF -DENABLE_CURL=ON -DCURL_ROOT=/tmp/curl"
+CMAKE_PARAMS="-DENABLE_MPI=0  -DENABLE_ECKIT_GEO=1 -DENABLE_BUILD_TOOLS=OFF -DENABLE_CURL=ON -DENABLE_PROJ=ON -DPROJ_ROOT=/tmp/proj"
 PYPROJECT_DIR="python_wrapper"
 DEPENDENCIES='[]'

--- a/python_wrapper/post-build.sh
+++ b/python_wrapper/post-build.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# NOTE in case of problems like we had with eccodes, replace with noop here
+if [ "$(uname)" != "Darwin" ] ; then
+    auditwheel repair -w /tmp/eckit/auditwheel /tmp/eckit/build/wheel/*whl
+    rm /tmp/eckit/build/wheel/*
+    mv /tmp/eckit/auditwheel/* /tmp/eckit/build/wheel
+fi
+
+# NOTE on macos we delocate with impunity, because the findlibs recursive depload
+# is disabled anyway
+if [ "$(uname)" = "Darwin" ] ; then
+    delocate-wheel /tmp/eccodes/build/wheel/*whl
+fi

--- a/python_wrapper/pre-compile.sh
+++ b/python_wrapper/pre-compile.sh
@@ -20,20 +20,27 @@ mkdir -p /tmp/eckit/target/eckit/lib64/
 if [ "$(uname)" != "Darwin" ] ; then
     echo "installing deps for platform $(uname)"
 
-    ## yum-available prereqs
-    yum install -y libpsl-devel openssl-devel 
+    ## curl -- handled by docker container being built with:
+    # dnf instal -y libpsl-devel openssl-devel curl-devel
+    ## this below if the build would need a customization:
+    # git clone https://github.com/curl/curl /src/curl
+    # cd /src/curl
+    # autoreconf -fi
+    # ./configure --prefix /tmp/curl --with-openssl
+    # make -j10 && make install
+    # cd -
 
-    ## curl
-    git clone https://github.com/curl/curl /src/curl
-    cd /src/curl
-    autoreconf -fi
-    ./configure --prefix /tmp/curl --with-openssl
-    make -j10 && make install
+    ## proj
+    git clone https://github.com/OSGeo/PROJ /src/proj
+    mkdir /src/proj/build && cd /src/proj/build
+    cmake .. -DCMAKE_INSTALL_PREFIX=/tmp/proj
+    cmake --build . -j8
+    cmake --build . --target install
     cd -
 
     # NOTE we will use auditwheel in post-compile. But in case of problems like we had with eccodes, introduce the libcopies here
 else
-    # TODO check macos agent has curl
+    # TODO check macos agent has curl and proj
     echo "no deps installation for platform $(uname)"
 fi
 
@@ -41,6 +48,7 @@ wget https://raw.githubusercontent.com/rockdaboot/libpsl/master/LICENSE -O pytho
 wget https://raw.githubusercontent.com/openssl/openssl/master/LICENSE.txt -O python_wrapper/src/copying/libssl.txt
 wget https://raw.githubusercontent.com/gnosis/libunistring/master/COPYING -O python_wrapper/src/copying/libunistring.txt
 wget https://raw.githubusercontent.com/libidn/libidn2/master/COPYINGv2 -O python_wrapper/src/copying/libidn2.txt
-cp /src/curl/COPYING python_wrapper/src/copying/libcurl.COPYING
-cp -R /src/curl/LICENSES python_wrapper/src/copying/libcurl
-echo '{"libpsl": {"path": "copying/libpsl.txt", "home": "https://github.com/rockdaboot/libpsl"}, "libssl": {"path": "copying/libssl.txt", "home": "https://github.com/openssl/openssl"}, "libcrypto": {"path": "copying/libssl.txt", "home": "https://github.com/openssl/openssl"}, "libunistring": {"path": "copying/libunistring.txt", "home": "https://github.com/gnosis/libunistring/"}, "libidn2": {"path": "copying/libidn2.txt", "home": "https://github.com/libidn/libidn2"}, "libcurl": {"path": "copying/liburl.COPYING", "home": "https://github.com/curl/curl"}}' > python_wrapper/src/copying/list.json
+wget https://raw.githubusercontent.com/curl/curl/master/COPYING -O python_wrapper/src/copying/libcurl.COPYING
+wget https://raw.githubusercontent.com/curl/curl/master/LICENSES -O python_wrapper/src/copying/libcurl
+wget https://raw.githubusercontent.com/OSGeo/PROJ/master/COPYING -O python_wrapper/src/copying/libproj.txt
+echo '{"libpsl": {"path": "copying/libpsl.txt", "home": "https://github.com/rockdaboot/libpsl"}, "libssl": {"path": "copying/libssl.txt", "home": "https://github.com/openssl/openssl"}, "libcrypto": {"path": "copying/libssl.txt", "home": "https://github.com/openssl/openssl"}, "libunistring": {"path": "copying/libunistring.txt", "home": "https://github.com/gnosis/libunistring/"}, "libidn2": {"path": "copying/libidn2.txt", "home": "https://github.com/libidn/libidn2"}, "libcurl": {"path": "copying/liburl.COPYING", "home": "https://github.com/curl/curl"}, "libproj": {"path": "copying/libproj.txt", "home": "https://github.com/OSGeo/PROJ"}}' > python_wrapper/src/copying/list.json

--- a/python_wrapper/pre-compile.sh
+++ b/python_wrapper/pre-compile.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+# the procedure for adding a new ext dependency to be bundled in here:
+# - add git checkout, compile, etc
+# - ensure the version ends up in python_wrapper/src/versions.txt
+# - ensure the licence ends up in python_wrapper/src/copying/, and fname is referenced in copying/list.json
+# - ensure the .so ends up in target/lib64/ with the expected libname
+# - validate that the resulting wheel contains all the above
+# additionally, make sure this script is aligned with /buildscripts/compile.sh and /buildscripts/wheel-linux.sh,
+# in particular when it comes to install targets and package data, etc
+
+# note also that for macos, we assume that the agent has the libraries already installed, as we can't run this in docker
+# we thus only prepare the license files
+
+set -euo pipefail
+
+mkdir -p python_wrapper/src/copying
+mkdir -p /tmp/eckit/target/eckit/lib64/
+
+if [ "$(uname)" != "Darwin" ] ; then
+    echo "installing deps for platform $(uname)"
+
+    ## yum-available prereqs
+    yum install -y libpsl-devel openssl-devel 
+
+    ## curl
+    git clone https://github.com/curl/curl /src/curl
+    cd /src/curl
+    autoreconf -fi
+    ./configure --prefix /tmp/curl --with-openssl
+    make -j10 && make install
+    cd -
+
+    # NOTE we will use auditwheel in post-compile. But in case of problems like we had with eccodes, introduce the libcopies here
+else
+    # TODO check macos agent has curl
+    echo "no deps installation for platform $(uname)"
+fi
+
+wget https://raw.githubusercontent.com/rockdaboot/libpsl/master/LICENSE -O python_wrapper/src/copying/libpsl.txt
+wget https://raw.githubusercontent.com/openssl/openssl/master/LICENSE.txt -O python_wrapper/src/copying/libssl.txt
+wget https://raw.githubusercontent.com/gnosis/libunistring/master/COPYING -O python_wrapper/src/copying/libunistring.txt
+wget https://raw.githubusercontent.com/libidn/libidn2/master/COPYINGv2 -O python_wrapper/src/copying/libidn2.txt
+cp /src/curl/COPYING python_wrapper/src/copying/libcurl.COPYING
+cp -R /src/curl/LICENSES python_wrapper/src/copying/libcurl
+echo '{"libpsl": {"path": "copying/libpsl.txt", "home": "https://github.com/rockdaboot/libpsl"}, "libssl": {"path": "copying/libssl.txt", "home": "https://github.com/openssl/openssl"}, "libcrypto": {"path": "copying/libssl.txt", "home": "https://github.com/openssl/openssl"}, "libunistring": {"path": "copying/libunistring.txt", "home": "https://github.com/gnosis/libunistring/"}, "libidn2": {"path": "copying/libidn2.txt", "home": "https://github.com/libidn/libidn2"}, "libcurl": {"path": "copying/liburl.COPYING", "home": "https://github.com/curl/curl"}}' > python_wrapper/src/copying/list.json


### PR DESCRIPTION
Adding `libcurl` as a dependency for eckit, consists of:
 - yum installing prerequisite libraries (ssl, psl)
 - cloning and building curl (with openssl)
 - adding eckit cmake params
 - including bundled licenses in the wheel
 - calling auditwheel at the end to bundle all libs in (note: we may change this later to manually bundling in, as we had to do with eccodes)


NOTE: the base is not `devel` but `fix/condDeclare` since this one is conditional on it