### PR TITLE
eckit::geo fix linking of libzip

### DIFF
--- a/src/eckit/geo/CMakeLists.txt
+++ b/src/eckit/geo/CMakeLists.txt
@@ -60,8 +60,6 @@ list(APPEND eckit_geo_srcs
     cache/Download.h
     cache/MemoryCache.cc
     cache/MemoryCache.h
-    cache/Unzip.cc
-    cache/Unzip.h
     container/PointsContainer.cc
     container/PointsContainer.h
     figure/Earth.cc
@@ -218,7 +216,12 @@ if(eckit_HAVE_GEO_GRID_ORCA)
 endif()
 
 if(eckit_HAVE_GEO_AREA_SHAPEFILE)
-    list(APPEND eckit_geo_srcs area/library/Shapefile.cc area/library/Shapefile.h)
+    list(APPEND eckit_geo_srcs
+        area/library/Shapefile.cc
+        area/library/Shapefile.h
+        cache/Unzip.cc
+        cache/Unzip.h
+    )
     list(APPEND eckit_geo_libs shapelib::shp libzip::zip)
 endif()
 


### PR DESCRIPTION
### Description
There is a problem in linking the geo lib of eckit when the build environment contains libzip but not shapelib (e.g. conda-forge). This fixes that issue.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 