### PR TITLE
Modernise exceptions

### DIFF
--- a/src/eckit/exception/Exceptions.cc
+++ b/src/eckit/exception/Exceptions.cc
@@ -64,14 +64,15 @@ void Exception::exceptionStack(std::ostream& out, bool callStack) {
     out << "End stack" << std::endl;
 }
 
-Exception::Exception(const std::string& w, const CodeLocation& loc) : what_(w), next_(first()), location_(loc) {
+Exception::Exception(const std::string& w, const CodeLocation& loc, bool quiet) :
+    what_(w), next_(first()), location_(loc) {
     callStack_ = BackTrace::dump();
 
     if (ECKIT_EXCEPTION_DUMPS_BACKTRACE) {
         std::cerr << "Exception dumping backtrace: " << callStack_ << std::endl;
     }
 
-    if (!ECKIT_EXCEPTION_IS_SILENT) {
+    if (!ECKIT_EXCEPTION_IS_SILENT && !quiet) {
         Log::error() << "Exception: " << w << " " << location_ << std::endl;
         Log::status() << "** " << w << location_ << std::endl;
     }

--- a/src/eckit/exception/Exceptions.cc
+++ b/src/eckit/exception/Exceptions.cc
@@ -127,7 +127,7 @@ void handle_assert(const std::string& msg, const CodeLocation& loc) {
     s << "Assertion failed: " << msg << loc;
 
     if (!ECKIT_ASSERT_FAILED_IS_SILENT) {
-        Log::status() << s.str() << std::endl << std::flush;
+        Log::status() << s.str() << std::endl;
 
         std::cout << s.str() << std::endl << BackTrace::dump() << std::endl << std::flush;
     }

--- a/src/eckit/exception/Exceptions.cc
+++ b/src/eckit/exception/Exceptions.cc
@@ -153,7 +153,7 @@ Cancel::Cancel(const std::string& w, const CodeLocation& loc) : Exception("Cance
 
 Retry::Retry(const std::string& w, const CodeLocation& loc) : Exception("Retry: " + w, loc) {}
 
-UserError::UserError(const std::string& w, const CodeLocation& loc) : Exception("User error: " + w, loc) {}
+UserError::UserError(const std::string& w, const CodeLocation& loc) : Exception("UserError: " + w, loc) {}
 
 UserError::UserError(const std::string& user, const std::string& w, const CodeLocation& loc) :
     UserError(user + " : " + w, loc) {}

--- a/src/eckit/exception/Exceptions.h
+++ b/src/eckit/exception/Exceptions.h
@@ -28,7 +28,7 @@ void handle_panic_no_log(const char*, const CodeLocation& = {});
 void handle_assert(const std::string&, const CodeLocation& = {});
 
 /**
- * @brief General purpose exception, non-copyable and non-movable.
+ * @brief General purpose exception.
  * Derive other exceptions from this class and implement them in the class that throws them.
  */
 class Exception : public std::exception {
@@ -38,16 +38,16 @@ public:
     explicit Exception(const std::string& what, const CodeLocation& = {}, bool quiet = false);
     Exception();
 
-    Exception(const Exception&) = delete;
-    Exception(Exception&&)      = delete;
+    Exception(const Exception&) = default;
+    Exception(Exception&&)      = default;
 
     /// Destructor
     /// @throws nothing
     ~Exception() noexcept override;
 
     /// Operators
-    Exception& operator=(const Exception&) = delete;
-    Exception& operator=(Exception&&)      = delete;
+    Exception& operator=(const Exception&) = default;
+    Exception& operator=(Exception&&)      = default;
 
     const char* what() const noexcept override { return what_.c_str(); }
 

--- a/src/eckit/exception/Exceptions.h
+++ b/src/eckit/exception/Exceptions.h
@@ -23,33 +23,34 @@ namespace eckit {
 
 //----------------------------------------------------------------------------------------------------------------------
 
-void handle_panic(const char*);
-void handle_panic(const char*, const CodeLocation&);
-void handle_panic_no_log(const char*, const CodeLocation&);
+void handle_panic(const char*, const CodeLocation& = {});
+void handle_panic_no_log(const char*, const CodeLocation& = {});
+void handle_assert(const std::string&, const CodeLocation& = {});
 
-void handle_assert(const std::string&, const CodeLocation&);
-
-/// @brief General purpose exception
-/// Derive other exceptions from this class and implement then in the class that throws them.
-
+/**
+ * @brief General purpose exception, non-copyable and non-movable.
+ * Derive other exceptions from this class and implement them in the class that throws them.
+ */
 class Exception : public std::exception {
+public:
 
-public:  // methods
+    /// Constructors
+    explicit Exception(const std::string& what, const CodeLocation& = {});
+    Exception();
 
-    /// Constructor with message
-    Exception(const std::string& what);
-
-    /// Constructor with message and location
-    Exception(const std::string& what, const CodeLocation& location);
-
-    /// Constructor with message location and "quiet" flag
-    Exception(const std::string& what, const CodeLocation& location, bool quiet);
+    Exception(const Exception&) = delete;
+    Exception(Exception&&)      = delete;
 
     /// Destructor
     /// @throws nothing
     ~Exception() noexcept override;
 
+    /// Operators
+    Exception& operator=(const Exception&) = delete;
+    Exception& operator=(Exception&&)      = delete;
+
     const char* what() const noexcept override { return what_.c_str(); }
+
     virtual bool retryOnServer() const { return false; }
     virtual bool retryOnClient() const { return false; }
     virtual bool terminateApplication() const { return false; }
@@ -61,17 +62,15 @@ public:  // methods
 
     const CodeLocation& location() const { return location_; }
 
-    void dumpStackTrace(std::ostream& = std::cout);
+    std::ostream& dumpStackTrace(std::ostream& = std::cout);
 
-protected:  // methods
+protected:
 
     void reason(const std::string&);
 
-    Exception();
-
     virtual void print(std::ostream&) const;
 
-private:  // members
+private:
 
     std::string what_;       ///< description
     std::string callStack_;  ///< call stack
@@ -79,36 +78,30 @@ private:  // members
     Exception* next_;
     CodeLocation location_;  ///< where exception was first thrown
 
-
     friend std::ostream& operator<<(std::ostream& s, const Exception& p) {
         p.print(s);
         return s;
     }
 };
 
-
 //----------------------------------------------------------------------------------------------------------------------
-
 
 class SeriousBug : public Exception {
 public:
 
-    SeriousBug(const std::string& w);
-    SeriousBug(const std::string&, const CodeLocation&);
-    SeriousBug(const char*, const CodeLocation&);
+    explicit SeriousBug(const std::string&, const CodeLocation& = {});
 };
 
 class TooManyRetries : public Exception {
 public:
 
-    TooManyRetries(const int);
-    TooManyRetries(const int, const std::string& msg);
+    explicit TooManyRetries(int, const std::string& msg = "");
 };
 
 class TimeOut : public Exception {
 public:
 
-    TimeOut(const std::string&, const unsigned long);
+    TimeOut(const std::string&, unsigned long);
 };
 
 class FailedLibraryCall : public Exception {
@@ -120,88 +113,77 @@ public:
 class FailedSystemCall : public Exception {
 public:
 
-    FailedSystemCall(const std::string&);
-    FailedSystemCall(const std::string&, const CodeLocation&);
-    FailedSystemCall(const char*, const CodeLocation&, int);
-    FailedSystemCall(const std::string&, const char*, const CodeLocation&, int);
+    FailedSystemCall(const std::string&, const CodeLocation& = {}, int = 0);
 };
 
 class AssertionFailed : public Exception {
 public:
 
-    AssertionFailed(const std::string&);
-    AssertionFailed(const std::string&, const CodeLocation&);
-    AssertionFailed(const char*, const CodeLocation&);
+    explicit AssertionFailed(const std::string&, const CodeLocation& = {});
 };
 
 class BadParameter : public Exception {
 public:
 
-    BadParameter(const std::string& s);
-    BadParameter(const std::string&, const CodeLocation&);
+    explicit BadParameter(const std::string&, const CodeLocation& = {});
 };
 
 class BadCast : public Exception {
 public:
 
-    BadCast(const std::string& s);
-    BadCast(const std::string&, const CodeLocation&);
+    explicit BadCast(const std::string&, const CodeLocation& = {});
 };
 
 class BadValue : public Exception {
 public:
 
-    BadValue(const std::string& s);
-    BadValue(const std::string&, const CodeLocation&);
-};
-
-class NotImplemented : public Exception {
-public:
-
-    explicit NotImplemented(const std::string& s, const CodeLocation& = {});
-    explicit NotImplemented(const CodeLocation&);
+    explicit BadValue(const std::string&, const CodeLocation& = {});
 };
 
 class Stop : public Exception {
 public:
 
-    Stop(const std::string&);
+    explicit Stop(const std::string&, const CodeLocation& = {});
 };
 
 class Abort : public Exception {
 public:
 
-    Abort(const std::string&);
-    Abort(const std::string&, const CodeLocation&);
+    explicit Abort(const std::string&, const CodeLocation& = {});
 };
 
 class Cancel : public Exception {
 public:
 
-    Cancel(const std::string&);
+    explicit Cancel(const std::string&, const CodeLocation& = {});
 };
 
 class Retry : public Exception {
 public:
 
-    Retry(const std::string&);
+    explicit Retry(const std::string&, const CodeLocation& = {});
 };
 
 class UserError : public Exception {
 public:
 
-    UserError(const std::string&, const CodeLocation&);
-    UserError(const std::string&);
-    UserError(const std::string&, const std::string&);
-    UserError(const std::string&, int);
+    explicit UserError(const std::string&, const CodeLocation& = {});
+    UserError(const std::string&, const std::string&, const CodeLocation& = {});
 };
 
 class OutOfRange : public Exception {
 public:
 
-    OutOfRange(const std::string&, const CodeLocation&);
-    OutOfRange(unsigned long long, unsigned long long, const CodeLocation&);
-    OutOfRange(unsigned long long, unsigned long long);
+    explicit OutOfRange(const std::string&, const CodeLocation& = {});
+    OutOfRange(unsigned long long, unsigned long long, const CodeLocation& = {});
+};
+
+//----------------------------------------------------------------------------------------------------------------------
+
+class NotImplemented : public Exception {
+public:
+
+    explicit NotImplemented(const std::string&, const CodeLocation& = {});
 };
 
 /// For compatibility
@@ -220,59 +202,55 @@ public:
 class FileError : public Exception {
 protected:
 
-    FileError(const std::string&);
-    FileError(const std::string&, const CodeLocation&);
-    FileError();
+    FileError(const std::string& file, const CodeLocation&);
+    FileError() = default;
 };
 
 class CantOpenFile : public FileError {
     bool retry_;
-    virtual bool retryOnServer() const { return retry_; }
+    bool retryOnServer() const override { return retry_; }
 
 public:
 
-    CantOpenFile(const std::string&, bool retry = false);
-    CantOpenFile(const std::string&, const CodeLocation&, bool retry = false);
+    explicit CantOpenFile(const std::string& file, bool retry = false, const CodeLocation& = {});
 };
 
 class WriteError : public FileError {
 public:
 
-    WriteError(const std::string&);
-    WriteError(const std::string&, const CodeLocation&);
+    explicit WriteError(const std::string& file, const CodeLocation& = {});
 };
 
 class ReadError : public FileError {
 public:
 
-    ReadError(const std::string&);
-    ReadError(const std::string&, const CodeLocation&);
+    explicit ReadError(const std::string& file, const CodeLocation& = {});
 };
 
 class CloseError : public FileError {
 public:
 
-    CloseError(const std::string&, const CodeLocation&);
+    explicit CloseError(const std::string& file, const CodeLocation& = {});
 };
 
 class ShortFile : public ReadError {
 public:
 
-    ShortFile(const std::string&);
-    ShortFile(const std::string&, const CodeLocation&);
+    explicit ShortFile(const std::string& file, const CodeLocation& = {});
 };
+
+//----------------------------------------------------------------------------------------------------------------------
 
 class RemoteException : public Exception {
 public:
 
-    RemoteException(const std::string& msg, const std::string& from);
+    RemoteException(const std::string&, const std::string& from);
 };
 
 class UnexpectedState : public Exception {
 public:
 
-    UnexpectedState(const std::string& msg);
-    UnexpectedState(const std::string&, const CodeLocation&);
+    explicit UnexpectedState(const std::string&, const CodeLocation& = {});
 };
 
 //----------------------------------------------------------------------------------------------------------------------
@@ -285,40 +263,43 @@ inline T SysCall(T code, const char* msg, const char* file, int line, const char
     return code;
 }
 
-
 template <class T>
 inline long long SysCall(long long code, const char* msg, const T& ctx, const char* file, int line, const char* func) {
     if (code < 0) {
         std::ostringstream os;
-        os << ctx;
-        throw FailedSystemCall(os.str(), msg, CodeLocation(file, line, func), errno);
+        os << msg << " [" << ctx << "]";
+        throw FailedSystemCall(os.str(), CodeLocation(file, line, func), errno);
     }
     return code;
 }
 
-
 inline void ThrCall(int code, const char* msg, const char* file, int line, const char* func) {
-    if (code != 0) {  // Threads return errno in return code
+    if (code != 0) {
+        // Threads return errno in return code
         handle_panic(msg, CodeLocation(file, line, func));
     }
 }
 
-/// This functions hides that assertions may be handled by a throw of AssertionFailed
-/// which is incompatible with using ASSERT inside destructors that are marked as no-throw,
-/// which is the default behavior in C++11.
-/// If env var ECKIT_ASSERT_ABORTS is set the assertion will abort instead of throwing.
-/// In the future this will become the default behavior.
+/**
+ * This functions hides that assertions may be handled by a throw of AssertionFailed
+ * which is incompatible with using ASSERT inside destructors that are marked as no-throw,
+ * which is the default behavior in C++11.
+ * If env var ECKIT_ASSERT_ABORTS is set the assertion will abort instead of throwing.
+ * In the future this will become the default behavior.
+ */
 inline void Assert(int code, const char* msg, const char* file, int line, const char* func) {
     if (code != 0) {
         handle_assert(msg, eckit::CodeLocation(file, line, func));
     }
 }
 
-/// This functions hides that assertions may be handled by a throw of AssertionFailed
-/// which is incompatible with using ASSERT inside destructors that are marked as no-throw,
-/// which is the default behavior in C++11.
-/// If env var ECKIT_ASSERT_ABORTS is set the assertion will abort instead of throwing.
-/// In the future this will become the default behavior.
+/**
+ * This functions hides that assertions may be handled by a throw of AssertionFailed
+ * which is incompatible with using ASSERT inside destructors that are marked as no-throw,
+ * which is the default behavior in C++11.
+ * If env var ECKIT_ASSERT_ABORTS is set the assertion will abort instead of throwing.
+ * In the future this will become the default behavior.
+ */
 inline void Assert(int code, const std::string& msg, const char* file, int line, const char* func) {
     if (code != 0) {
         handle_assert(msg, eckit::CodeLocation(file, line, func));
@@ -339,10 +320,10 @@ inline void PanicNoLog(int code, const char* msg, const CodeLocation& loc) {
 
 //----------------------------------------------------------------------------------------------------------------------
 
-/// For compatibility
+// For compatibility
 class OutOfMemory : public Exception {
-    virtual bool terminateApplication() const { return true; }
-    virtual const char* what() const noexcept { return "OutOfMemory"; }
+    bool terminateApplication() const override { return true; }
+    const char* what() const noexcept override { return "OutOfMemory"; }
 
 public:
 

--- a/src/eckit/exception/Exceptions.h
+++ b/src/eckit/exception/Exceptions.h
@@ -35,7 +35,7 @@ class Exception : public std::exception {
 public:
 
     /// Constructors
-    explicit Exception(const std::string& what, const CodeLocation& = {});
+    explicit Exception(const std::string& what, const CodeLocation& = {}, bool quiet = false);
     Exception();
 
     Exception(const Exception&) = delete;


### PR DESCRIPTION
Here's a modernisation of the base eckit::Exception class and bundled derived hierarchy. This includes:
- consistent interface among exceptions
- consistent (possible) use of CodeLocation (Here())
- ~~enforce non-copiable, non-movable (we have no case of a use pattern that requires moveability)~~ (some downstream projects are copying exceptions)
- conditional behaviour on the environment guaranteed by assigning conditionals before main()
- fixed mising return, nullptr access and tests

I've done this for some time but just found the motivation to push this ahead of possible changes to exception logging. Whether we do/don't do it, this is rather a cleanup before new code comes in.