### PR TITLE
Add .git-blame-ignore-revs

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,11 @@
+# The following refs can be ignored by git blame if 'git blame' is called with
+# --ignore-revs-file .git-blame-ignore-revs
+# Alternatively configure git to always ignore refs stored in this file by
+# calling:
+#   git config blame.ignoreRevsFile .git-blame-ignore-revs
+# Or extend your git config manually with
+# [blame]
+#    ignoreRevsFile = .git-blame-ignore-revs
+
+# Reformatted codebase with clang-format
+2b05a8023ff3b4aef2d6047a0ab38ac38d9de026


### PR DESCRIPTION
'git blame' can be configured to ignore specific commits such as reformatting the codebase with clang format.

We track the commits we want to be ignored in .git-blame-ignore-revs.

You can use git blame from the cli with:
    git blame --ignore-revs-file .git-blame-ignore-revs <FILE>

Or you configure your git config to always use .git-blame-ignore-revs by setting:
    git config blame.ignoreRevsFile .git-blame-ignore-revs

Or extending your gitconfig with:

[blame]
    ignoreRevsFile = .git-blame-ignore-revs

Note that .git-blame-ignore-revs is recognized by GitHub.