### PR TITLE
ECKIT-687: pooled file mutex

### DIFF
--- a/src/eckit/io/PooledFile.cc
+++ b/src/eckit/io/PooledFile.cc
@@ -88,11 +88,12 @@ public:
 
     PoolFileEntry(const std::string& name) : name_(name), file_{nullptr}, count_(0) {}
 
-    void doClose() {
+    void doClose() noexcept {
         if (file_) {
             Log::debug<LibEcKit>() << "Closing from file " << name_ << std::endl;
+            // log and swallow rather than throw (a throwing destructor would terminate!)
             if (::fclose(file_) != 0) {
-                throw PooledFileError(name_, "Failed to close", Here());
+                Log::error() << "PooledFile: failed to close " << name_ << " (" << Log::syserr << ")" << std::endl;
             }
             file_ = nullptr;
             buffer_.reset();
@@ -235,9 +236,7 @@ public:
 
 PooledFile::PooledFile(const PathName& name) : name_(name), entry_(Pool::instance().get(name, this)) {}
 
-/// @note this dtor may throw
 PooledFile::~PooledFile() {
-    ASSERT(entry_);
     Pool::instance().release(name_, this);
 }
 

--- a/src/eckit/io/PooledFile.cc
+++ b/src/eckit/io/PooledFile.cc
@@ -314,7 +314,9 @@ void Pool::release(const eckit::PathName& name, const eckit::PooledFile* file) {
     std::lock_guard lock(filePoolMutex_);
     auto iter = filePool_.find(name);
     ASSERT(iter != filePool_.end());
-    if (auto* entry = iter->second.get(); entry->remove(file)) {
+    auto* entry        = iter->second.get();
+    auto last_user_out = entry->remove(file);
+    if (last_user_out) {
         entry->doClose();
         filePool_.erase(iter);
     }

--- a/src/eckit/io/PooledFile.cc
+++ b/src/eckit/io/PooledFile.cc
@@ -14,6 +14,7 @@
 #include <map>
 #include <memory>
 #include <mutex>
+#include <ostream>
 #include <sstream>
 #include <string>
 #include <utility>
@@ -24,6 +25,8 @@
 #include "eckit/filesystem/PathName.h"
 #include "eckit/io/Buffer.h"
 #include "eckit/log/Bytes.h"
+#include "eckit/log/CodeLocation.h"
+#include "eckit/log/Log.h"
 
 namespace eckit {
 class PoolFileEntry;
@@ -45,8 +48,8 @@ public:
         static Pool pool;
         return pool;
     }
-    eckit::PoolFileEntry* get(const eckit::PathName& name);
-    void erase(const eckit::PathName& name);
+    eckit::PoolFileEntry* get(const eckit::PathName& name, const eckit::PooledFile* file);
+    void release(const eckit::PathName& name, const eckit::PooledFile* file);
 };
 
 }  // namespace
@@ -72,6 +75,8 @@ public:
 
     std::map<const PooledFile*, PoolFileEntryStatus> statuses_;
 
+    mutable std::mutex mutex_;
+
     size_t nbOpens_ = 0;
     size_t nbReads_ = 0;
     size_t nbSeeks_ = 0;
@@ -92,23 +97,25 @@ public:
     }
 
     void add(const PooledFile* file) {
+        std::lock_guard lock(mutex_);
         ASSERT(statuses_.find(file) == statuses_.end());
         statuses_[file] = PoolFileEntryStatus();
     }
 
-    void remove(const PooledFile* file) {
+    /// Detach @p file. Called by Pool::release while holding the Pool lock.
+    /// @returns true if this was the last user, in which case the caller must close and destroy the
+    ///          entry (still under the Pool lock, so no new user can attach in between).
+    bool remove(const PooledFile* file) {
+        std::lock_guard lock(mutex_);
         auto s = statuses_.find(file);
         ASSERT(s != statuses_.end());
 
         statuses_.erase(s);
-        if (statuses_.size() == 0) {
-            doClose();
-            Pool::instance().erase(name_);
-            // No code after !!!
-        }
+        return statuses_.empty();
     }
 
     void open(const PooledFile* file) {
+        std::lock_guard lock(mutex_);
         auto s = statuses_.find(file);
         ASSERT(s != statuses_.end());
         ASSERT(!s->second.opened_);
@@ -138,6 +145,7 @@ public:
     }
 
     void close(const PooledFile* file) {
+        std::lock_guard lock(mutex_);
         auto s = statuses_.find(file);
         ASSERT(s != statuses_.end());
 
@@ -146,6 +154,7 @@ public:
     }
 
     int fileno(const PooledFile* file) const {
+        std::lock_guard lock(mutex_);
         auto s = statuses_.find(file);
         ASSERT(s != statuses_.end());
         ASSERT(s->second.opened_);
@@ -153,6 +162,7 @@ public:
     }
 
     long read(const PooledFile* file, void* buffer, long len) {
+        std::lock_guard lock(mutex_);
         auto s = statuses_.find(file);
         ASSERT(s != statuses_.end());
         ASSERT(s->second.opened_);
@@ -179,6 +189,7 @@ public:
     }
 
     long seek(const PooledFile* file, off_t position) {
+        std::lock_guard lock(mutex_);
         auto s = statuses_.find(file);
         ASSERT(s != statuses_.end());
         ASSERT(s->second.opened_);
@@ -199,6 +210,7 @@ public:
     }
 
     long seekEnd(const PooledFile* file) {
+        std::lock_guard lock(mutex_);
         auto s = statuses_.find(file);
         ASSERT(s != statuses_.end());
         ASSERT(s->second.opened_);
@@ -218,14 +230,12 @@ public:
 };
 
 
-PooledFile::PooledFile(const PathName& name) : name_(name), entry_(Pool::instance().get(name)) {
+PooledFile::PooledFile(const PathName& name) : name_(name), entry_(Pool::instance().get(name, this)) {}
 
-    entry_->add(this);
-}
-
+/// @note this dtor may throw
 PooledFile::~PooledFile() {
     ASSERT(entry_);
-    entry_->remove(this);
+    Pool::instance().release(name_, this);
 }
 
 void PooledFile::open() {
@@ -282,20 +292,31 @@ PooledFileError::PooledFileError(const std::string& file, const std::string& msg
 
 }  // namespace eckit
 
+//----------------------------------------------------------------------------------------------------------------------
+
 namespace {
 
-eckit::PoolFileEntry* Pool::get(const eckit::PathName& name) {
-    std::lock_guard<std::mutex> lock(filePoolMutex_);
-    auto j = filePool_.find(name);
-    if (j == filePool_.end()) {
-        filePool_.emplace(name, new eckit::PoolFileEntry(name));
-        j = filePool_.find(name);
+eckit::PoolFileEntry* Pool::get(const eckit::PathName& name, const eckit::PooledFile* file) {
+    std::lock_guard lock(filePoolMutex_);
+    auto iter = filePool_.find(name);
+    if (iter == filePool_.end()) {
+        iter = filePool_.emplace(name, new eckit::PoolFileEntry(name)).first;
     }
-    return (*j).second.get();
+    auto* entry = iter->second.get();
+    entry->add(file);
+    return entry;
 }
-void Pool::erase(const eckit::PathName& name) {
-    std::lock_guard<std::mutex> lock(filePoolMutex_);
-    filePool_.erase(name);
+
+void Pool::release(const eckit::PathName& name, const eckit::PooledFile* file) {
+    std::lock_guard lock(filePoolMutex_);
+    auto iter = filePool_.find(name);
+    ASSERT(iter != filePool_.end());
+    if (auto* entry = iter->second.get(); entry->remove(file)) {
+        entry->doClose();
+        filePool_.erase(iter);
+    }
 }
 
 }  // namespace
+
+//----------------------------------------------------------------------------------------------------------------------

--- a/src/eckit/io/PooledFile.cc
+++ b/src/eckit/io/PooledFile.cc
@@ -48,7 +48,10 @@ public:
         static Pool pool;
         return pool;
     }
+    // Acquire the entry for `name` and register `file` as a user.
+    // The returned pointer is valid until the matching release(name, file).
     eckit::PoolFileEntry* get(const eckit::PathName& name, const eckit::PooledFile* file);
+    // Unregister `file`; close and erase the entry when the last user releases it.
     void release(const eckit::PathName& name, const eckit::PooledFile* file);
 };
 

--- a/tests/io/test_pooledfile.cc
+++ b/tests/io/test_pooledfile.cc
@@ -8,6 +8,8 @@
  * does it submit to any jurisdiction.
  */
 
+#include <unistd.h>
+
 #include <algorithm>
 #include <cstring>
 #include <thread>
@@ -170,6 +172,7 @@ CASE("Error handling") {
         Tester test;
         PooledFile* f = new PooledFile(test.path1_);
         EXPECT_NO_THROW(f->open());
+        EXPECT_EQUAL(::close(f->fileno()), 0);
         EXPECT_NO_THROW(delete f);
     }
 }

--- a/tests/io/test_pooledfile.cc
+++ b/tests/io/test_pooledfile.cc
@@ -8,7 +8,10 @@
  * does it submit to any jurisdiction.
  */
 
+#include <algorithm>
 #include <cstring>
+#include <thread>
+#include <vector>
 
 #include "eckit/config/Resource.h"
 #include "eckit/filesystem/PathName.h"
@@ -254,6 +257,47 @@ CASE("Seeking to location") {
 
         EXPECT(b[0] == 'A');
     }
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+
+/// test for the race reported by TSAN on the shared PoolFileEntry (ECKIT-687)
+CASE("Concurrent ctor/dtor on the same path") {
+
+    Tester test;
+
+    size_t num_threads    = Resource<size_t>("$ECKIT_TEST_THREADS", 32);
+    num_threads           = std::min(size_t{48}, num_threads);
+    const size_t num_iter = Resource<size_t>("$ECKIT_TEST_ITERATIONS", 200);
+    const size_t len_msg  = ::strlen(test.message);
+
+    std::vector<std::thread> threads;
+    threads.reserve(num_threads);
+
+    for (size_t t = 0; t < num_threads; ++t) {
+        const auto& path = (t % 2 == 0) ? test.path1_ : test.path2_;
+        // spawn a thread that repeatedly constructs and destructs a PooledFile, reading from it
+        threads.emplace_back([&path, num_iter, len_msg]() {
+            std::vector<char> buffer(len_msg, '\0');
+            for (size_t i = 0; i < num_iter; ++i) {
+                PooledFile file{path};
+                file.open();
+                const auto len = file.read(buffer.data(), static_cast<long>(buffer.size()));
+                EXPECT(len == static_cast<long>(len_msg));
+                file.close();
+            }
+        });
+    }
+
+    for (auto& thread : threads) {
+        thread.join();
+    }
+
+    // test a fresh PooledFile
+    PooledFile file{test.path1_};
+    EXPECT_NO_THROW(file.open());
+    EXPECT(file.nbOpens() == 1);
+    EXPECT_NO_THROW(file.close());
 }
 
 //----------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
### Description

on fdb concurrency tests, tsan reports race condition as:
```
side A  T19: statuses_.erase   PoolFileEntry::remove   PooledFile.cc:103  (~PooledFile)   [no mutex]
side B  T22: statuses_ insert  PoolFileEntry::add/open PooledFile.cc      (mutexes: write M0)
                → both reached via CacheLRU::purge/clear (Inspector's reader cache)
```

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 


<!-- PREVIEW-URL_BEGIN -->
🌦️ >> Documentation << 🌦️
https://sites.ecmwf.int/docs/dev-section/eckit/pull-requests/PR-314
<!-- PREVIEW-URL_END -->