### PR TITLE
chore: findlibs>=0.1.2

### DIFF
--- a/python/eckit/setup.py
+++ b/python/eckit/setup.py
@@ -8,7 +8,7 @@ with open("VERSION", "r") as fVersion:
     version = fVersion.readlines()[0].strip()
 install_requires = [
     f"eckitlib=={version}",
-    "findlibs",
+    "findlibs>=0.1.2",
     "pyyaml",
     "requests",
 ]


### PR DESCRIPTION
### Description
Uses `findlibs.load` method

https://github.com/ecmwf/eckit/blob/a761693e49ab14d116d14d7079fb534b411b023d/python/eckit/src/eckit/__init__.py#L12

but this isn't available in older versions e.g. 0.1.0, giving errors

```
        findlibs.load("eckit")
        ^^^^^^^^^^^^^
    AttributeError: module 'findlibs' has no attribute 'load'
```

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 


<!-- PREVIEW-URL_BEGIN -->
🌦️ >> Documentation << 🌦️
https://sites.ecmwf.int/docs/dev-section/eckit/pull-requests/PR-307
<!-- PREVIEW-URL_END -->