### PR TITLE
eckit::Fraction improved convergence

### DIFF
--- a/src/eckit/types/Fraction.cc
+++ b/src/eckit/types/Fraction.cc
@@ -12,6 +12,8 @@
 
 #include <cmath>
 #include <limits>
+#include <numeric>
+#include <ostream>
 
 #include "eckit/exception/Exceptions.h"
 #include "eckit/serialisation/Stream.h"
@@ -23,114 +25,94 @@
 
 namespace eckit {
 
-static Fraction::value_type gcd(Fraction::value_type a, Fraction::value_type b) {
-    while (b != 0) {
-        Fraction::value_type r = a % b;
-        a                      = b;
-        b                      = r;
-    }
-    return a;
-}
-
-//----------------------------------------------------------------------------------------------------------------------
-
 Fraction::Fraction(value_type top, value_type bottom) {
-
     ASSERT(bottom != 0);
 
-    /// @note in theory we also assume that numerator and denominator are both representable in
-    ///       double without loss
-    //    ASSERT(top == value_type(double(top)));
-    //    ASSERT(bottom == value_type(double(bottom)));
+    value_type sgn = top < 0 == bottom < 0 ? 1 : -1;
+    top            = std::abs(top);
+    bottom         = std::abs(bottom);
 
-    value_type sign = 1;
-    if (top < 0) {
-        top  = -top;
-        sign = -sign;
-    }
-
-    if (bottom < 0) {
-        bottom = -bottom;
-        sign   = -sign;
-    }
-
-    value_type g = gcd(top, bottom);
-    top          = top / g;
-    bottom       = bottom / g;
-
-    top_    = sign * top;
-    bottom_ = bottom;
+    value_type g = std::gcd(top, bottom);
+    top_         = top / g * sgn;
+    bottom_      = bottom / g;
 }
 
-const Fraction::value_type MAX_DENOM = std::sqrt(std::numeric_limits<Fraction::value_type>::max());
+constexpr auto VALUE_TYPE_MAX = std::numeric_limits<Fraction::value_type>::max();
+constexpr auto VALUE_TYPE_MIN = std::numeric_limits<Fraction::value_type>::lowest();
+
+const auto MAX_DENOM = static_cast<Fraction::value_type>(std::sqrt(VALUE_TYPE_MAX));
 
 Fraction::value_type Fraction::max_denominator() {
     return MAX_DENOM;
 }
 
-Fraction::Fraction(double x) {
-
-    double value = x;
-
+Fraction::Fraction(double value) : top_(1), bottom_(0) {
     ASSERT(!std::isnan(value));
-    // ASSERT(fabs(value) < 1e30);
 
+    // Implementation of the continued fraction algorithm, with
+    // - protection overflows, by limiting to sqrt(value_type maximum)
+    // - limited interations
+    // - increased tolerance on non-convergence (top/bottom greater than value_type maximum)
 
-    value_type sign = 1;
-    if (x < 0) {
-        sign = -sign;
-        x    = -x;
-    }
+    value_type m00 = 1;
+    value_type m10 = 0;
 
-    value_type m00 = 1, m11 = 1, m01 = 0, m10 = 0;
-    value_type a  = x;
-    value_type t2 = m10 * a + m11;
+    for (double eps : {0., 1e-9, 1e-8, 1e-7, 1e-6}) {
+        m00 = 1;
+        m10 = 0;
 
-    size_t cnt = 0;
+        value_type m11 = 1;
+        value_type m01 = 0;
 
-    while (t2 <= MAX_DENOM) {
+        auto x  = std::abs(value);
+        auto a  = static_cast<value_type>(x);
+        auto t2 = m10 * a + m11;
 
-        value_type t1 = m00 * a + m01;
-        m01           = m00;
-        m00           = t1;
+        size_t cnt = 0;
 
-        m11 = m10;
-        m10 = t2;
+        while (t2 <= MAX_DENOM) {
+            auto t1 = m00 * a + m01;
 
-        if (x == a) {
-            break;
+            m01 = m00;
+            m00 = t1;
+
+            m11 = m10;
+            m10 = t2;
+
+            auto dx = x - static_cast<double>(a);
+            if (std::abs(dx) < eps) {
+                break;
+            }
+
+            x = 1. / dx;
+            if (x > static_cast<double>(VALUE_TYPE_MAX)) {
+                break;
+            }
+
+            a  = static_cast<value_type>(x);
+            t2 = m10 * a + m11;
+
+            if (cnt++ > 10000) {
+                throw BadValue("Cannot compute fraction from " + std::to_string(value));
+            }
         }
 
-        x = 1.0 / (x - a);
-
-        if (x > static_cast<double>(std::numeric_limits<Fraction::value_type>::max())) {
-            break;
+        while (m10 >= MAX_DENOM || m00 >= MAX_DENOM) {
+            m00 >>= 1;
+            m10 >>= 1;
         }
 
-        a  = x;
-        t2 = m10 * a + m11;
+        if (m10 != 0) {
+            value_type sgn = value < 0 ? -1 : 1;
+            value_type g   = std::gcd(m00, m10);
 
-        if (cnt++ > 10000) {
-            std::ostringstream oss;
-            oss << "Cannot compute fraction from " << value << std::endl;
-            throw eckit::BadValue(oss.str());
+            top_    = m00 / g * sgn;
+            bottom_ = m10 / g;
+            return;
         }
     }
 
-    while (m10 >= MAX_DENOM || m00 >= MAX_DENOM) {
-        m00 >>= 1;
-        m10 >>= 1;
-    }
-
-    value_type top    = m00;
-    value_type bottom = m10;
-
-    value_type g = gcd(top, bottom);
-    top          = top / g;
-    bottom       = bottom / g;
-
-    top_    = sign * top;
-    bottom_ = bottom;
+    throw BadValue("Cannot compute fraction from " + std::to_string(value));
 }
 
 Fraction::Fraction(const std::string& s) {
@@ -142,10 +124,9 @@ Fraction::Fraction(const std::string& s) {
         ASSERT(v.size() == 2);
         static Translator<std::string, value_type> s2l;
         Fraction f(s2l(v[0]), s2l(v[1]));
+
         top_    = f.top_;
         bottom_ = f.bottom_;
-
-
         return;
     }
 
@@ -167,30 +148,24 @@ Fraction Fraction::abs(const Fraction& f) {
 }
 
 void Fraction::print(std::ostream& out) const {
-    if (bottom_ == 1) {
-        out << top_;
-    }
-    else {
-        out << top_ << '/' << bottom_;
-    }
+    out << to_string();
 }
 
 Fraction::operator value_type() const {
     if (bottom_ == 1) {
         return top_;
     }
-    std::ostringstream oss;
-    oss << "Cannot convert fraction " << *this << " (" << double(*this) << ") to integer";
-    throw eckit::SeriousBug(oss.str());
+
+    throw SeriousBug("Cannot convert fraction " + to_string() + " (" + std::to_string(operator double()) +
+                     ") to integer");
 }
 
-eckit::Fraction Fraction::inverse() const {
-    if (top_ == 0) {
-        std::ostringstream oss;
-        oss << "Cannot compute inverse of " << *this << std::endl;
-        throw eckit::BadValue(oss.str());
+Fraction Fraction::inverse() const {
+    if (top_ != 0) {
+        return {bottom_, top_};
     }
-    return {bottom_, top_};
+
+    throw BadValue("Cannot compute inverse of " + to_string());
 }
 
 void Fraction::hash(MD5& md5) const {
@@ -208,27 +183,20 @@ void Fraction::decode(Stream& s) {
     s >> bottom_;
 }
 
+std::string Fraction::to_string() const {
+    return bottom_ == 1 ? std::to_string(top_) : (std::to_string(top_) + '/' + std::to_string(bottom_));
+}
+
 //----------------------------------------------------------------------------------------------------------------------
 
 inline Fraction::value_type mul(bool& overflow, Fraction::value_type a, Fraction::value_type b) {
-
-    if (overflow or (b != 0 and std::abs(a) > (std::numeric_limits<Fraction::value_type>::max() / std::abs(b)))) {
-        overflow = true;  // report overflow
-        return Fraction::value_type();
-    }
-
-    return a * b;
+    overflow = overflow or (b != 0 and std::abs(a) > (VALUE_TYPE_MAX / std::abs(b)));
+    return overflow ? 0 : a * b;
 }
 
 inline Fraction::value_type add(bool& overflow, Fraction::value_type a, Fraction::value_type b) {
-
-    if (overflow or (b > 0 ? a > std::numeric_limits<Fraction::value_type>::max() - b
-                           : a < std::numeric_limits<Fraction::value_type>::lowest() - b)) {
-        overflow = true;  // report overflow
-        return Fraction::value_type();
-    }
-
-    return a + b;
+    overflow = overflow or (b > 0 ? a > VALUE_TYPE_MAX - b : a < VALUE_TYPE_MIN - b);
+    return overflow ? 0 : a + b;
 }
 
 inline Fraction::value_type sub(bool& overflow, Fraction::value_type a, Fraction::value_type b) {
@@ -236,62 +204,43 @@ inline Fraction::value_type sub(bool& overflow, Fraction::value_type a, Fraction
 }
 
 Fraction Fraction::operator+(const Fraction& other) const {
-
     bool overflow = false;
-
-    value_type top = add(overflow, mul(overflow, top_, other.bottom_), mul(overflow, bottom_, other.top_));
-
-    value_type bottom = mul(overflow, bottom_, other.bottom_);
-
-    if (!overflow) {
-        return Fraction(top, bottom);
+    if (value_type top = add(overflow, mul(overflow, top_, other.bottom_), mul(overflow, bottom_, other.top_)),
+        bottom         = mul(overflow, bottom_, other.bottom_);
+        !overflow) {
+        return {top, bottom};
     }
 
-    return Fraction(double(*this) + double(other));
+    return Fraction(operator double() + other.operator double());
 }
 
 Fraction Fraction::operator-(const Fraction& other) const {
-
     bool overflow = false;
-
-    value_type top = sub(overflow, mul(overflow, top_, other.bottom_), mul(overflow, bottom_, other.top_));
-
-    value_type bottom = mul(overflow, bottom_, other.bottom_);
-
-    if (!overflow) {
-        return Fraction(top, bottom);
+    if (value_type top = sub(overflow, mul(overflow, top_, other.bottom_), mul(overflow, bottom_, other.top_)),
+        bottom         = mul(overflow, bottom_, other.bottom_);
+        !overflow) {
+        return {top, bottom};
     }
 
-    return Fraction(double(*this) - double(other));
+    return Fraction(operator double() - other.operator double());
 }
 
 Fraction Fraction::operator/(const Fraction& other) const {
     bool overflow = false;
-
-    value_type top = mul(overflow, top_, other.bottom_);
-
-    value_type bottom = mul(overflow, bottom_, other.top_);
-
-    if (!overflow) {
-        return Fraction(top, bottom);
+    if (value_type top = mul(overflow, top_, other.bottom_), bottom = mul(overflow, bottom_, other.top_); !overflow) {
+        return {top, bottom};
     }
 
-    return Fraction(double(*this) / double(other));
+    return Fraction(operator double() / other.operator double());
 }
 
 Fraction Fraction::operator*(const Fraction& other) const {
-
     bool overflow = false;
-
-    value_type top = mul(overflow, top_, other.top_);
-
-    value_type bottom = mul(overflow, bottom_, other.bottom_);
-
-    if (!overflow) {
-        return Fraction(top, bottom);
+    if (value_type top = mul(overflow, top_, other.top_), bottom = mul(overflow, bottom_, other.bottom_); !overflow) {
+        return {top, bottom};
     }
 
-    return Fraction(double(*this) * double(other));
+    return Fraction(operator double() * other.operator double());
 }
 
 bool Fraction::operator==(const Fraction& other) const {
@@ -300,52 +249,51 @@ bool Fraction::operator==(const Fraction& other) const {
 }
 
 bool Fraction::operator!=(const Fraction& other) const {
-    return !(*this == other);
+    return !operator==(other);
 }
 
 bool Fraction::operator<(const Fraction& other) const {
-    bool overflow = false;
-    bool result   = mul(overflow, top_, other.bottom_) < mul(overflow, other.top_, bottom_);
-    if (overflow) {
-        return double(*this) < double(other);
+    if (bool overflow = false, result = mul(overflow, top_, other.bottom_) < mul(overflow, other.top_, bottom_);
+        !overflow) {
+        return result;
     }
-    return result;
+
+    return operator double() < other.operator double();
 }
 
 bool Fraction::operator<=(const Fraction& other) const {
-    bool overflow = false;
-    bool result   = mul(overflow, top_, other.bottom_) <= mul(overflow, other.top_, bottom_);
-    if (overflow) {
-        return double(*this) <= double(other);
+    if (bool overflow = false, result = mul(overflow, top_, other.bottom_) <= mul(overflow, other.top_, bottom_);
+        !overflow) {
+        return result;
     }
-    return result;
+
+    return operator double() <= other.operator double();
 }
 
 bool Fraction::operator>(const Fraction& other) const {
-    bool overflow = false;
-    bool result   = mul(overflow, top_, other.bottom_) > mul(overflow, other.top_, bottom_);
-    if (overflow) {
-        return double(*this) > double(other);
+    if (bool overflow = false, result = mul(overflow, top_, other.bottom_) > mul(overflow, other.top_, bottom_);
+        !overflow) {
+        return result;
     }
-    return result;
+
+    return operator double() > other.operator double();
 }
 
 bool Fraction::operator>=(const Fraction& other) const {
-    bool overflow = false;
-    bool result   = mul(overflow, top_, other.bottom_) >= mul(overflow, other.top_, bottom_);
-    if (overflow) {
-        return double(*this) >= double(other);
+    if (bool overflow = false, result = mul(overflow, top_, other.bottom_) >= mul(overflow, other.top_, bottom_);
+        !overflow) {
+        return result;
     }
-    return result;
+
+    return operator double() >= other.operator double();
 }
 
 //----------------------------------------------------------------------------------------------------------------------
 
 
 Fraction Fraction::fromString(const std::string& s) {
-
     long numerator   = 0;
-    long denumerator = 1;
+    long denominator = 1;
     int sgn          = 1;
     size_t err       = 0;
     bool decimal     = false;
@@ -380,7 +328,7 @@ Fraction Fraction::fromString(const std::string& s) {
                 numerator *= 10;
                 numerator += s[i] - '0';
                 if (decimal) {
-                    denumerator *= 10;
+                    denominator *= 10;
                 }
                 break;
 
@@ -389,33 +337,21 @@ Fraction Fraction::fromString(const std::string& s) {
         }
     }
 
-    if (err) {
-        throw eckit::UserError("Fraction::fromString: invalid value [" + s + "]");
+    if (err != 0) {
+        throw UserError("Fraction::fromString: invalid value [" + s + "]");
     }
 
-    return eckit::Fraction(sgn * numerator, denumerator);
+    return {sgn * numerator, denominator};
 }
 
 Fraction Fraction::stableVersion(size_t max) const {
     Fraction x(*this);
 
     size_t n = 0;
-    for (;;) {
-        Fraction y = Fraction(double(x));
-        if (y == x) {
-            //             std::cout << "STABLE =========== " << n << " "
-            //             << double(*this) << " " << *this
-            // << " -> " << double(x) << " " << x <<
-            //             std::endl;
-            break;
-        }
-        x = y;
-        n++;
-        if (n >= max) {
-            std::ostringstream oss;
-            oss << "Fraction::stableVersion(" << *this << ") did not converge after " << max
-                << " iterations. Last value: " << x;
-            throw eckit::SeriousBug(oss.str());
+    for (Fraction y(static_cast<double>(x)); x != y; x = y, y = Fraction{static_cast<double>(x)}) {
+        if (n++; n >= max) {
+            throw SeriousBug("Fraction::stableVersion(" + to_string() + ") did not converge after " +
+                             std::to_string(max) + " iterations. Last value: " + x.to_string());
         }
     }
 
@@ -426,32 +362,32 @@ Fraction Fraction::stableVersion(size_t max) const {
 
 template <>
 bool Fraction::operator==(double other) const {
-    return double(*this) == other;
+    return operator double() == other;
 }
 
 template <>
 bool Fraction::operator<(double other) const {
-    return double(*this) < other;
+    return operator double() < other;
 }
 
 template <>
 bool Fraction::operator<=(double other) const {
-    return double(*this) <= other;
+    return operator double() <= other;
 }
 
 template <>
 bool Fraction::operator!=(double other) const {
-    return double(*this) != other;
+    return operator double() != other;
 }
 
 template <>
 bool Fraction::operator>(double other) const {
-    return double(*this) > other;
+    return operator double() > other;
 }
 
 template <>
 bool Fraction::operator>=(double other) const {
-    return double(*this) >= other;
+    return operator double() >= other;
 }
 
 }  // namespace eckit

--- a/src/eckit/types/Fraction.cc
+++ b/src/eckit/types/Fraction.cc
@@ -28,13 +28,14 @@ namespace eckit {
 Fraction::Fraction(value_type top, value_type bottom) {
     ASSERT(bottom != 0);
 
-    value_type sgn = top < 0 == bottom < 0 ? 1 : -1;
-    top            = std::abs(top);
-    bottom         = std::abs(bottom);
+    const auto abs_top    = std::abs(top);
+    const auto abs_bottom = std::abs(bottom);
 
-    value_type g = std::gcd(top, bottom);
-    top_         = top / g * sgn;
-    bottom_      = bottom / g;
+    const value_type sgn = top < 0 == bottom < 0 ? 1 : -1;
+    const value_type g   = std::gcd(abs_top, abs_bottom);
+
+    top_    = abs_top / g * sgn;
+    bottom_ = abs_bottom / g;
 }
 
 constexpr auto VALUE_TYPE_MAX = std::numeric_limits<Fraction::value_type>::max();
@@ -71,7 +72,7 @@ Fraction::Fraction(double value) : top_(1), bottom_(0) {
         size_t cnt = 0;
 
         while (t2 <= MAX_DENOM) {
-            auto t1 = m00 * a + m01;
+            const auto t1 = m00 * a + m01;
 
             m01 = m00;
             m00 = t1;
@@ -79,13 +80,8 @@ Fraction::Fraction(double value) : top_(1), bottom_(0) {
             m11 = m10;
             m10 = t2;
 
-            auto dx = x - static_cast<double>(a);
-            if (std::abs(dx) < eps) {
-                break;
-            }
-
-            x = 1. / dx;
-            if (x > static_cast<double>(VALUE_TYPE_MAX)) {
+            if (const auto dx = x - static_cast<double>(a);
+                std::abs(dx) < eps || (x = 1. / dx) > static_cast<double>(VALUE_TYPE_MAX)) {
                 break;
             }
 
@@ -103,8 +99,8 @@ Fraction::Fraction(double value) : top_(1), bottom_(0) {
         }
 
         if (m10 != 0) {
-            value_type sgn = value < 0 ? -1 : 1;
-            value_type g   = std::gcd(m00, m10);
+            const value_type sgn = value < 0 ? -1 : 1;
+            const value_type g   = std::gcd(m00, m10);
 
             top_    = m00 / g * sgn;
             bottom_ = m10 / g;

--- a/src/eckit/types/Fraction.cc
+++ b/src/eckit/types/Fraction.cc
@@ -57,7 +57,7 @@ Fraction::Fraction(double value) : top_(1), bottom_(0) {
     value_type m00 = 1;
     value_type m10 = 0;
 
-    for (double eps : {0., 1e-9, 1e-8, 1e-7, 1e-6}) {
+    for (auto eps : {std::numeric_limits<double>::epsilon(), 1e-9, 1e-8, 1e-7, 1e-6}) {
         m00 = 1;
         m10 = 0;
 

--- a/src/eckit/types/Fraction.h
+++ b/src/eckit/types/Fraction.h
@@ -14,6 +14,7 @@
 #ifndef eckit_Fraction_h
 #define eckit_Fraction_h
 
+#include <iosfwd>
 #include <string>
 
 
@@ -30,9 +31,9 @@ class Stream;
 class Fraction {
 public:
 
-    typedef long long value_type;
+    using value_type = long long;
 
-    // typedef __int128 value_type;
+    // using value_type = __int128 ;
 
 public:  // methods
          // -- Contructors
@@ -52,8 +53,8 @@ public:  // methods
 
     explicit Fraction(unsigned int n) : top_(n), bottom_(1) {}
     explicit Fraction(unsigned short n) : top_(n), bottom_(1) {}
-    explicit Fraction(unsigned long n) : top_(n), bottom_(1) {}
-    explicit Fraction(unsigned long long n) : top_(n), bottom_(1) {}
+    explicit Fraction(unsigned long n) : top_(static_cast<value_type>(n)), bottom_(1) {}
+    explicit Fraction(unsigned long long n) : top_(static_cast<value_type>(n)), bottom_(1) {}
 
     // Fraction(const Fraction& other):
     //     top_(other.top_), bottom_(other.bottom_) {}
@@ -73,11 +74,11 @@ public:  // operators
 
     static Fraction::value_type max_denominator();
 
-    operator double() const { return double(top_) / double(bottom_); }
+    operator double() const { return static_cast<double>(top_) / static_cast<double>(bottom_); }
 
     operator value_type() const;
 
-    Fraction operator-() const { return Fraction(-top_, bottom_); }
+    Fraction operator-() const { return {-top_, bottom_}; }
 
     value_type integralPart() const { return top_ / bottom_; }
 
@@ -216,6 +217,7 @@ private:  // members
     void encode(Stream& out) const;
     void decode(Stream& out);
 
+    std::string to_string() const;
 
     friend std::ostream& operator<<(std::ostream& s, const Fraction& x) {
         x.print(s);

--- a/src/eckit/types/Fraction.h
+++ b/src/eckit/types/Fraction.h
@@ -33,15 +33,7 @@ public:
 
     using value_type = long long;
 
-    // using value_type = __int128 ;
-
-public:  // methods
-         // -- Contructors
-
     Fraction() : top_(0), bottom_(1) {}
-
-    // template<class T>
-    // explicit Fraction(T top): top_(top), bottom_(1) {}
 
     Fraction(value_type top, value_type bottom);
 
@@ -56,21 +48,15 @@ public:  // methods
     explicit Fraction(unsigned long n) : top_(static_cast<value_type>(n)), bottom_(1) {}
     explicit Fraction(unsigned long long n) : top_(static_cast<value_type>(n)), bottom_(1) {}
 
-    // Fraction(const Fraction& other):
-    //     top_(other.top_), bottom_(other.bottom_) {}
-
     explicit Fraction(const std::string&);
     explicit Fraction(const char*);
 
     bool integer() const { return bottom_ == 1; }
 
-    static Fraction abs(const Fraction& f);
+    static Fraction abs(const Fraction&);
 
-    // Convert string to fraction by shifting
-    // the decimal point: e.g. 14.5 in 145/10
+    // Convert string to fraction by shifting the decimal point: e.g. 14.5 in 145/10
     static Fraction fromString(const std::string&);
-
-public:  // operators
 
     static Fraction::value_type max_denominator();
 
@@ -112,23 +98,23 @@ public:  // operators
 
     bool operator>=(const Fraction&) const;
 
-    Fraction& operator+=(const Fraction& other) {
-        *this = (*this) + other;
+    Fraction& operator+=(const Fraction& f) {
+        *this = (*this) + f;
         return *this;
     }
 
-    Fraction& operator-=(const Fraction& other) {
-        *this = (*this) - other;
+    Fraction& operator-=(const Fraction& f) {
+        *this = (*this) - f;
         return *this;
     }
 
-    Fraction& operator/=(const Fraction& other) {
-        *this = (*this) / other;
+    Fraction& operator/=(const Fraction& f) {
+        *this = (*this) / f;
         return *this;
     }
 
-    Fraction& operator*=(const Fraction& other) {
-        *this = (*this) * other;
+    Fraction& operator*=(const Fraction& f) {
+        *this = (*this) * f;
         return *this;
     }
 
@@ -205,32 +191,33 @@ public:  // operators
     }
 
     //====================================
+
     // Return a version that can be converted to double and back
     Fraction stableVersion(size_t max = 1000000) const;
 
-private:  // members
+private:
 
     value_type top_;
     value_type bottom_;
 
-    void print(std::ostream& out) const;
-    void encode(Stream& out) const;
-    void decode(Stream& out);
+    void print(std::ostream&) const;
+    void encode(Stream&) const;
+    void decode(Stream&);
 
     std::string to_string() const;
 
-    friend std::ostream& operator<<(std::ostream& s, const Fraction& x) {
-        x.print(s);
+    friend std::ostream& operator<<(std::ostream& s, const Fraction& f) {
+        f.print(s);
         return s;
     }
 
-    friend Stream& operator<<(Stream& s, const Fraction& x) {
-        x.encode(s);
+    friend Stream& operator<<(Stream& s, const Fraction& f) {
+        f.encode(s);
         return s;
     }
 
-    friend Stream& operator>>(Stream& s, Fraction& x) {
-        x.decode(s);
+    friend Stream& operator>>(Stream& s, Fraction& f) {
+        f.decode(s);
         return s;
     }
 };

--- a/tests/types/test_fraction.cc
+++ b/tests/types/test_fraction.cc
@@ -8,6 +8,7 @@
  * does it submit to any jurisdiction.
  */
 
+#include <cmath>
 #include <limits>
 #include <utility>
 

--- a/tests/types/test_fraction.cc
+++ b/tests/types/test_fraction.cc
@@ -261,12 +261,16 @@ CASE("Regression (Fraction <=> double)") {
 
 CASE("Values known to have problematic conversion to fraction") {
 
-    auto values = std::vector<double>{0.47718059708975263};
+    auto values = std::vector<double>{19.011363983154297, 0.47718059708975263};
     std::streamsize p(Log::debug().precision(16));
     for (auto value : values) {
 
         Log::debug() << "Test " << value << "..." << std::endl;
-        Log::debug() << "Test " << value << " = " << Fraction(value) << std::endl;
+
+        auto frac = Fraction(value);
+        Log::debug() << "Test " << value << " = " << frac << std::endl;
+
+        EXPECT_NOT_EQUAL(frac.denominator(), 0);
     }
     Log::debug().precision(p);
 }


### PR DESCRIPTION
This fixes an issue with eckit::Fraction on some specific conversions from real values (double). It incrementally relaxes the comparison to determine fraction convergence, a more robust approach in the general case.

There's only behaviour change in the Fraction::Fraction(double).

Note that the original behaviour is also preserved, which is just the first attempt to converge strictly (without relaxation), so this does not incur on any changes of results for already working code (particularly mir.) Instead it only makes some additional specific cases work (found on handling some unstructured grids.)

There is urgency in merging this.