### PR TITLE
Remove nested SECTION in test_polygon.cc (reported in #71)

### DIFF
--- a/tests/geometry/test_polygon.cc
+++ b/tests/geometry/test_polygon.cc
@@ -238,7 +238,8 @@ CASE("LonLatPolygon") {
 
         Polygon poly({{lonmin, latmax}, {lonmax, latmax}, {lonmax, latmin}, {lonmin, latmin}, {lonmin, latmax}});
 
-        SECTION("Contains edges") {
+        // SUBSECTION: Contains edges
+        {
             EXPECT(poly.contains({lonmin, latmax}));
             EXPECT(poly.contains({lonmid, latmax}));
             EXPECT(poly.contains({lonmax, latmax}));
@@ -249,7 +250,8 @@ CASE("LonLatPolygon") {
             EXPECT(poly.contains({lonmin, latmid}));
         }
 
-        SECTION("Contains in/outward of edges") {
+        // SUBSECTION: "Contains in/outward of edges"
+        {
             constexpr auto eps = 0.001;
 
             for (size_t i = 0; i <= 100; ++i) {

--- a/tests/geometry/test_polygon.cc
+++ b/tests/geometry/test_polygon.cc
@@ -255,17 +255,17 @@ CASE("LonLatPolygon") {
             constexpr auto eps = 0.001;
 
             for (size_t i = 0; i <= 100; ++i) {
-                const auto lon = lonmin + static_cast<double>(i) * (lonmax - lonmin) / 99.;
+                const auto lon = lonmin + static_cast<double>(i) * (lonmax - lonmin) / 100.;
                 EXPECT(poly.contains({lon, latmin + eps}));
                 EXPECT(poly.contains({lon, latmax - eps}));
                 EXPECT_NOT(poly.contains({lon, latmin - eps}));
                 EXPECT_NOT(poly.contains({lon, latmax + eps}));
 
-                const auto lat = latmin + static_cast<double>(i) * (latmax - latmin) / 99.;
+                const auto lat = latmin + static_cast<double>(i) * (latmax - latmin) / 100.;
                 EXPECT(poly.contains({lonmin + eps, lat}));
                 EXPECT(poly.contains({lonmax - eps, lat}));
-                EXPECT_NOT(poly.contains({lonmin - eps, lat}));
-                EXPECT_NOT(poly.contains({lonmax + eps, lat}));
+                EXPECT(poly.contains({lonmin - eps, lat}));  // periodic
+                EXPECT(poly.contains({lonmax + eps, lat}));  // ...
             }
         }
 


### PR DESCRIPTION
This PR attempts to address issue #71 .
Nested SECTION scopes in `eckit_test_geometry_polygon` unit test were simply ignored.
By fixing this, it exposes that the unit-test was actually faulty with failed `EXPECT`.

Therefore this PR is currently failing and should be fixed further.
@pmaciel if you don't mind I took the liberty to assign you to see how to fix the failing `EXPECT` as this test is in your expertise and development.