### PR TITLE
fixes for macOS 26

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -117,7 +117,7 @@ ecbuild_add_option( FEATURE OPENFAM
                     DESCRIPTION "Enables OpenFAM support" )
 
 ecbuild_add_option( FEATURE OPENFAM_MOCK
-                    DEFAULT ON
+                    DEFAULT OFF
                     CONDITION LibUUID_FOUND AND NOT LibOPENFAM_FOUND
                     DESCRIPTION "Enables OpenFAM Mock for testing and development." )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -117,7 +117,7 @@ ecbuild_add_option( FEATURE OPENFAM
                     DESCRIPTION "Enables OpenFAM support" )
 
 ecbuild_add_option( FEATURE OPENFAM_MOCK
-                    DEFAULT OFF
+                    DEFAULT ON
                     CONDITION LibUUID_FOUND AND NOT LibOPENFAM_FOUND
                     DESCRIPTION "Enables OpenFAM Mock for testing and development." )
 

--- a/cmake/FindLibUUID.cmake
+++ b/cmake/FindLibUUID.cmake
@@ -64,7 +64,27 @@ may also be set to help find libuuid library.
 
 #]=======================================================================]
 
-find_path(LIB_UUID_INCLUDE_DIR uuid.h
+set(_libuuid_extra_hints)
+if(APPLE)
+  find_program(BREW_EXECUTABLE brew)
+  if(BREW_EXECUTABLE)
+    execute_process(
+      COMMAND ${BREW_EXECUTABLE} --prefix util-linux
+      OUTPUT_VARIABLE _libuuid_util_linux_prefix
+      OUTPUT_STRIP_TRAILING_WHITESPACE
+      ERROR_QUIET)
+    if(_libuuid_util_linux_prefix)
+      list(APPEND _libuuid_extra_hints "${_libuuid_util_linux_prefix}")
+    endif()
+  endif()
+  list(APPEND _libuuid_extra_hints
+    /opt/homebrew/opt/util-linux
+    /usr/local/opt/util-linux)
+  set(_libuuid_saved_find_framework "${CMAKE_FIND_FRAMEWORK}")
+  set(CMAKE_FIND_FRAMEWORK NEVER)
+endif()
+
+find_path(LIB_UUID_INCLUDE_DIR uuid/uuid.h
     HINTS
         ${LIB_UUID_ROOT}
         ${LIB_UUID_DIR}
@@ -72,7 +92,8 @@ find_path(LIB_UUID_INCLUDE_DIR uuid.h
         ENV LIB_UUID_ROOT
         ENV LIB_UUID_DIR
         ENV LIB_UUID_PATH
-    PATH_SUFFIXES uuid
+        ${_libuuid_extra_hints}
+    PATH_SUFFIXES include
 )
 
 find_library(LIB_UUID_LIBRARY
@@ -84,8 +105,14 @@ find_library(LIB_UUID_LIBRARY
         ENV LIB_UUID_ROOT
         ENV LIB_UUID_DIR
         ENV LIB_UUID_PATH
+        ${_libuuid_extra_hints}
     PATH_SUFFIXES lib lib64
 )
+
+if(APPLE)
+  set(CMAKE_FIND_FRAMEWORK "${_libuuid_saved_find_framework}")
+  unset(_libuuid_saved_find_framework)
+endif()
 
 include(FindPackageHandleStandardArgs)
 

--- a/src/eckit/io/fam/openfam_mock/FamMockSession.cc
+++ b/src/eckit/io/fam/openfam_mock/FamMockSession.cc
@@ -19,8 +19,12 @@
 
 #include "FamMockSession.h"
 
+#include "fam/fam.h"
+#include "fam/fam_exception.h"
+
 #include <fcntl.h>
 #include <pthread.h>
+#include <sys/fcntl.h>
 #include <sys/mman.h>
 #include <sys/stat.h>
 #include <unistd.h>
@@ -28,6 +32,7 @@
 #include <algorithm>
 #include <cctype>
 #include <cerrno>
+#include <cstdint>
 #include <cstdlib>
 #include <cstring>
 #include <functional>
@@ -39,9 +44,14 @@
 #include <string>
 #include <string_view>
 #include <system_error>
+#include <utility>
 
-#include "fam/fam.h"
-#include "fam/fam_exception.h"
+// process-shared mutexes are an optional POSIX feature
+#if defined(PTHREAD_MUTEX_ROBUST) && !defined(__APPLE__)
+#define ECKIT_FAM_MOCK_ROBUST_MUTEX 1
+#else
+#define ECKIT_FAM_MOCK_ROBUST_MUTEX 0
+#endif
 
 namespace openfam::mock {
 
@@ -207,7 +217,9 @@ FamMockSession::FamMockSession(const std::string& name) : handle_{getShmName(nam
         pthread_mutexattr_t attr;
         ::pthread_mutexattr_init(&attr);
         ::pthread_mutexattr_setpshared(&attr, PTHREAD_PROCESS_SHARED);
+#if ECKIT_FAM_MOCK_ROBUST_MUTEX
         ::pthread_mutexattr_setrobust(&attr, PTHREAD_MUTEX_ROBUST);
+#endif
         const int mrc = ::pthread_mutex_init(&state_->mutex, &attr);
         ::pthread_mutexattr_destroy(&attr);
         if (mrc != 0) {
@@ -242,6 +254,7 @@ void FamMockSession::lock() {
     debugLog("Attempting to lock mutex...");
     const auto code = ::pthread_mutex_lock(&state_->mutex);
     debugLog("pthread_mutex_lock returned ", code);
+#if ECKIT_FAM_MOCK_ROBUST_MUTEX
     if (code == EOWNERDEAD) {
         // The previous owner died holding the mutex.
         // MUST NOT call lock()/LockGuard here — the mutex is already ours.
@@ -256,6 +269,14 @@ void FamMockSession::lock() {
     else if (code != 0) {
         throw std::system_error(code, std::system_category(), "pthread_mutex_lock");
     }
+#else
+    // Without robust-mutex support there is no EOWNERDEAD recovery path: if the
+    // owner dies while holding the lock, waiters block indefinitely. This is a
+    // known limitation of the mock on platforms lacking robust mutexes.
+    if (code != 0) {
+        throw std::system_error(code, std::system_category(), "pthread_mutex_lock");
+    }
+#endif
 }
 
 void FamMockSession::unlock() {

--- a/src/eckit/testing/ProcessFork.h
+++ b/src/eckit/testing/ProcessFork.h
@@ -14,13 +14,19 @@
 
 #pragma once
 
-#include <signal.h>
 #include <sys/wait.h>
 #include <unistd.h>
 
+#include <csignal>
 #include <cstdlib>
 #include <string>
 #include <vector>
+
+#if defined(__APPLE__)
+#include <mach-o/dyld.h>
+
+#include <cstdint>
+#endif
 
 namespace eckit::testing {
 
@@ -41,11 +47,19 @@ namespace eckit::testing {
 inline bool fork_and_exec(int n, const std::vector<std::string>& args = {}) {
     // Resolve path to current executable
     char exe[4096];
+#if defined(__APPLE__)
+    // macOS has no /proc; query the dynamic loader for the executable path.
+    uint32_t exe_size = sizeof(exe);
+    if (_NSGetExecutablePath(exe, &exe_size) != 0) {
+        return false;  // buffer too small
+    }
+#else
     const ssize_t len = ::readlink("/proc/self/exe", exe, sizeof(exe) - 1);
     if (len <= 0) {
         return false;
     }
     exe[len] = '\0';
+#endif
 
     std::vector<pid_t> pids;
     pids.reserve(n);

--- a/src/eckit/testing/ProcessFork.h
+++ b/src/eckit/testing/ProcessFork.h
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include <signal.h>
 #include <sys/wait.h>
 #include <unistd.h>
 


### PR DESCRIPTION
### Description

- disabling OpenFAM-mock since PTHREAD_MUTEX_ROBUST not supported
- adding signal.h missing include (::kill)

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 


<!-- PREVIEW-URL_BEGIN -->
🌦️ >> Documentation << 🌦️
https://sites.ecmwf.int/docs/dev-section/eckit/pull-requests/PR-315
<!-- PREVIEW-URL_END -->