### PR TITLE
ECKIT-628 added timeout to RLE encoder

### DIFF
--- a/src/eckit/utils/RLE.cc
+++ b/src/eckit/utils/RLE.cc
@@ -126,13 +126,22 @@ stop:
 }
 
 template <class T, class U>
-long long RLEencode2(T first, T last, U output, long long maxLoop, const EncodingClock::duration timelimit) {
-    std::optional<EncodingClock::time_point> deadline{};
-    if (timelimit != EncodingClock::duration::zero()) {
-        deadline = EncodingClock::now() + timelimit;
-    }
-    return RLEencode2timeout(first, last, output, maxLoop, deadline);
+long long RLEencode2(T first, T last, U output, long long maxLoop) {
+    return RLEencode2timeout(first, last, output, maxLoop, std::optional<EncodingClock::time_point>{});
 }
+
+template <class T, class U>
+long long RLEencode2(T first, T last, U output, long long maxLoop, const EncodingClock::duration timelimit) {
+    return RLEencode2timeout(first, last, output, maxLoop,
+                             std::optional<EncodingClock::time_point>{EncodingClock::now() + timelimit});
+}
+
+template <class InputIterator, class OutputIterator>
+long long RLEencode2(InputIterator first, InputIterator last, OutputIterator result, long long maxloop);
+
+template <class InputIterator, class OutputIterator>
+long long RLEencode2(InputIterator first, InputIterator last, OutputIterator result, long long maxloop,
+                     const EncodingClock::duration timelimit);
 
 template <class T, class U>
 void RLEdecode2(T first, T last, U output) {

--- a/src/eckit/utils/RLE.cc
+++ b/src/eckit/utils/RLE.cc
@@ -8,10 +8,9 @@
  * does it submit to any jurisdiction.
  */
 
-#include "eckit/utils/RLE.h"
-
 #include <cstddef>
 #include <iterator>
+#include <optional> 
 #include <vector>
 
 #include "eckit/log/Log.h"
@@ -46,10 +45,10 @@ dummy_iterator<T> make_dummy(T*) {
     return dummy_iterator<T>();
 }
 
-
 template <class T, class U>
 long long RLEencode2timeout(T first, T last, U output, long long maxLoop,
                             std::optional<EncodingClock::time_point> deadline) {
+
     long long x    = 0;
     long long m    = 0;
     long long j    = 0;
@@ -81,9 +80,13 @@ long long RLEencode2timeout(T first, T last, U output, long long maxLoop,
                 m = a;
                 x = n;
                 j = i;
-                if (m > enough || (deadline && EncodingClock::now() > deadline))
+                if (m > enough || (deadline && EncodingClock::now() > deadline.value()))
                     goto stop;
             }
+        }
+
+        if (deadline && EncodingClock::now() > deadline.value()) {
+            goto stop;
         }
     }
 stop:
@@ -123,9 +126,9 @@ stop:
 }
 
 template <class T, class U>
-long long RLEencode2(T first, T last, U output, long long maxLoop, EncodingClock::duration timelimit) {
-    std::optional<EncodingClock::time_point> deadline;
-    if (timelimit > EncodingClock::duration::zero()) {
+long long RLEencode2(T first, T last, U output, long long maxLoop, const EncodingClock::duration timelimit) {
+    std::optional<EncodingClock::time_point> deadline{};
+    if (timelimit != EncodingClock::duration::zero()) {
         deadline = EncodingClock::now() + timelimit;
     }
     return RLEencode2timeout(first, last, output, maxLoop, deadline);

--- a/src/eckit/utils/RLE.cc
+++ b/src/eckit/utils/RLE.cc
@@ -10,7 +10,7 @@
 
 #include <cstddef>
 #include <iterator>
-#include <optional> 
+#include <optional>
 #include <vector>
 
 #include "eckit/log/Log.h"
@@ -92,7 +92,7 @@ long long RLEencode2timeout(T first, T last, U output, long long maxLoop,
 stop:
 
     if (m == 0) {
-        copy(first, last, output);
+        std::copy(first, last, output);
         return last - first;
     }
     else {

--- a/src/eckit/utils/RLE.h
+++ b/src/eckit/utils/RLE.h
@@ -28,8 +28,11 @@ using EncodingClock = std::chrono::steady_clock;
 class Stream;
 
 template <class InputIterator, class OutputIterator>
+long long RLEencode2(InputIterator first, InputIterator last, OutputIterator result, long long maxloop);
+
+template <class InputIterator, class OutputIterator>
 long long RLEencode2(InputIterator first, InputIterator last, OutputIterator result, long long maxloop,
-                     const EncodingClock::duration timelimit = EncodingClock::duration::zero());
+                     const EncodingClock::duration timelimit);
 
 template <class InputIterator, class OutputIterator>
 void RLEdecode2(InputIterator first, InputIterator last, OutputIterator result);

--- a/src/eckit/utils/RLE.h
+++ b/src/eckit/utils/RLE.h
@@ -14,20 +14,22 @@
 #ifndef eckit_RLE_h
 #define eckit_RLE_h
 
-
-#include <iosfwd>
 #include <chrono>
+#include <iosfwd>
 
 //-----------------------------------------------------------------------------
 
 namespace eckit {
+
+using EncodingClock = std::chrono::steady_clock;
 
 //-----------------------------------------------------------------------------
 
 class Stream;
 
 template <class InputIterator, class OutputIterator>
-long long RLEencode2(InputIterator first, InputIterator last, OutputIterator result, long long maxloop, std::chrono::steady_clock::duration timelimit = std::chrono::steady_clock::duration::zero());
+long long RLEencode2(InputIterator first, InputIterator last, OutputIterator result, long long maxloop,
+                     EncodingClock::duration timelimit = EncodingClock::duration::zero());
 
 template <class InputIterator, class OutputIterator>
 void RLEdecode2(InputIterator first, InputIterator last, OutputIterator result);

--- a/src/eckit/utils/RLE.h
+++ b/src/eckit/utils/RLE.h
@@ -29,7 +29,7 @@ class Stream;
 
 template <class InputIterator, class OutputIterator>
 long long RLEencode2(InputIterator first, InputIterator last, OutputIterator result, long long maxloop,
-                     EncodingClock::duration timelimit = EncodingClock::duration::zero());
+    const EncodingClock::duration timelimit = EncodingClock::duration::zero());
 
 template <class InputIterator, class OutputIterator>
 void RLEdecode2(InputIterator first, InputIterator last, OutputIterator result);

--- a/src/eckit/utils/RLE.h
+++ b/src/eckit/utils/RLE.h
@@ -29,7 +29,7 @@ class Stream;
 
 template <class InputIterator, class OutputIterator>
 long long RLEencode2(InputIterator first, InputIterator last, OutputIterator result, long long maxloop,
-    const EncodingClock::duration timelimit = EncodingClock::duration::zero());
+                     const EncodingClock::duration timelimit = EncodingClock::duration::zero());
 
 template <class InputIterator, class OutputIterator>
 void RLEdecode2(InputIterator first, InputIterator last, OutputIterator result);

--- a/src/eckit/utils/RLE.h
+++ b/src/eckit/utils/RLE.h
@@ -16,6 +16,7 @@
 
 
 #include <iosfwd>
+#include <chrono>
 
 //-----------------------------------------------------------------------------
 
@@ -26,7 +27,7 @@ namespace eckit {
 class Stream;
 
 template <class InputIterator, class OutputIterator>
-long long RLEencode2(InputIterator first, InputIterator last, OutputIterator result, long long maxloop);
+long long RLEencode2(InputIterator first, InputIterator last, OutputIterator result, long long maxloop, std::chrono::steady_clock::duration timelimit = std::chrono::steady_clock::duration::zero());
 
 template <class InputIterator, class OutputIterator>
 void RLEdecode2(InputIterator first, InputIterator last, OutputIterator result);

--- a/tests/utils/CMakeLists.txt
+++ b/tests/utils/CMakeLists.txt
@@ -37,6 +37,10 @@ ecbuild_add_test( TARGET      eckit_test_utils_rendezvoushash
                   SOURCES     test_rendezvoushash.cc
                   LIBS        eckit )
 
+ecbuild_add_test( TARGET      eckit_test_utils_rle
+                  SOURCES     test_rle.cc
+                  LIBS        eckit )
+
 ecbuild_add_test( TARGET      eckit_test_utils_compressor
                   SOURCES     test_compressor.cc
                   LIBS        eckit )

--- a/tests/utils/test_rle.cc
+++ b/tests/utils/test_rle.cc
@@ -8,16 +8,16 @@
  * does it submit to any jurisdiction.
  */
 
-#include <vector>
 #include <iostream>
 #include <limits>
 #include <memory>
 #include <random>
 #include <set>
+#include <vector>
 
 #include "eckit/config/LibEcKit.h"
-#include "eckit/utils/RLE.h"
 #include "eckit/log/Timer.h"
+#include "eckit/utils/RLE.h"
 
 #include "eckit/testing/Test.h"
 
@@ -29,7 +29,8 @@ namespace eckit::test {
 
 //----------------------------------------------------------------------------------------------------------------------
 
-void test(const std::vector<long>& in, EncodingClock::duration timeout = std::chrono::milliseconds(2), long expectedSize = -1) {
+void test(const std::vector<long>& in, EncodingClock::duration timeout = std::chrono::milliseconds(2),
+          long expectedSize = -1) {
 
     std::vector<long> out;
     std::vector<long> outTimeout;
@@ -40,19 +41,22 @@ void test(const std::vector<long>& in, EncodingClock::duration timeout = std::ch
     {
         eckit::Timer timer;
         n = RLEencode2(in.begin(), in.end(), std::back_inserter(out), maxLoop);
-        LOG_DEBUG_LIB(LibEcKit) << "no_timeout - time elapsed: " << timer.elapsed() << " - output size: " << out.size() << std::endl;
+        LOG_DEBUG_LIB(LibEcKit) << "no_timeout - time elapsed: " << timer.elapsed() << " - output size: " << out.size()
+                                << std::endl;
     }
     {
         eckit::Timer timer;
         t = RLEencode2(in.begin(), in.end(), std::back_inserter(outTimeout), maxLoop, timeout);
-        LOG_DEBUG_LIB(LibEcKit) << "timeout " << std::chrono::duration_cast<std::chrono::milliseconds>(timeout).count() << "ms - time elapsed: " << timer.elapsed() << " - output size: " << outTimeout.size() << std::endl;
+        LOG_DEBUG_LIB(LibEcKit) << "timeout " << std::chrono::duration_cast<std::chrono::milliseconds>(timeout).count()
+                                << "ms - time elapsed: " << timer.elapsed() << " - output size: " << outTimeout.size()
+                                << std::endl;
     }
 
     if (expectedSize > 0) {
         EXPECT_EQUAL(expectedSize, n);
         EXPECT_EQUAL(expectedSize, t);
         EXPECT_EQUAL(out.size(), outTimeout.size());
-        for (size_t i = 0; i<out.size(); i++) {
+        for (size_t i = 0; i < out.size(); i++) {
             EXPECT_EQUAL(out[i], outTimeout[i]);
         }
     }
@@ -60,51 +64,51 @@ void test(const std::vector<long>& in, EncodingClock::duration timeout = std::ch
     std::vector<long> decoded;
     RLEdecode2(out.begin(), out.end(), std::back_inserter(decoded));
     EXPECT_EQUAL(in.size(), decoded.size());
-    for (size_t i = 0; i<in.size(); i++) {
+    for (size_t i = 0; i < in.size(); i++) {
         EXPECT_EQUAL(in[i], decoded[i]);
     }
 
     std::vector<long> decodedTimeout;
     RLEdecode2(outTimeout.begin(), outTimeout.end(), std::back_inserter(decodedTimeout));
     EXPECT_EQUAL(in.size(), decodedTimeout.size());
-    for (size_t i = 0; i<in.size(); i++) {
+    for (size_t i = 0; i < in.size(); i++) {
         EXPECT_EQUAL(in[i], decodedTimeout[i]);
     }
 }
 
 CASE("single") {
-    std::vector<long> in={4};
+    std::vector<long> in = {4};
 
     test(in, std::chrono::seconds(1), 1);
 }
 
 CASE("identical") {
-    size_t size=1000;
+    size_t size = 1000;
     std::vector<long> in;
     in.reserve(size);
-    for (size_t i=0; i<size; i++) {
+    for (size_t i = 0; i < size; i++) {
         in.push_back(4);
     }
 
-    test(in, std::chrono::seconds(1), 2); /// we expect [-1000,4]
+    test(in, std::chrono::seconds(1), 2);  /// we expect [-1000,4]
 }
 
 CASE("interleaved") {
-    size_t size=1000;
+    size_t size = 1000;
     std::vector<long> in;
     in.reserve(size);
-    for (size_t i=0; i<size; i++) {
-        in.push_back(i%2);
+    for (size_t i = 0; i < size; i++) {
+        in.push_back(i % 2);
     }
 
-    test(in, std::chrono::seconds(1), 4); /// we expect [-500,-2,0,1]
+    test(in, std::chrono::seconds(1), 4);  /// we expect [-500,-2,0,1]
 }
 
 CASE("pattern") {
-    size_t size=100000;
+    size_t size = 100000;
     std::vector<long> in;
     in.reserve(size);
-    for (size_t i=0; i<size; i++) {
+    for (size_t i = 0; i < size; i++) {
         in.push_back(std::ceil(std::sqrt(i)));
     }
 
@@ -113,14 +117,14 @@ CASE("pattern") {
 
 
 void randTest(int limit) {
-    std::random_device rd;  // a seed source for the random number engine
-    std::mt19937 gen(rd()); // mersenne_twister_engine seeded with rd()
+    std::random_device rd;   // a seed source for the random number engine
+    std::mt19937 gen(rd());  // mersenne_twister_engine seeded with rd()
     std::uniform_int_distribution<> distrib(1, std::numeric_limits<int>::max());
 
-    size_t size=10000000;
+    size_t size = 10000000;
     std::vector<long> in;
     in.reserve(size);
-    for (size_t i=0; i<size; i++) {
+    for (size_t i = 0; i < size; i++) {
         in.push_back(distrib(gen));
     }
     test(in);

--- a/tests/utils/test_rle.cc
+++ b/tests/utils/test_rle.cc
@@ -1,0 +1,150 @@
+/*
+ * (C) Copyright 1996- ECMWF.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation nor
+ * does it submit to any jurisdiction.
+ */
+
+#include <vector>
+#include <iostream>
+#include <limits>
+#include <memory>
+#include <random>
+#include <set>
+
+#include "eckit/config/LibEcKit.h"
+#include "eckit/utils/RLE.h"
+#include "eckit/log/Timer.h"
+
+#include "eckit/testing/Test.h"
+
+using namespace std;
+using namespace eckit;
+using namespace eckit::testing;
+
+namespace eckit::test {
+
+//----------------------------------------------------------------------------------------------------------------------
+
+void test(const std::vector<long>& in, EncodingClock::duration timeout = std::chrono::milliseconds(2), long expectedSize = -1) {
+
+    std::vector<long> out;
+    std::vector<long> outTimeout;
+    int maxLoop = 5000;
+
+    long long n;
+    long long t;
+    {
+        eckit::Timer timer;
+        n = RLEencode2(in.begin(), in.end(), std::back_inserter(out), maxLoop);
+        LOG_DEBUG_LIB(LibEcKit) << "no_timeout - time elapsed: " << timer.elapsed() << " - output size: " << out.size() << std::endl;
+    }
+    {
+        eckit::Timer timer;
+        t = RLEencode2(in.begin(), in.end(), std::back_inserter(outTimeout), maxLoop, timeout);
+        LOG_DEBUG_LIB(LibEcKit) << "timeout " << std::chrono::duration_cast<std::chrono::milliseconds>(timeout).count() << "ms - time elapsed: " << timer.elapsed() << " - output size: " << outTimeout.size() << std::endl;
+    }
+
+    if (expectedSize > 0) {
+        EXPECT_EQUAL(expectedSize, n);
+        EXPECT_EQUAL(expectedSize, t);
+        EXPECT_EQUAL(out.size(), outTimeout.size());
+        for (size_t i = 0; i<out.size(); i++) {
+            EXPECT_EQUAL(out[i], outTimeout[i]);
+        }
+    }
+
+    std::vector<long> decoded;
+    RLEdecode2(out.begin(), out.end(), std::back_inserter(decoded));
+    EXPECT_EQUAL(in.size(), decoded.size());
+    for (size_t i = 0; i<in.size(); i++) {
+        EXPECT_EQUAL(in[i], decoded[i]);
+    }
+
+    std::vector<long> decodedTimeout;
+    RLEdecode2(outTimeout.begin(), outTimeout.end(), std::back_inserter(decodedTimeout));
+    EXPECT_EQUAL(in.size(), decodedTimeout.size());
+    for (size_t i = 0; i<in.size(); i++) {
+        EXPECT_EQUAL(in[i], decodedTimeout[i]);
+    }
+}
+
+CASE("single") {
+    std::vector<long> in={4};
+
+    test(in, std::chrono::seconds(1), 1);
+}
+
+CASE("identical") {
+    size_t size=1000;
+    std::vector<long> in;
+    in.reserve(size);
+    for (size_t i=0; i<size; i++) {
+        in.push_back(4);
+    }
+
+    test(in, std::chrono::seconds(1), 2); /// we expect [-1000,4]
+}
+
+CASE("interleaved") {
+    size_t size=1000;
+    std::vector<long> in;
+    in.reserve(size);
+    for (size_t i=0; i<size; i++) {
+        in.push_back(i%2);
+    }
+
+    test(in, std::chrono::seconds(1), 4); /// we expect [-500,-2,0,1]
+}
+
+CASE("pattern") {
+    size_t size=100000;
+    std::vector<long> in;
+    in.reserve(size);
+    for (size_t i=0; i<size; i++) {
+        in.push_back(std::ceil(std::sqrt(i)));
+    }
+
+    test(in);
+}
+
+
+void randTest(int limit) {
+    std::random_device rd;  // a seed source for the random number engine
+    std::mt19937 gen(rd()); // mersenne_twister_engine seeded with rd()
+    std::uniform_int_distribution<> distrib(1, std::numeric_limits<int>::max());
+
+    size_t size=10000000;
+    std::vector<long> in;
+    in.reserve(size);
+    for (size_t i=0; i<size; i++) {
+        in.push_back(distrib(gen));
+    }
+    test(in);
+}
+
+CASE("randMaxInt") {
+    randTest(std::numeric_limits<int>::max());
+}
+
+CASE("rand100") {
+    randTest(100);
+}
+
+CASE("rand10") {
+    randTest(10);
+}
+
+CASE("rand2") {
+    randTest(2);
+}
+//----------------------------------------------------------------------------------------------------------------------
+
+}  // namespace eckit::test
+
+int main(int argc, char* argv[]) {
+    return run_tests(argc, argv);
+}


### PR DESCRIPTION
added optional timeout to RLEdecode2 (to be used in mars-server layout compression).
As the timeout expires, we copy the remaining input data and return