### PR TITLE
Python wheel: add testpypi param, push-tag trigger

### DIFF
--- a/.github/workflows/build-wheel-wrapper.yml
+++ b/.github/workflows/build-wheel-wrapper.yml
@@ -11,15 +11,27 @@ name: Build Python Wrapper Wheel
 
 on:
   # Trigger the workflow manually
-  workflow_dispatch: ~
+  workflow_dispatch:
+    inputs:
+      use_test_pypi:
+        description: Use test pypi instead of the regular one
+        required: false
+        type: boolean
+        default: false
 
-  # Allow to be called from another workflow
-  workflow_call: ~
-
-  # TODO automation trigger
+  # Allow to be called from another workflow -- eg `cd.yml`
+  workflow_call:
+    inputs:
+      use_test_pypi:
+        description: Use test pypi instead of the regular one
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   python-wrapper-wheel:
     name: Python Wrapper Wheel
     uses: ecmwf/reusable-workflows/.github/workflows/python-wrapper-wheel.yml@main
+    with:
+      use_test_pypi: ${{ inputs.use_test_pypi }}
     secrets: inherit

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -9,3 +9,7 @@ jobs:
   deploy:
     uses: ecmwf/reusable-workflows/.github/workflows/create-package.yml@v2
     secrets: inherit
+  wheel:
+    uses: ./.github/workflows/build-wheel-wrapper.yml
+    secrets: inherit
+


### PR DESCRIPTION
1/ exposes `use_test_pypi` option -- with that set to `true`, the action is safe to run from any branch etc. Later I'll add a trigger to test it automatically on eg a PR to `main`
2/ adds wheel building & uploading invocation to tag push

Note: *needs* https://github.com/ecmwf/reusable-workflows/pull/18 merged