### PR TITLE
Use division for PointLonLat

### DIFF
--- a/src/eckit/geo/PointLonLat.h
+++ b/src/eckit/geo/PointLonLat.h
@@ -128,6 +128,7 @@ public:
         return {p.lon() + q.lon(), p.lat() + q.lat()};
     }
     friend PointLonLat operator*(const PointLonLat& p, value_type d) { return {p.lon() * d, p.lat() * d}; }
+    friend PointLonLat operator/(const PointLonLat& p, value_type d) { return {p.lon() / d, p.lat() / d}; }
 
     friend bool operator<(const PointLonLat& p, const PointLonLat& q) {
         return static_cast<const container_type&>(p) < static_cast<const container_type&>(q);

--- a/src/eckit/geo/polygon/Polygon.cc
+++ b/src/eckit/geo/polygon/Polygon.cc
@@ -99,7 +99,7 @@ void Polygon::emplace_back_point_at_intersection(const Edge& E, const Edge& F) {
 
     if (const auto D = cross(A, B); !is_zero(D)) {
         const auto C = E.first - F.first;
-        emplace_back_point(E.first + A * cross(B, C) * (1. / D));
+        emplace_back_point(E.first + A * cross(B, C) / D);
     }
 }
 


### PR DESCRIPTION
### Description

Use a division for PointLonLat in addition to the other arithmetic operators.  Resolves #234.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
