### PR TITLE
Remove now-redundant -DENABLE_ECKIT_GEO=ON from ci-config.yml

### DIFF
--- a/.github/ci-config.yml
+++ b/.github/ci-config.yml
@@ -1,4 +1,3 @@
-cmake_options: -DENABLE_ECKIT_GEO=ON
 dependencies: |
   ecmwf/ecbuild
   MathisRosenhauer/libaec@refs/tags/v1.1.3


### PR DESCRIPTION
Now that the default for -DENABLE_ECKIT_GEO is ON, we no longer need to specify it in the ci-config. This should result in a great improvement in ci performance, as it will increase the number of cache hits when finding ci build artifacts for any package that uses eckit.