### PR TITLE
Fix compilation of Unzip.cc in legacy conda environment

### DIFF
--- a/src/eckit/geo/cache/Unzip.cc
+++ b/src/eckit/geo/cache/Unzip.cc
@@ -10,6 +10,9 @@
  */
 
 
+#include <algorithm>
+#include <memory>
+
 #include "eckit/geo/cache/Unzip.h"
 
 #include "eckit/eckit_config.h"


### PR DESCRIPTION
### Description
Issue found when building for post-processing conda stack

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 