### PR TITLE
Python Wrapper Wheel: no Eigen

### DIFF
--- a/python_wrapper/buildconfig
+++ b/python_wrapper/buildconfig
@@ -11,6 +11,6 @@
 # TODO we duplicate information -- pyproject.toml's `name` and `packages` are derivable from $NAME and must stay consistent
 
 NAME="eckit"
-CMAKE_PARAMS="-DENABLE_MPI=0  -DENABLE_ECKIT_GEO=1 -DENABLE_BUILD_TOOLS=OFF -DENABLE_AEC=0"
+CMAKE_PARAMS="-DENABLE_MPI=0  -DENABLE_ECKIT_GEO=1 -DENABLE_BUILD_TOOLS=OFF -DENABLE_AEC=0 -DENABLE_EIGEN=0"
 PYPROJECT_DIR="python_wrapper"
 DEPENDENCIES='[]'


### PR DESCRIPTION
Disabling Eigen in python wrapper wheel. Our MacOS builder agents do have it -> it sneaks in by default, which is undesirable