### PR TITLE
Adds safe signed->unsigned, unsigned->signed casts

### DIFF
--- a/src/eckit/utils/SafeCasts.h
+++ b/src/eckit/utils/SafeCasts.h
@@ -1,0 +1,72 @@
+/*
+ * (C) Copyright 2025- ECMWF.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation nor
+ * does it submit to any jurisdiction.
+ */
+
+/**
+ * Place functions to allow for save type casting in this file
+ */
+#pragma once
+#include <limits>
+#include <type_traits>
+
+#include "eckit/exception/Exceptions.h"
+
+namespace eckit {
+
+/**
+ *  Casts signed integer into unsigned.
+ *  @param value to cast from.
+ *  @return value cast into, same as before but unsigned type.
+ *  @throws BadCast if used with a negative value.
+ */
+template <typename S, std::enable_if_t<std::is_integral_v<S> && std::is_signed_v<S>, int> = 0>
+[[nodiscard]] constexpr auto into_unsigned(S value) -> std::make_unsigned_t<S> {
+    using U = std::make_unsigned_t<S>;
+    if (value < 0) {
+        throw eckit::BadCast("Negative value cannot be cast to unsigned type", Here());
+    }
+    return static_cast<U>(value);
+}
+
+/**
+ * Template specialization that turns unsigned to unsigned conversions with 'into_unsigned' into a NoOp
+ * @param value
+ * @return value, returned unmodified.
+ */
+template <typename S, std::enable_if_t<std::is_integral_v<S> && std::is_unsigned_v<S>, int> = 0>
+[[nodiscard]] constexpr auto into_unsigned(S value) -> std::make_unsigned_t<S> {
+    return value;
+}
+
+/**
+ *  Casts unsigned integer into signed.
+ *  @param value to cast from.
+ *  @return value cast into, same as before but signed type.
+ *  @throws BadCast if used with a value > 2^(bits-1)-1
+ */
+template <typename U, std::enable_if_t<std::is_integral_v<U> && std::is_unsigned_v<U>, int> = 0>
+[[nodiscard]] constexpr auto into_signed(U value) -> std::make_signed_t<U> {
+    using S = std::make_signed_t<U>;
+    if (value > static_cast<U>(std::numeric_limits<S>::max())) {
+        throw eckit::BadCast("Value too large to cast to signed type");
+    }
+    return static_cast<S>(value);
+}
+
+/**
+ * Template specialization that turns signed to signed conversions with 'into_signed' into a NoOp
+ * @param value
+ * @return value, returned unmodified.
+ */
+template <typename U, std::enable_if_t<std::is_integral_v<U> && std::is_signed_v<U>, int> = 0>
+[[nodiscard]] constexpr auto into_signed(U value) -> std::make_signed_t<U> {
+    return value;
+}
+
+}  // namespace eckit

--- a/tests/utils/CMakeLists.txt
+++ b/tests/utils/CMakeLists.txt
@@ -78,3 +78,8 @@ ecbuild_add_test( TARGET      eckit_test_regex
 ecbuild_add_test( TARGET      eckit_test_literals
                   SOURCES     test_literals.cc
                   LIBS        eckit )
+
+ecbuild_add_test( TARGET      eckit_test_safe_casts
+                  SOURCES     test_safe_casts.cc
+                  LIBS        eckit )
+

--- a/tests/utils/test_safe_casts.cc
+++ b/tests/utils/test_safe_casts.cc
@@ -1,0 +1,100 @@
+/*
+ * (C) Copyright 2025- ECMWF.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation nor
+ * does it submit to any jurisdiction.
+ */
+
+#include "eckit/exception/Exceptions.h"
+#include "eckit/testing/Test.h"
+#include "eckit/utils/SafeCasts.h"
+
+#include <cstdint>
+#include <limits>
+
+using eckit::into_signed;
+using eckit::into_unsigned;
+
+CASE("Can convert positive signed to unsigned") {
+    EXPECT_EQUAL(into_unsigned(int8_t{5}), uint8_t{5});
+    EXPECT_EQUAL(into_unsigned(int16_t{5}), uint16_t{5});
+    EXPECT_EQUAL(into_unsigned(int32_t{5}), uint32_t{5});
+    EXPECT_EQUAL(into_unsigned(int64_t{5}), uint64_t{5});
+    EXPECT_EQUAL(into_unsigned(static_cast<signed char>(5)), 5);
+    EXPECT_EQUAL(into_unsigned(static_cast<short>(5)), 5);
+    EXPECT_EQUAL(into_unsigned(static_cast<int>(5)), 5);
+    EXPECT_EQUAL(into_unsigned(static_cast<long>(5)), 5);
+    EXPECT_EQUAL(into_unsigned(static_cast<long long>(5)), 5);
+}
+
+CASE("Throws 'BadCast' on negative signed to unsigned") {
+    EXPECT_THROWS_AS((void)into_unsigned(int8_t{-5}), eckit::BadCast);
+    EXPECT_THROWS_AS((void)into_unsigned(int16_t{-5}), eckit::BadCast);
+    EXPECT_THROWS_AS((void)into_unsigned(int32_t{-5}), eckit::BadCast);
+    EXPECT_THROWS_AS((void)into_unsigned(int64_t{-5}), eckit::BadCast);
+    EXPECT_THROWS_AS((void)into_unsigned(static_cast<signed char>(-5)), eckit::BadCast);
+    EXPECT_THROWS_AS((void)into_unsigned(static_cast<short>(-5)), eckit::BadCast);
+    EXPECT_THROWS_AS((void)into_unsigned(static_cast<int>(-5)), eckit::BadCast);
+    EXPECT_THROWS_AS((void)into_unsigned(static_cast<long>(-5)), eckit::BadCast);
+    EXPECT_THROWS_AS((void)into_unsigned(static_cast<long long>(-5)), eckit::BadCast);
+}
+
+CASE("No-op if used as unsigned to unsigned cast") {
+    EXPECT_EQUAL(into_unsigned(uint8_t{5}), 5);
+    EXPECT_EQUAL(into_unsigned(uint16_t{5}), 5);
+    EXPECT_EQUAL(into_unsigned(uint32_t{5}), 5);
+    EXPECT_EQUAL(into_unsigned(uint64_t{5}), 5);
+    EXPECT_EQUAL(into_unsigned(static_cast<unsigned char>(5)), 5);
+    EXPECT_EQUAL(into_unsigned(static_cast<unsigned short>(5)), 5);
+    EXPECT_EQUAL(into_unsigned(static_cast<unsigned int>(5)), 5);
+    EXPECT_EQUAL(into_unsigned(static_cast<unsigned long>(5)), 5);
+    EXPECT_EQUAL(into_unsigned(static_cast<unsigned long long>(5)), 5);
+}
+
+CASE("Can convert unsigned to signed for unsigned values smaller that 2^(bits-1)-1") {
+    EXPECT_EQUAL(into_signed(uint8_t{5}), int8_t{5});
+    EXPECT_EQUAL(into_signed(uint16_t{5}), int16_t{5});
+    EXPECT_EQUAL(into_signed(uint32_t{5}), int32_t{5});
+    EXPECT_EQUAL(into_signed(uint64_t{5}), int64_t{5});
+    EXPECT_EQUAL(into_signed(static_cast<unsigned char>(5)), 5);
+    EXPECT_EQUAL(into_signed(static_cast<unsigned short>(5)), 5);
+    EXPECT_EQUAL(into_signed(static_cast<unsigned int>(5)), 5);
+    EXPECT_EQUAL(into_signed(static_cast<unsigned long>(5)), 5);
+    EXPECT_EQUAL(into_signed(static_cast<unsigned long long>(5)), 5);
+}
+
+CASE("Throws 'BadCast' on unsigned to signed conversion if value cannot be represented") {
+    EXPECT_THROWS_AS((void)into_signed(uint8_t{std::numeric_limits<uint8_t>::max()}), eckit::BadCast);
+    EXPECT_THROWS_AS((void)into_signed(uint16_t{std::numeric_limits<uint16_t>::max()}), eckit::BadCast);
+    EXPECT_THROWS_AS((void)into_signed(uint32_t{std::numeric_limits<uint32_t>::max()}), eckit::BadCast);
+    EXPECT_THROWS_AS((void)into_signed(uint64_t{std::numeric_limits<uint64_t>::max()}), eckit::BadCast);
+    EXPECT_THROWS_AS((void)into_signed(static_cast<unsigned char>(std::numeric_limits<unsigned char>::max())),
+                     eckit::BadCast);
+    EXPECT_THROWS_AS((void)into_signed(static_cast<unsigned short>(std::numeric_limits<unsigned short>::max())),
+                     eckit::BadCast);
+    EXPECT_THROWS_AS((void)into_signed(static_cast<unsigned int>(std::numeric_limits<unsigned int>::max())),
+                     eckit::BadCast);
+    EXPECT_THROWS_AS((void)into_signed(static_cast<unsigned long>(std::numeric_limits<unsigned long>::max())),
+                     eckit::BadCast);
+    EXPECT_THROWS_AS((void)into_signed(static_cast<unsigned long long>(std::numeric_limits<unsigned long long>::max())),
+                     eckit::BadCast);
+}
+
+CASE("No-op if used as signed to signed cast") {
+    EXPECT_EQUAL(into_signed(int8_t{-5}), -5);
+    EXPECT_EQUAL(into_signed(int16_t{-5}), -5);
+    EXPECT_EQUAL(into_signed(int32_t{-5}), -5);
+    EXPECT_EQUAL(into_signed(int64_t{-5}), -5);
+    EXPECT_EQUAL(into_signed(static_cast<char>(-5)), -5);
+    EXPECT_EQUAL(into_signed(static_cast<short>(-5)), -5);
+    EXPECT_EQUAL(into_signed(static_cast<int>(-5)), -5);
+    EXPECT_EQUAL(into_signed(static_cast<long>(-5)), -5);
+    EXPECT_EQUAL(into_signed(static_cast<long long>(-5)), -5);
+}
+
+int main(int argc, char* argv[]) {
+    return eckit::testing::run_tests(argc, argv);
+}


### PR DESCRIPTION
Adds new 'into_unsigned()' and 'into_signed' type casts that throw on conversion from a unrepresentable value in the target representation.