### PR TITLE
Make baseName consistent with C++17 filesystem::path::stem

### DIFF
--- a/src/eckit/filesystem/LocalPathName.cc
+++ b/src/eckit/filesystem/LocalPathName.cc
@@ -167,19 +167,9 @@ LocalPathName LocalPathName::baseName(bool ext) const {
 
     std::string s(path_.c_str() + n + 1);
     if (!ext) {
-        n = -1;
-        i = 0;
-        q = s.c_str();
-        while (*q) {
-            if (*q == '.') {
-                n = i;
-                break;
-            }
-            q++;
-            i++;
-        }
-        if (n >= 0) {
-            s.resize(n);
+        const auto lastDot = s.find_last_of('.');
+        if (lastDot != std::string::npos && lastDot != 0) {
+            s.resize(lastDot);
         }
     }
 

--- a/src/eckit/filesystem/LocalPathName.h
+++ b/src/eckit/filesystem/LocalPathName.h
@@ -135,7 +135,7 @@ public:  // methods
     std::string clusterName() const;
 
     /// Base name of the path
-    /// @param ext if false the extension is stripped
+    /// @param ext if false only the final extension is stripped
     /// @return the name part of the path
     LocalPathName baseName(bool ext = true) const;
 

--- a/tests/filesystem/test_localpathname.cc
+++ b/tests/filesystem/test_localpathname.cc
@@ -255,6 +255,23 @@ CASE("Extract basename") {
     LocalPathName p("/a/made/up/path/that/does/not/exist/file.ok");
     EXPECT(p.baseName(false) == "file");
     EXPECT(p.baseName(true) == "file.ok");
+
+    // ECKIT-415: multi-dot filenames should strip only the final extension
+    EXPECT(LocalPathName("/path/archive.tar.gz").baseName(false) == "archive.tar");
+    EXPECT(LocalPathName("/path/archive.tar.gz").baseName(true) == "archive.tar.gz");
+
+    EXPECT(LocalPathName("file..txt").baseName(false) == "file.");
+    EXPECT(LocalPathName("file..txt").baseName(true) == "file..txt");
+
+    // Hidden files (leading dot is not an extension separator)
+    EXPECT(LocalPathName("/path/.hidden").baseName(false) == ".hidden");
+    EXPECT(LocalPathName("/path/.hidden").baseName(true) == ".hidden");
+    EXPECT(LocalPathName("/path/.hidden.tar.gz").baseName(false) == ".hidden.tar");
+    EXPECT(LocalPathName("/path/.hidden.tar.gz").baseName(true) == ".hidden.tar.gz");
+
+    // Directory with dots in the path should not affect baseName
+    EXPECT(LocalPathName("/path/with.dot/to/file.ext").baseName(false) == "file");
+    EXPECT(LocalPathName("/path/with.dot/to/file.ext").baseName(true) == "file.ext");
 }
 
 CASE("Extract extension from Path") {


### PR DESCRIPTION
### Description


baseName(false) stripped from the first dot instead of the last, producing incorrect results for multi-extension filenames such as archive.tar.gz (yielded "archive" instead of "archive.tar"). This is inconsistent with C++17 std::filesystem::path::stem and with eckit's own extension() method which already uses find_last_of.

Fixes: ECKIT-415

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 

<!-- PREVIEW-URL_BEGIN -->
🌦️ >> Documentation << 🌦️
https://sites.ecmwf.int/docs/dev-section/eckit/pull-requests/PR-281
<!-- PREVIEW-URL_END -->