### PR TITLE
Type to string conversion utilites

### DIFF
--- a/src/eckit/utils/TypeToString.h
+++ b/src/eckit/utils/TypeToString.h
@@ -1,0 +1,142 @@
+/*
+ * (C) Copyright 2025- ECMWF.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation nor
+ * does it submit to any jurisdiction.
+ */
+
+#pragma once
+
+#include <functional>
+#include <memory>
+#include <optional>
+#include <string>
+#include <tuple>
+#include <type_traits>
+#include <variant>
+#include <vector>
+
+#include <string_view>
+
+/// This file provides utilities to convert types to readable strings
+///
+/// > IMPORTANT: These utilities are intended to be used for log and exception
+/// > messages. Do not use them to carry type information and build logic on top.
+
+
+namespace eckit {
+
+/// Very common and accepted approach: https://stackoverflow.com/a/56766138/576911
+/// Demo: https://godbolt.org/z/Mr1ercr49
+/// Works for Clang, GCC, ICC, NVC++
+/// Only types like `std::string` usually get printed as `std::basic_string<char>` or `std::__cxx11::basic_string<char,
+/// std::char_traits<char>, std::allocator<char>>` For this reason a wrapper `TypeToString` is presented.
+template <typename T>
+constexpr auto typeName() {
+    std::string_view name, prefix, suffix;
+#ifdef __clang__
+    name   = __PRETTY_FUNCTION__;
+    prefix = "auto eckit::typeName() [T = ";
+    suffix = "]";
+#elif defined(__GNUC__)
+    name   = __PRETTY_FUNCTION__;
+    prefix = "constexpr auto eckit::typeName() [with T = ";
+    suffix = "]";
+#elif defined(_MSC_VER)
+    name   = __FUNCSIG__;
+    prefix = "auto __cdecl eckit::typeName<";
+    suffix = ">(void)";
+#endif
+    name.remove_prefix(prefix.size());
+    name.remove_suffix(suffix.size());
+    return name;
+}
+
+/// Template class to customize string representation for specific types for *log and error messages*.
+/// By default it uses `typeName<T>()` - but in some cases a prettier output is desired (e.g. std::string)
+///
+/// A few template `std` types are specialized to pretty print the template arguments.
+///
+/// Instead of using a string_view, a call operator is used at runtime that allows concatenation of strings.
+/// With C++20 all could be written with constexpr strings.
+template <typename T>
+struct TypeToString {
+    std::string operator()() const { return std::string(typeName<T>()); };
+};
+
+
+template <typename T>
+std::string typeToString() {
+    return TypeToString<T>{}();
+}
+
+template <typename T>
+struct TypeToString<const T> {
+    std::string operator()() const { return std::string("const ") + typeToString<std::remove_cv_t<T>>(); };
+};
+
+template <typename T>
+struct TypeToString<T&> {
+    std::string operator()() const { return typeToString<std::remove_reference_t<T>>() + std::string("&"); };
+};
+template <typename T>
+struct TypeToString<T&&> {
+    std::string operator()() const { return typeToString<std::remove_reference_t<T>>() + std::string("&&"); };
+};
+
+template <>
+struct TypeToString<std::string> {
+    std::string operator()() const { return "std::string"; };
+};
+
+template <typename T>
+struct TypeToString<std::optional<T>> {
+    std::string operator()() const { return std::string("std::optional<") + typeToString<T>() + std::string(">"); };
+};
+
+template <typename T, typename Alloc>
+struct TypeToString<std::vector<T, Alloc>> {
+    std::string operator()() const { return std::string("std::vector<") + typeToString<T>() + std::string(">"); };
+};
+
+template <typename... T>
+struct TypeToString<std::tuple<T...>> {
+    std::string operator()() const {
+        return std::string("std::tuple<") + ((typeToString<T>() + std::string(", ")) + ... + std::string(">"));
+    };
+};
+
+template <typename... T>
+struct TypeToString<std::variant<T...>> {
+    std::string operator()() const {
+        return std::string("std::variant<") + ((typeToString<T>() + std::string(", ")) + ... + std::string(">"));
+    };
+};
+
+template <typename T>
+struct TypeToString<std::reference_wrapper<T>> {
+    std::string operator()() const {
+        return std::string("std::reference_wrapper<") + typeToString<T>() + std::string(">");
+    };
+};
+
+template <typename T, typename Deleter>
+struct TypeToString<std::unique_ptr<T, Deleter>> {
+    std::string operator()() const {
+        return std::string("std::unique_ptr<") + typeToString<T>() + std::string(", Deleter>");
+    };
+};
+
+template <typename T>
+struct TypeToString<std::shared_ptr<T>> {
+    std::string operator()() const { return std::string("std::shared_ptr<") + typeToString<T>() + std::string(">"); };
+};
+
+
+//-----------------------------------------------------------------------------
+
+
+}  // namespace eckit

--- a/tests/utils/CMakeLists.txt
+++ b/tests/utils/CMakeLists.txt
@@ -21,6 +21,10 @@ ecbuild_add_test( TARGET      eckit_test_utils_string_tools
                   SOURCES     test_string_tools.cc
                   LIBS        eckit )
 
+ecbuild_add_test( TARGET      eckit_test_type_to_string
+                  SOURCES     test_type_to_string.cc
+                  LIBS        eckit )
+
 ecbuild_add_test( TARGET      eckit_test_utils_translator
                   SOURCES     test_translator.cc
                   LIBS        eckit )

--- a/tests/utils/test_type_to_string.cc
+++ b/tests/utils/test_type_to_string.cc
@@ -1,0 +1,88 @@
+/*
+ * (C) Copyright 1996- ECMWF.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation nor
+ * does it submit to any jurisdiction.
+ */
+
+#include "eckit/log/Log.h"
+#include "eckit/runtime/Tool.h"
+#include "eckit/utils/TypeToString.h"
+
+#include "eckit/testing/Test.h"
+
+using namespace std;
+using namespace eckit;
+using namespace eckit::testing;
+
+namespace eckit::test {
+
+//----------------------------------------------------------------------------------------------------------------------
+
+CASE("typeToString<std::string>()") {
+    EXPECT_EQUAL(typeToString<std::string>(), "std::string");
+}
+CASE("typeToString<const std::string>()") {
+    EXPECT_EQUAL(typeToString<const std::string>(), "const std::string");
+}
+CASE("typeToString<const std::string&>()") {
+    EXPECT_EQUAL(typeToString<const std::string&>(), "const std::string&");
+}
+
+CASE("typeToString<int>()") {
+    EXPECT_EQUAL(typeToString<int>(), "int");
+}
+CASE("typeToString<const int>()") {
+    EXPECT_EQUAL(typeToString<const int>(), "const int");
+}
+CASE("typeToString<const int&>()") {
+    EXPECT_EQUAL(typeToString<const int&>(), "const int&");
+}
+
+CASE("typeToString<double>()") {
+    EXPECT_EQUAL(typeToString<double>(), "double");
+}
+CASE("typeToString<const double>()") {
+    EXPECT_EQUAL(typeToString<const double>(), "const double");
+}
+CASE("typeToString<const double&>()") {
+    EXPECT_EQUAL(typeToString<const double&>(), "const double&");
+}
+
+
+namespace myspace {
+template <typename X>
+struct MyType;
+}  // namespace myspace
+
+}  // namespace eckit::test
+
+namespace eckit {
+template <typename X>
+struct TypeToString<eckit::test::myspace::MyType<X>> {
+    std::string operator()() const {
+        return std::string("eckit::test::myspace::MyType<") + eckit::typeToString<X>() + std::string(">");
+    }
+};
+}  // namespace eckit
+
+namespace eckit::test {
+
+CASE("typeToString<eckit::test::myspace::MyType<int>>()") {
+    EXPECT_EQUAL(typeToString<eckit::test::myspace::MyType<int>>(), "eckit::test::myspace::MyType<int>");
+}
+CASE("typeToString<eckit::test::myspace::MyType<std::string>>()") {
+    EXPECT_EQUAL(typeToString<eckit::test::myspace::MyType<std::string>>(),
+                 "eckit::test::myspace::MyType<std::string>");
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+
+}  // namespace eckit::test
+
+int main(int argc, char** argv) {
+    return run_tests(argc, argv);
+}


### PR DESCRIPTION
### Description

This PR provides utilities to convert arbitrary types to strings by calling `typeToString<T>()`. 
This utility is useful to create detailed error (and log) messages in templated code or to generate 
a set of specialized error messages consistently.

A typical usecase is type dispatching with `std::variant`:

```
using Value = std::variant<bool, long, double, std::string>;

template<typename T>
T getValue(const Value& var) {
   if (std::holds_alternative<T>(var)) {
      return std::get<T>(var);   
   }
   std::ostringstream oss;
   oss << "Expected type " << typeToString<T>() << " but contained ";
   oss << std::visit([](const auto& v){ return typeToString<std::decay_t<decltype(v)>>(); }, var);
   throw std::runtime_error(oss.str());
};

```


### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 