### PR TITLE
Workaround for SIGSEGV during MPI_Finalize after main() with CUDA-aware MPI

### DIFF
--- a/src/eckit/mpi/Comm.cc
+++ b/src/eckit/mpi/Comm.cc
@@ -125,6 +125,7 @@ public:
             delete itr->second;
         }
         communicators.clear();
+        default_ = nullptr;
     }
 
     Comm& getComm(std::string_view name = {}) {
@@ -203,17 +204,13 @@ public:
     }
 
 
-    Environment() :
-        default_(nullptr) {}
+    Environment() = default;
 
     ~Environment() {
-        AutoLock<Mutex> lock(mutex_);
-
         finaliseAllComms();
-        default_ = nullptr;
     }
 
-    Comm* default_;
+    Comm* default_{nullptr};
 
     std::map<std::string, Comm*, std::less<>> communicators;
 


### PR DESCRIPTION
### The problem:

With some MPI implementations a SIGSEGV occurs during `MPI_Finalize()` when invoked after `main()` ends. This is the standard way that `eckit::mpi` operates as the registration of MPI communicators is stored in a global static registry that is destroyed after `main()`.

Consider following C++ program using `eckit::mpi` :
```c++
#include <iostream>
#include "eckit/mpi/Comm.h"
#include "eckit/runtime/Main.h"

int main(int argc, char* argv[]) {
  std::cerr << "------ start of main ------" << std::endl;
  eckit::Main::initialise(argc,argv);

  // MPI gets automatically initialized on first use
  int mpi_size = eckit::mpi::comm().size();

  // eckit::mpi::finaliseAllComms();
  // --> Uncommenting this avoids the problem but is generally not used.

  std::cerr << "------ end of main ------" << std::endl;
  return 0;
}
```
- eckit is compiled with the MPI feature enabled
- openmpi is used with CUDA-aware features to enable direct GPU-to-GPU transfer. On our HPC this environment is used to compile and run eckit and the program:
    ```bash
    module load purge
    module load cmake/3.28
    module load prgenv/nvidia
    module load nvidia/22.11
    module load hpcx-openmpi/2.14.0-cuda
    ```
- The program above is launched with `srun -n 1 --gpus-per-task=1 -q ng <program>` to give it access to a GPU resource.

This leads to following crash with output:
```
----- start of main ------
------ end of main ------
[ac6-300:1751655:0:1751655] Caught signal 11 (Segmentation fault: address not mapped to object at address 0x400000002e0)
==== backtrace (tid:1751655) ====
 0 0x000000000004eb50 killpg()  ???:0
 1 0x00000000000cbe67 __strlen_avx2()  :0
 2 0x000000000006884d _IO_vfprintf_internal()  :0
 3 0x000000000008ef74 _IO_vsnprintf()  :0
 4 0x0000000000008f41 uct_cuda_copy_iface_t_cleanup()  /build-result/src/hpcx-v2.14-gcc-MLNX_OFED_LINUX-5-redhat8-cuda11-gdrcopy2-nccl2.16-x86_64/ucx-5e8621f95002cf2ad7135987c2a7dc32d4fc72fb/src/uct/cuda/cuda_copy/cuda_copy_iface.c:469
 5 0x000000000006f916 ucs_class_call_cleanup_chain()  /build-result/src/hpcx-v2.14-gcc-MLNX_OFED_LINUX-5-redhat8-cuda11-gdrcopy2-nccl2.16-x86_64/ucx-5e8621f95002cf2ad7135987c2a7dc32d4fc72fb/src/ucs/type/class.c:56
 6 0x00000000000090c8 uct_cuda_copy_iface_t_delete()  /build-result/src/hpcx-v2.14-gcc-MLNX_OFED_LINUX-5-redhat8-cuda11-gdrcopy2-nccl2.16-x86_64/ucx-5e8621f95002cf2ad7135987c2a7dc32d4fc72fb/src/uct/cuda/cuda_copy/cuda_copy_iface.c:500
 7 0x000000000004a0df ucp_worker_uct_iface_close()  /build-result/src/hpcx-v2.14-gcc-MLNX_OFED_LINUX-5-redhat8-cuda11-gdrcopy2-nccl2.16-x86_64/ucx-5e8621f95002cf2ad7135987c2a7dc32d4fc72fb/src/ucp/core/ucp_worker.c:801
 8 0x000000000004a0df ucp_worker_iface_cleanup()  /build-result/src/hpcx-v2.14-gcc-MLNX_OFED_LINUX-5-redhat8-cuda11-gdrcopy2-nccl2.16-x86_64/ucx-5e8621f95002cf2ad7135987c2a7dc32d4fc72fb/src/ucp/core/ucp_worker.c:1416
 9 0x0000000000049761 ucp_worker_close_ifaces()  /build-result/src/hpcx-v2.14-gcc-MLNX_OFED_LINUX-5-redhat8-cuda11-gdrcopy2-nccl2.16-x86_64/ucx-5e8621f95002cf2ad7135987c2a7dc32d4fc72fb/src/ucp/core/ucp_worker.c:1171
10 0x000000000004e6e9 ucp_worker_destroy()  /build-result/src/hpcx-v2.14-gcc-MLNX_OFED_LINUX-5-redhat8-cuda11-gdrcopy2-nccl2.16-x86_64/ucx-5e8621f95002cf2ad7135987c2a7dc32d4fc72fb/src/ucp/core/ucp_worker.c:2696
11 0x0000000000006adb mca_pml_ucx_cleanup()  /usr/local/apps/hpcx-openmpi/2.14.0-cuda/NVIDIA/22.11/sources/openmpi-gitclone/ompi/mca/pml/ucx/pml_ucx.c:390
12 0x0000000000053804 ompi_mpi_finalize()  /usr/local/apps/hpcx-openmpi/2.14.0-cuda/NVIDIA/22.11/sources/openmpi-gitclone/ompi/runtime/ompi_mpi_finalize.c:342
13 0x000000000003273d eckit::mpi::Parallel::~Parallel()  /perm/nawd/atlas-bundle-gpu/source/eckit/src/eckit/mpi/Parallel.cc:309
14 0x000000000003280e eckit::mpi::Parallel::~Parallel()  ???:0
15 0x0000000000025472 eckit::mpi::Environment::finaliseAllComms()  /perm/nawd/atlas-bundle-gpu/source/eckit/src/eckit/mpi/Comm.cc:125
16 0x0000000000026892 eckit::mpi::Environment::~Environment()  /perm/nawd/atlas-bundle-gpu/source/eckit/src/eckit/mpi/Comm.cc:210
17 0x000000000005126c __run_exit_handlers()  :0
18 0x00000000000513a0 __GI_exit()  :0
19 0x000000000003ad8c __libc_start_main()  ???:0
20 0x000000000040095e _start()  ???:0
=================================
[ac6-300:1751655] *** Process received signal ***
[ac6-300:1751655] Signal: Segmentation fault (11)
[ac6-300:1751655] Signal code:  (-6)
[ac6-300:1751655] Failing at address: 0xe35001aba67
[ac6-300:1751655] [ 0] /lib64/libc.so.6(+0x4eb50)[0x14f9b465fb50]
[ac6-300:1751655] [ 1] /lib64/libc.so.6(+0xcbe67)[0x14f9b46dce67]
[ac6-300:1751655] [ 2] /lib64/libc.so.6(_IO_vfprintf+0x1e6d)[0x14f9b467984d]
[ac6-300:1751655] [ 3] /lib64/libc.so.6(vsnprintf+0x94)[0x14f9b469ff74]
[ac6-300:1751655] [ 4] /usr/local/apps/hpcx-openmpi/2.14.0-cuda/NVIDIA/22.11/ucx/mt/lib/libucs.so.0(ucs_log_default_handler+0x16f)[0x14f96078e10f]
[ac6-300:1751655] [ 5] /usr/local/apps/hpcx-openmpi/2.14.0-cuda/NVIDIA/22.11/ucx/mt/lib/libucs.so.0(ucs_log_dispatch+0xcc)[0x14f96078f22c]
[ac6-300:1751655] [ 6] /usr/local/apps/hpcx-openmpi/2.14.0-cuda/NVIDIA/22.11/ucx/mt/lib/ucx/libuct_cuda.so.0(+0x8f41)[0x14f9b5c05f41]
[ac6-300:1751655] [ 7] /usr/local/apps/hpcx-openmpi/2.14.0-cuda/NVIDIA/22.11/ucx/mt/lib/libucs.so.0(ucs_class_call_cleanup_chain+0x66)[0x14f9607a0916]
[ac6-300:1751655] [ 8] /usr/local/apps/hpcx-openmpi/2.14.0-cuda/NVIDIA/22.11/ucx/mt/lib/ucx/libuct_cuda.so.0(+0x90c8)[0x14f9b5c060c8]
[ac6-300:1751655] [ 9] /usr/local/apps/hpcx-openmpi/2.14.0-cuda/NVIDIA/22.11/ucx/mt/lib/libucp.so.0(ucp_worker_iface_cleanup+0x7f)[0x14f9b5d230df]
[ac6-300:1751655] [10] /usr/local/apps/hpcx-openmpi/2.14.0-cuda/NVIDIA/22.11/ucx/mt/lib/libucp.so.0(+0x49761)[0x14f9b5d22761]
[ac6-300:1751655] [11] /usr/local/apps/hpcx-openmpi/2.14.0-cuda/NVIDIA/22.11/ucx/mt/lib/libucp.so.0(ucp_worker_destroy+0x239)[0x14f9b5d276e9]
[ac6-300:1751655] [12] /usr/local/apps/hpcx-openmpi/2.14.0-cuda/NVIDIA/22.11/ec-hpcx-ompi/lib/openmpi/mca_pml_ucx.so(mca_pml_ucx_cleanup+0x17b)[0x14f955bcaadb]
[ac6-300:1751655] [13] /usr/local/apps/hpcx-openmpi/2.14.0-cuda/NVIDIA/22.11/ec-hpcx-ompi/lib/libmpi.so.40(ompi_mpi_finalize+0x564)[0x14f9b4337804]
[ac6-300:1751655] [14] lib/libeckit_mpi.so(_ZN5eckit3mpi8ParallelD1Ev+0xfd)[0x14f9b59a573d]
[ac6-300:1751655] [15] lib/libeckit_mpi.so(_ZN5eckit3mpi8ParallelD0Ev+0xe)[0x14f9b59a580e]
[ac6-300:1751655] [16] lib/libeckit_mpi.so(_ZN5eckit3mpi11Environment16finaliseAllCommsEv+0x72)[0x14f9b5998472]
[ac6-300:1751655] [17] lib/libeckit_mpi.so(_ZN5eckit3mpi11EnvironmentD1Ev+0x12)[0x14f9b5999892]
[ac6-300:1751655] [18] /lib64/libc.so.6(+0x5126c)[0x14f9b466226c]
[ac6-300:1751655] [19] /lib64/libc.so.6(on_exit+0x0)[0x14f9b46623a0]
[ac6-300:1751655] [20] /lib64/libc.so.6(__libc_start_main+0xec)[0x14f9b464bd8c]
[ac6-300:1751655] [21] /etc/ecmwf/nfs/dh1_2_perm_a/nawd/atlas-bundle-gpu/build-nvidia-native-cuda/./a.out[0x40095e]
[ac6-300:1751655] *** End of error message ***
srun: error: ac6-300: task 0: Segmentation fault
srun: Terminating StepId=35442991.0
```

### Proposed possible solution in this PR

In this PR I propose to ignore the SEGV signal as it is during teardown anyway in a third-party library. This is done via a signal handler that uses `setjmp` and `longjmp`.
This is only to be active when following environment variable is set:
```bash
export ECKIT_MPI_WORKAROUND_SEGV_AT_EXIT=1
```

I tried another solution, to register `eckit::mpi::finaliseAllComms()` with `std::atexit` or `std::at_quick_exit` but in both cases it seems that the calls to `atexit` are happening *after* this crash is happening so that it's not a working solution.