### PR TITLE
fix configuration thread safety

### DIFF
--- a/src/eckit/config/Configuration.cc
+++ b/src/eckit/config/Configuration.cc
@@ -194,8 +194,8 @@ bool Configuration::get(const std::string& name, double& value) const {
 }
 
 bool Configuration::get(const std::string& name, std::vector<int>& value) const {
-    bool found     = false;
-    eckit::Value v = lookUp(name, found);
+    bool found           = false;
+    const eckit::Value v = lookUp(name, found);
     if (found) {
         ASSERT(v.isList());
         value.clear();
@@ -211,8 +211,8 @@ bool Configuration::get(const std::string& name, std::vector<int>& value) const 
 }
 
 bool Configuration::get(const std::string& name, std::vector<long>& value) const {
-    bool found     = false;
-    eckit::Value v = lookUp(name, found);
+    bool found           = false;
+    const eckit::Value v = lookUp(name, found);
     if (found) {
         ASSERT(v.isList());
         value.clear();
@@ -226,8 +226,8 @@ bool Configuration::get(const std::string& name, std::vector<long>& value) const
 }
 
 bool Configuration::get(const std::string& name, std::vector<long long>& value) const {
-    bool found     = false;
-    eckit::Value v = lookUp(name, found);
+    bool found           = false;
+    const eckit::Value v = lookUp(name, found);
     if (found) {
         ASSERT(v.isList());
         value.clear();
@@ -241,8 +241,8 @@ bool Configuration::get(const std::string& name, std::vector<long long>& value) 
 }
 
 bool Configuration::get(const std::string& name, std::vector<size_t>& value) const {
-    bool found     = false;
-    eckit::Value v = lookUp(name, found);
+    bool found           = false;
+    const eckit::Value v = lookUp(name, found);
     if (found) {
         ASSERT(v.isList());
         value.clear();
@@ -256,8 +256,8 @@ bool Configuration::get(const std::string& name, std::vector<size_t>& value) con
 }
 
 bool Configuration::get(const std::string& name, std::vector<float>& value) const {
-    bool found     = false;
-    eckit::Value v = lookUp(name, found);
+    bool found           = false;
+    const eckit::Value v = lookUp(name, found);
     if (found) {
         ASSERT(v.isList());
         value.clear();
@@ -271,8 +271,8 @@ bool Configuration::get(const std::string& name, std::vector<float>& value) cons
 }
 
 bool Configuration::get(const std::string& name, std::vector<double>& value) const {
-    bool found     = false;
-    eckit::Value v = lookUp(name, found);
+    bool found           = false;
+    const eckit::Value v = lookUp(name, found);
     if (found) {
         ASSERT(v.isList());
         value.clear();
@@ -286,8 +286,8 @@ bool Configuration::get(const std::string& name, std::vector<double>& value) con
 }
 
 bool Configuration::get(const std::string& name, std::vector<std::string>& value) const {
-    bool found     = false;
-    eckit::Value v = lookUp(name, found);
+    bool found           = false;
+    const eckit::Value v = lookUp(name, found);
     if (found) {
         ASSERT(v.isList());
         value.clear();
@@ -317,8 +317,8 @@ void Configuration::hash(Hash& h) const {
 }
 
 bool Configuration::get(const std::string& name, std::vector<LocalConfiguration>& value) const {
-    bool found     = false;
-    eckit::Value v = lookUp(name, found);
+    bool found           = false;
+    const eckit::Value v = lookUp(name, found);
     if (found) {
         ASSERT(v.isList());
         value.clear();


### PR DESCRIPTION
### Description

small but big const-ness fix!

e.g., `Configuration::get` uses a non-const local eckit::Value, resulting in Value::update() while another thread increments ref count.. -> race condition

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 


<!-- PREVIEW-URL_BEGIN -->
🌦️ >> Documentation << 🌦️
https://sites.ecmwf.int/docs/dev-section/eckit/pull-requests/PR-316
<!-- PREVIEW-URL_END -->