### PR TITLE
Exception no longer prints to log it set to quiet.

### DIFF
--- a/src/eckit/exception/Exceptions.cc
+++ b/src/eckit/exception/Exceptions.cc
@@ -83,19 +83,7 @@ Exception::Exception(const std::string& w, const CodeLocation& location, bool qu
         Log::error() << "Exception: " << w << " " << location_ << std::endl;
     }
 
-#if 0
-    if (next_) {
-        Log::error() << "Exception: stack containts " << next_->what() << std::endl;
-    }
-    else
-    {
-        Log::error() << "Exception: stack is empty" << std::endl;
-    }
-#endif
-
     first() = this;
-
-    Log::status() << "** " << w << location_ << std::endl;
 }
 
 void Exception::dumpStackTrace(std::ostream& out) {

--- a/src/eckit/exception/Exceptions.cc
+++ b/src/eckit/exception/Exceptions.cc
@@ -81,6 +81,7 @@ Exception::Exception(const std::string& w, const CodeLocation& location, bool qu
 
     if (!::getenv("ECKIT_EXCEPTION_IS_SILENT") && !quiet) {
         Log::error() << "Exception: " << w << " " << location_ << std::endl;
+        Log::status() << "** " << w << location_ << std::endl;
     }
 
     first() = this;


### PR DESCRIPTION
Exception constructor now respects quiet flag and env variable ECKIT_EXCEPTION_IS_SILENT and no longer logs if any is set.

Fixes: FDB-405