### PR TITLE
Add IEC multi-byte unit literals

### DIFF
--- a/src/eckit/utils/Literals.h
+++ b/src/eckit/utils/Literals.h
@@ -1,0 +1,52 @@
+/*
+ * (C) Copyright 2025- ECMWF.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation nor
+ * does it submit to any jurisdiction.
+ */
+#pragma once
+
+#include <cstdint>
+
+/// Eckit literals provides user defined literals for IEC multi-byte units.
+/// To make these literals available to your code use `using namespace eckit::literals`
+/// Usage example:
+/// ```
+/// using namespace eckit::literals;
+/// const auto bufferSize = 3_MiB;
+/// ```
+namespace eckit::literals {
+
+/// Literal to express Kibibyte
+constexpr std::uint64_t operator""_KiB(unsigned long long int x) {
+    return 1024ULL * x;
+}
+
+/// Literal to express Mebibyte
+constexpr std::uint64_t operator""_MiB(unsigned long long int x) {
+    return 1024_KiB * x;
+}
+
+/// Literal to express Gibibyte
+constexpr std::uint64_t operator""_GiB(unsigned long long int x) {
+    return 1024_MiB * x;
+}
+
+/// Literal to express Tebibyte
+constexpr std::uint64_t operator""_TiB(unsigned long long int x) {
+    return 1024_GiB * x;
+}
+
+/// Literal to express Pebibyte
+constexpr std::uint64_t operator""_PiB(unsigned long long int x) {
+    return 1024_TiB * x;
+}
+
+/// Literal to express Exbibyte
+constexpr std::uint64_t operator""_EiB(unsigned long long int x) {
+    return 1024_PiB * x;
+}
+}  // namespace eckit::literals

--- a/tests/utils/CMakeLists.txt
+++ b/tests/utils/CMakeLists.txt
@@ -70,3 +70,7 @@ ecbuild_add_test( TARGET      eckit_test_rsync
 ecbuild_add_test( TARGET      eckit_test_regex
                   SOURCES     test_regex.cc
                   LIBS        eckit )
+
+ecbuild_add_test( TARGET      eckit_test_literals
+                  SOURCES     test_literals.cc
+                  LIBS        eckit )

--- a/tests/utils/test_literals.cc
+++ b/tests/utils/test_literals.cc
@@ -1,0 +1,32 @@
+/*
+ * (C) Copyright 2025- ECMWF.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation nor
+ * does it submit to any jurisdiction.
+ */
+
+#include "eckit/utils/Literals.h"
+
+#include "eckit/testing/Test.h"
+
+using namespace eckit::literals;
+using namespace eckit::testing;
+
+namespace eckit::test {
+
+CASE("size literals") {
+    EXPECT_EQUAL(1_KiB, 1ULL << 10);
+    EXPECT_EQUAL(1_MiB, 1ULL << 20);
+    EXPECT_EQUAL(1_GiB, 1ULL << 30);
+    EXPECT_EQUAL(1_TiB, 1ULL << 40);
+    EXPECT_EQUAL(1_PiB, 1ULL << 50);
+    EXPECT_EQUAL(1_EiB, 1ULL << 60);
+}
+}  // namespace eckit::test
+
+int main(int argc, char* argv[]) {
+    return run_tests(argc, argv);
+}


### PR DESCRIPTION
Add user defined literals for all 64bit representable power of 2 multi byte units. KiB, MiB, GiB, TiB, PiB and EiB.

Literals are made availabe by including 'utils/Literals.h' and declaring 'using namespace eckit::literals'

Example:

    #include <eckit/utils/Literals.h>
    using namespace eckit::literals;
    const auto bufferSize = 3_KiB;