### PR TITLE
Add new exception type 'ProtocolError'

### DIFF
--- a/src/eckit/exception/Exceptions.cc
+++ b/src/eckit/exception/Exceptions.cc
@@ -216,6 +216,9 @@ RemoteException::RemoteException(const std::string& w, const std::string& from) 
 UnexpectedState::UnexpectedState(const std::string& w, const CodeLocation& loc) :
     Exception("Unexpected state: " + w, loc) {}
 
+ProtocolError::ProtocolError(const std::string& what, const CodeLocation& loc) :
+    Exception("Protocol error: " + what, loc, true) {}
+
 //----------------------------------------------------------------------------------------------------------------------
 
 void handle_panic(const char* msg, const CodeLocation& loc) {

--- a/src/eckit/exception/Exceptions.h
+++ b/src/eckit/exception/Exceptions.h
@@ -253,6 +253,17 @@ public:
     explicit UnexpectedState(const std::string&, const CodeLocation& = {});
 };
 
+/**
+ * Signals a protocol error in client/server communiation.
+ * Use if the expected communication protocol is broken, i.e. wrong message flow or broken message.
+ * @note This exception is 'silent', i.e. no backtrace is logged.
+ */
+class ProtocolError : public Exception {
+public:
+
+    explicit ProtocolError(const std::string& what, const CodeLocation& = {});
+};
+
 //----------------------------------------------------------------------------------------------------------------------
 
 template <class T>


### PR DESCRIPTION
this commit adds a new exception type to signal client server communication erros on the protocol level. I.e. the network is fine but the other side is sending unexpected data or out or order messages.

