### PR TITLE
Test cache only when libzip is available

### DIFF
--- a/tests/geo/CMakeLists.txt
+++ b/tests/geo/CMakeLists.txt
@@ -4,7 +4,6 @@ file(COPY "${CMAKE_CURRENT_SOURCE_DIR}/eckit_geo_cache" DESTINATION "${CMAKE_CUR
 foreach(_test
         area_boundingbox
         area_polygon
-        cache
         figure
         figure_earth
         gaussian
@@ -49,6 +48,12 @@ foreach(_test
 endforeach()
 
 if(eckit_HAVE_ZIP)
+    ecbuild_add_test(
+        TARGET      eckit_test_geo_cache
+        SOURCES     cache.cc ${PROJECT_SOURCE_DIR}/src/eckit/geo/cache/Unzip.cc
+        LIBS        eckit_geo libzip::zip
+        ENVIRONMENT "ECKIT_GEO_CACHE_PATH=${_cache_path}" )
+
     target_compile_definitions(eckit_test_geo_cache PRIVATE ZIP_FILE="${CMAKE_CURRENT_SOURCE_DIR}/test.zip")
 endif()
 


### PR DESCRIPTION
### Description
This pull request updates the test configuration for the geo module by changing how the `cache` test is handled. The main change is to move the `cache` test out of the standard test loop and add it conditionally, only when ZIP support is available.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 


<!-- PREVIEW-URL_BEGIN -->
🌦️ >> Documentation << 🌦️
https://sites.ecmwf.int/docs/dev-section/eckit/pull-requests/PR-305
<!-- PREVIEW-URL_END -->