### PR TITLE
Restore compatibility with ecbuild-3.7

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@
 
 cmake_minimum_required( VERSION 3.12 FATAL_ERROR )
 
-find_package( ecbuild 3.11 REQUIRED HINTS ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/../ecbuild)
+find_package( ecbuild 3.7 REQUIRED HINTS ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/../ecbuild)
 
 project( eckit LANGUAGES CXX )
 


### PR DESCRIPTION
### Description

In a update for IFS (diab_CY49R1_for_49R2_v9_hackathon_mtg2sc), I believe for ERA6,
a metkit branch "feature/mtg2_merge" is needed/tested. This recently got updated to require eckit 1.31.4,
which in turn requires ecbuild 3.11 as of recent.

With this setup, the particular ifs-bundle does not build, without more changes to other projects.
It seems ecbuild 3.7 compatibility can still be maintained within eckit,
and the particular IFS configuration was able to successfully build with this PR.

FYI, @andrewcbennett @towil1

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 