### PR TITLE
Add std::hash specializations for Date, Time, DateTime

### DIFF
--- a/src/eckit/CMakeLists.txt
+++ b/src/eckit/CMakeLists.txt
@@ -682,6 +682,7 @@ list( APPEND eckit_utils_srcs
     utils/EnumBitmask.h
     utils/Hash.cc
     utils/Hash.h
+    utils/HashCombine.h
     utils/HyperCube.cc
     utils/HyperCube.h
     utils/Literals.h

--- a/src/eckit/types/Date.h
+++ b/src/eckit/types/Date.h
@@ -16,6 +16,8 @@
 #ifndef eckit_Date_h
 #define eckit_Date_h
 
+#include <functional>
+
 #include "eckit/persist/Bless.h"
 
 namespace eckit {
@@ -166,5 +168,12 @@ private:
 //----------------------------------------------------------------------------------------------------------------------
 
 }  // namespace eckit
+
+template <>
+struct std::hash<eckit::Date> {
+    std::size_t operator()(const eckit::Date& d) const noexcept {
+        return std::hash<long>{}(d.julian());
+    }
+};
 
 #endif

--- a/src/eckit/types/DateTime.h
+++ b/src/eckit/types/DateTime.h
@@ -18,6 +18,7 @@
 
 #include "eckit/types/Date.h"
 #include "eckit/types/Time.h"
+#include "eckit/utils/HashCombine.h"
 
 
 namespace eckit {
@@ -97,5 +98,14 @@ private:  // methods
 //----------------------------------------------------------------------------------------------------------------------
 
 }  // namespace eckit
+
+template <>
+struct std::hash<eckit::DateTime> {
+    std::size_t operator()(const eckit::DateTime& dt) const noexcept {
+        std::size_t seed = std::hash<eckit::Date>{}(dt.date());
+        eckit::hash_combine(seed, std::hash<eckit::Time>{}(dt.time()));
+        return seed;
+    }
+};
 
 #endif

--- a/src/eckit/types/Time.h
+++ b/src/eckit/types/Time.h
@@ -17,6 +17,7 @@
 #define eckit_Time_h
 
 #include <cstdint>
+#include <functional>
 
 #include "eckit/exception/Exceptions.h"
 #include "eckit/persist/Bless.h"
@@ -124,5 +125,12 @@ public:
 //----------------------------------------------------------------------------------------------------------------------
 
 }  // namespace eckit
+
+template <>
+struct std::hash<eckit::Time> {
+    std::size_t operator()(const eckit::Time& t) const noexcept {
+        return std::hash<long>{}(t.hhmmss());
+    }
+};
 
 #endif

--- a/src/eckit/utils/HashCombine.h
+++ b/src/eckit/utils/HashCombine.h
@@ -1,0 +1,34 @@
+/*
+ * (C) Copyright 1996- ECMWF.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation nor
+ * does it submit to any jurisdiction.
+ */
+
+#pragma once
+
+#include <cstddef>
+#include <functional>
+
+namespace eckit {
+
+/// Combine a hash value into a seed (boost::hash_combine equivalent).
+///
+/// Uses the 64-bit golden-ratio constant to mix bits and reduce
+/// collisions when combining multiple hash values for use with
+/// std::hash and unordered containers.
+inline void hash_combine(std::size_t& seed, std::size_t value) noexcept {
+    seed ^= value + 0x9e3779b97f4a7c15ULL + (seed << 6) + (seed >> 2);
+}
+
+/// Variadic convenience: combine multiple hash values into a seed.
+template <typename T, typename... Rest>
+inline void hash_combine(std::size_t& seed, const T& v, const Rest&... rest) {
+    hash_combine(seed, std::hash<T>{}(v));
+    (hash_combine(seed, std::hash<Rest>{}(rest)), ...);
+}
+
+}  // namespace eckit

--- a/tests/types/test_time.cc
+++ b/tests/types/test_time.cc
@@ -10,7 +10,10 @@
 
 
 #include <iomanip>
+#include <unordered_set>
 #include "eckit/testing/Test.h"
+#include "eckit/types/Date.h"
+#include "eckit/types/DateTime.h"
 #include "eckit/types/Time.h"
 
 using namespace std;
@@ -165,6 +168,50 @@ CASE("Time with unit (__h__m__s)") {
     EXPECT(Time("0d3h10m20s") == Time("3h10m20s"));
     EXPECT(Time("0d3h10m20s") == Time("3h620s"));
     EXPECT(Time("2D3h", true) == Time("51h", true));
+}
+
+CASE("std::hash<Date>") {
+    std::unordered_set<Date> dates;
+    dates.insert(Date(2024, 3, 15));
+    dates.insert(Date(2024, 3, 15));  // duplicate
+    dates.insert(Date(2024, 3, 16));
+    EXPECT(dates.size() == 2);
+
+    EXPECT(std::hash<Date>{}(Date(2024, 3, 15))
+        == std::hash<Date>{}(Date(2024, 3, 15)));
+
+    EXPECT(std::hash<Date>{}(Date(2024, 3, 15))
+        != std::hash<Date>{}(Date(2024, 3, 16)));
+}
+
+CASE("std::hash<Time>") {
+    std::unordered_set<Time> times;
+    times.insert(Time(12, 30, 0));
+    times.insert(Time(12, 30, 0));  // duplicate
+    times.insert(Time(12, 30, 1));
+    EXPECT(times.size() == 2);
+
+    EXPECT(std::hash<Time>{}(Time(12, 30, 0))
+        == std::hash<Time>{}(Time(12, 30, 0)));
+
+    EXPECT(std::hash<Time>{}(Time(12, 30, 0))
+        != std::hash<Time>{}(Time(12, 30, 1)));
+}
+
+CASE("std::hash<DateTime>") {
+    std::unordered_set<DateTime> dts;
+    dts.insert(DateTime(Date(2024, 3, 15), Time(12, 0, 0)));
+    dts.insert(DateTime(Date(2024, 3, 15), Time(12, 0, 0)));  // duplicate
+    dts.insert(DateTime(Date(2024, 3, 15), Time(12, 0, 1)));
+    EXPECT(dts.size() == 2);
+
+    // Same date, different time
+    EXPECT(std::hash<DateTime>{}(DateTime(Date(2024, 3, 15), Time(12, 0, 0)))
+        != std::hash<DateTime>{}(DateTime(Date(2024, 3, 15), Time(12, 0, 1))));
+
+    // Different date, same time
+    EXPECT(std::hash<DateTime>{}(DateTime(Date(2024, 3, 15), Time(12, 0, 0)))
+        != std::hash<DateTime>{}(DateTime(Date(2024, 3, 16), Time(12, 0, 0))));
 }
 
 //----------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
### Description

Allow Date, Time, and DateTime to be used as keys in std::unordered_map and std::unordered_set by providing std::hash specializations in each type's header.

Date hashes via julian(), Time via hhmmss() (avoiding floating-point hash pitfalls on the underlying double), and DateTime combines both using a new hash_combine utility.

Requires ecbuild fix for sg.pl to handle template <> syntax.

Fixes: ECKIT-561

NOTE: blocked by a bug in ecbuild/sg.pl https://github.com/ecmwf/ecbuild/pull/134

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 

<!-- PREVIEW-URL_BEGIN -->
🌦️ >> Documentation << 🌦️
https://sites.ecmwf.int/docs/dev-section/eckit/pull-requests/PR-278
<!-- PREVIEW-URL_END -->