### PR TITLE
Python wheel: switch to migrated action repo

### DIFF
--- a/.github/workflows/build-wheel-wrapper.yml
+++ b/.github/workflows/build-wheel-wrapper.yml
@@ -21,5 +21,5 @@ on:
 jobs:
   python-wrapper-wheel:
     name: Python Wrapper Wheel
-    uses: ecmwf-actions/reusable-workflows/.github/workflows/python-wrapper-wheel.yml@main
+    uses: ecmwf/reusable-workflows/.github/workflows/python-wrapper-wheel.yml@main
     secrets: inherit


### PR DESCRIPTION
This is actually important, because the original action is not updated anymore and thus fails