### PR TITLE
Feature/exceptions runtime context

### DIFF
--- a/src/eckit/cmd/CmdArg.cc
+++ b/src/eckit/cmd/CmdArg.cc
@@ -55,7 +55,7 @@ CmdArg::CmdArg() {}
 
 CmdArg::~CmdArg() {}
 
-CmdArg::CmdArg(const CmdArg& other) : args_(other.args_) {}
+CmdArg::CmdArg(const CmdArg& other) : Streamable(other), args_(other.args_) {}
 
 CmdArg& CmdArg::operator=(const CmdArg& other) {
     args_ = other.args_;

--- a/src/eckit/cmd/UserInput.cc
+++ b/src/eckit/cmd/UserInput.cc
@@ -564,7 +564,7 @@ void UserInput::loadHistory(const char* path) {
     memset(line, 0, sizeof(line));
     while (fgets(line, sizeof(line) - 1, f)) {
 
-        entry* h = (entry*)calloc(sizeof(entry), 1);
+        entry* h = (entry*)calloc(1, sizeof(entry));
 
         int len = strlen(line);
         while (len) {
@@ -639,7 +639,7 @@ const char* UserInput::getUserInput(const char* prompt, completion_proc completi
 
     bool done = false;
     context s;
-    entry* h = (entry*)calloc(sizeof(entry), 1);
+    entry* h = (entry*)calloc(1, sizeof(entry));
     h->len   = 80;
     h->line  = (char*)calloc(h->len, 1);
     h->prev  = history;

--- a/src/eckit/exception/Exceptions.cc
+++ b/src/eckit/exception/Exceptions.cc
@@ -23,9 +23,35 @@ namespace eckit {
 
 //----------------------------------------------------------------------------------------------------------------------
 
-static bool getenv_on(const char* env) {
-    const auto* var = std::getenv(env);
-    return var != nullptr && std::string(var) != "0";
+struct Runtime {
+    static const Runtime& instance() {
+        static const Runtime runtime;
+        return runtime;
+    }
+
+    bool assertFailedIsSilent;
+    bool exceptionIsSilent;
+    bool seriousBugIsSilent;
+
+    bool assertAborts;
+    bool exceptionDumpsBacktrace;
+    bool stopOnPanic;
+
+private:
+
+    static bool getenv_on(const char* env) {
+        static const std::string ZERO("0");
+        const auto* var = std::getenv(env);
+        return var != nullptr && var != ZERO;
+    }
+
+    Runtime() :
+        assertFailedIsSilent(getenv_on("ECKIT_ASSERT_FAILED_IS_SILENT")),
+        exceptionIsSilent(getenv_on("ECKIT_EXCEPTION_IS_SILENT")),
+        seriousBugIsSilent(getenv_on("ECKIT_SERIOUS_BUG_IS_SILENT")),
+        assertAborts(getenv_on("ECKIT_ASSERT_ABORTS")),
+        exceptionDumpsBacktrace(getenv_on("ECKIT_EXCEPTION_DUMPS_BACKTRACE")),
+        stopOnPanic(getenv_on("STOP_ON_PANIC")) {}
 };
 
 static Exception*& first() {
@@ -38,7 +64,7 @@ Exception::Exception() : next_(first()) {
 
     callStack_ = BackTrace::dump();
 
-    if (getenv_on("ECKIT_EXCEPTION_DUMPS_BACKTRACE")) {
+    if (Runtime::instance().exceptionDumpsBacktrace) {
         std::cerr << "Exception dumping backtrace: " << callStack_ << std::endl;
     }
 }
@@ -69,11 +95,11 @@ Exception::Exception(const std::string& w, const CodeLocation& loc, bool quiet) 
     what_(w), next_(first()), location_(loc) {
     callStack_ = BackTrace::dump();
 
-    if (getenv_on("ECKIT_EXCEPTION_DUMPS_BACKTRACE")) {
+    if (Runtime::instance().exceptionDumpsBacktrace) {
         std::cerr << "Exception dumping backtrace: " << callStack_ << std::endl;
     }
 
-    if (!getenv_on("ECKIT_EXCEPTION_IS_SILENT") && !quiet) {
+    if (!Runtime::instance().exceptionIsSilent && !quiet) {
         Log::error() << "Exception: " << w << " " << location_ << std::endl;
         Log::status() << "** " << w << location_ << std::endl;
     }
@@ -86,7 +112,7 @@ std::ostream& Exception::dumpStackTrace(std::ostream& out) {
 }
 
 void Exception::reason(const std::string& w) {
-    if (!getenv_on("ECKIT_EXCEPTION_IS_SILENT")) {
+    if (!Runtime::instance().exceptionIsSilent) {
         Log::error() << "Exception: " << w << std::endl;
     }
     what_ = w;
@@ -115,7 +141,7 @@ FailedSystemCall::FailedSystemCall(const std::string& w, const CodeLocation& loc
 }
 
 SeriousBug::SeriousBug(const std::string& w, const CodeLocation& loc) : Exception("Serious bug: " + w, loc) {
-    if (!getenv_on("ECKIT_SERIOUS_BUG_IS_SILENT")) {
+    if (!Runtime::instance().seriousBugIsSilent) {
         std::cout << what() << std::endl << BackTrace::dump() << std::endl;
     }
 }
@@ -127,13 +153,13 @@ void handle_assert(const std::string& msg, const CodeLocation& loc) {
     std::ostringstream s;
     s << "Assertion failed: " << msg << loc;
 
-    if (!getenv_on("ECKIT_ASSERT_FAILED_IS_SILENT")) {
+    if (!Runtime::instance().assertFailedIsSilent) {
         Log::status() << s.str() << std::endl;
 
         std::cout << s.str() << std::endl << BackTrace::dump() << std::endl;
     }
 
-    if (getenv_on("ECKIT_ASSERT_ABORTS")) {
+    if (Runtime::instance().assertAborts) {
         LibEcKit::instance().abort();
         return;
     }
@@ -231,7 +257,7 @@ void handle_panic(const char* msg, const CodeLocation& loc) {
               << "----------------------------------------\n"
               << std::endl;
 
-    if (getenv_on("STOP_ON_PANIC")) {
+    if (Runtime::instance().stopOnPanic) {
         pid_t pid = ::getpid();
 
         std::cout << "Stopped process with PID " << pid << " - attach a debugger or send a SIGCONT signal to abort"

--- a/src/eckit/exception/Exceptions.h
+++ b/src/eckit/exception/Exceptions.h
@@ -26,6 +26,7 @@
 #include <cerrno>
 #include <iostream>
 #include <sstream>
+#include <string>
 
 #include "eckit/log/CodeLocation.h"
 #include "eckit/log/Log.h"

--- a/src/eckit/sql/expression/function/FunctionCOUNT.cc
+++ b/src/eckit/sql/expression/function/FunctionCOUNT.cc
@@ -19,8 +19,7 @@ namespace eckit::sql::expression::function {
 static FunctionBuilder<FunctionCOUNT> countFunctionBuilder("count");
 
 const type::SQLType* FunctionCOUNT::type() const {
-    const type::SQLType& x = type::SQLType::lookup("double");
-    return &x;
+    return &type::SQLType::lookup(std::string{"double"});
 }
 
 FunctionCOUNT::FunctionCOUNT(const std::string& name, const expression::Expressions& args) :


### PR DESCRIPTION
### Description

This refactors the messaging behaviour of the eckit::Exception base class, it is a refactor simply to ensure:
- env variables are retrieved and evaluated once
- the code is easier to follow -- this (good)change comes from the difficulty of integrating eckit with eccodes, anything helps

There is a second commit to this which is only compilation warning fixes, that should be not related to this but are so minor (and should really go straight to develop) but I would like you to have a quick look anyway, since it is for code you might have come accross already.


### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 


<!-- PREVIEW-URL_BEGIN -->
🌦️ >> Documentation << 🌦️
https://sites.ecmwf.int/docs/dev-section/eckit/pull-requests/PR-288
<!-- PREVIEW-URL_END -->