### PR TITLE
Avoid lz4 tests without lz4

### DIFF
--- a/tests/geo/CMakeLists.txt
+++ b/tests/geo/CMakeLists.txt
@@ -8,18 +8,15 @@ foreach(_test
         figure_earth
         gaussian
         great_circle
-        grid
         grid_fesom
         grid_healpix
         grid_icon
-        grid_orca
         grid_reduced_gg
         grid_reduced_ll
         grid_regular_gg
         grid_regular_ll
         grid_reorder
         grid_to_points
-        grid_unstructured_ll
         gridspec
         integration
         iterator
@@ -46,6 +43,24 @@ foreach(_test
         LIBS        eckit_geo
         ENVIRONMENT "ECKIT_GEO_CACHE_PATH=${_cache_path}" )
 endforeach()
+
+if(eckit_HAVE_LZ4)
+    ecbuild_add_test(
+        TARGET      eckit_test_geo_grid
+        SOURCES     grid.cc
+        LIBS        eckit_geo
+        ENVIRONMENT "ECKIT_GEO_CACHE_PATH=${_cache_path}" )
+    ecbuild_add_test(
+        TARGET      eckit_test_geo_grid_orca
+        SOURCES     grid_orca.cc
+        LIBS        eckit_geo
+        ENVIRONMENT "ECKIT_GEO_CACHE_PATH=${_cache_path}" )
+    ecbuild_add_test(
+        TARGET      eckit_test_geo_grid_unstructured_ll
+        SOURCES     grid_unstructured_ll.cc
+        LIBS        eckit_geo
+        ENVIRONMENT "ECKIT_GEO_CACHE_PATH=${_cache_path}" )
+endif()
 
 if(eckit_HAVE_ZIP)
     ecbuild_add_test(


### PR DESCRIPTION
### Description

Don't compile tests that require lz4 when lz4 is support is not there.

Fix #310.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
