### PR TITLE
Python: make eckit build compatible with cd release

### DIFF
--- a/python/eckit/pyproject.toml
+++ b/python/eckit/pyproject.toml
@@ -32,8 +32,8 @@ classifiers=[
 	"Operating System :: MacOS",
 	"Topic :: Scientific/Engineering",
 ]
-dependencies = ["findlibs", "eckitlib", "pyyaml"]
-dynamic = ["version"]
+# dependencies = [] # NOTE don't put anything here, use setup.py instead
+dynamic = ["version", "dependencies"]
 
 
 [tool.setuptools]

--- a/python/eckit/requirements-devel.txt
+++ b/python/eckit/requirements-devel.txt
@@ -1,0 +1,8 @@
+Cython
+numpy
+pyyaml
+setuptools
+build
+twine
+wheel
+pytest

--- a/python/eckit/setup.py
+++ b/python/eckit/setup.py
@@ -39,15 +39,25 @@ def _ext(name: str, sources: list, libraries: list) -> Extension:
         extra_link_args=extra_compile_args,
     )
 
+version: str
+try:
+    with open("../../VERSION", 'r') as f:
+        version = f.readlines()[0].strip()
+except Exception:
+    warnings.warn("failed to read VERSION, falling back to 0.0.0")
+    version = "0.0.0"
+
+install_requires = ["findlibs", "pyyaml"]
 try:
     import eckitlib
-    version = importlib.metadata.version("eckitlib")
+    install_requires.append(f"eckitlib=={eckitlib.__version__}")
 except ImportError:
-    version = "0.0.0"
+    warnings.warn("failed to import eckitlib, not listing as a dependency")
 
 setup(
     name="eckit",
     version=version,
+    install_requires=install_requires,
     ext_modules=cythonize(
         [
             _ext(


### PR DESCRIPTION
1/ similar changes that we recently did to mir-python
2/ support for local installation of prereq wheels (required for whole-stack-develop release)
3/ dynamic version & dependencies