### PR TITLE
CI: land the cross-repo orchestration ahead of the rest of the rollout

### DIFF
--- a/.ci/manifest.toml
+++ b/.ci/manifest.toml
@@ -1,0 +1,106 @@
+# Single source of truth for eckit's CI under ecmwf/ci-infrastructure.
+#
+# Alongside this manifest:
+#   - .github/workflows/ci.yml               push/PR build that publishes the artifact
+#   - .github/workflows/cross-repo-trigger.yml
+#                                            GENERATED entry point for upstream fan-out
+#                                            and consumer-driven rebuilds
+#   - .github/workflows/trigger-downstream.yml
+#                                            GENERATED fan-out to our own consumers
+#   - .github/workflows/old_CI.yml           the legacy ecmwf/downstream-ci pipeline,
+#                                            still running unchanged during migration
+
+[package]
+name = "eckit"
+prefix = "eckit"
+repo = "ecmwf/eckit"
+# Public, so upstreams call our cross-repo-trigger.yml directly via `uses:`
+# rather than dispatching it to keep logs out of a public run.
+visibility = "public"
+compiler-inputs = ["cxx-compiler"]
+
+[[deps]]
+repo = "ecmwf/ecbuild"
+package = "ecbuild"
+ref = "develop"
+# ecbuild installs a compiler-independent CMake toolchain: one artifact serves
+# every compiler, so no compiler field enters its name.
+compiler-inputs = []
+
+[[deps]]
+repo = "ecmwf/stack-dependencies"
+package = "stack-deps"
+ref = "master"
+# Supplies libaec (FEATURE AEC), and qhull/PROJ should those features ever be
+# switched on. Compiled C++, so the compiler is part of its identity.
+compiler-inputs = ["cxx-compiler"]
+
+# Both legs share platform ubuntu-24.04 so they reuse the ecbuild and stack-deps
+# artifacts built under that same slug. runs-on/container are scheduling only and
+# never enter an artifact name.
+[[matrix.build.include]]
+cxx-compiler = "clang++-18"
+build-type = "Release"
+runs-on = "arc-runner-very-large"
+container = "eccr.ecmwf.int/public-playground-ci/ubuntu24.04-clang18-gfortran13:latest"
+platform = "ubuntu-24.04"
+
+[[matrix.build.include]]
+cxx-compiler = "g++-13"
+build-type = "Release"
+runs-on = "arc-runner-very-large"
+container = "eccr.ecmwf.int/public-playground-ci/ubuntu24.04-clang18-gfortran13:latest"
+platform = "ubuntu-24.04"
+
+[matrix.build]
+triggers = ["upstream-change", "rebuild-request"]
+action = "./.github/actions/build-eckit"
+forwarded-inputs = ["cxx-compiler", "build-type"]
+forwarded-deps-outputs = ["cmake-prefix-path"]
+needs = ["ecbuild/build", "stack-deps/build"]
+
+# --- HPC build --------------------------------------------------------------
+# eckit built inside a SLURM job, linking the atos-hpc-gnu ecbuild and stack-deps
+# artifacts. `needs` names the HPC kinds, never the runner ones: the two lanes
+# are separate artifact universes distinguished by platform, and a runner rebuild
+# must not be what re-runs this.
+#
+# The compiler fields are discriminators for artifact identity and dep matching,
+# not the binaries the recipe invokes — the job loads whatever prgenv/gnu
+# provides. They only have to agree with what the upstreams published under.
+#
+# runs-on/container/site are scheduling only and never enter the artifact name.
+# The container carries the cluster ssh identity (keys, the hpc-batch alias,
+# known_hosts) without which troika cannot submit; it is private, hence
+# container-credentials.
+[[matrix.build-hpc.include]]
+cxx-compiler = "g++-13"
+build-type = "Release"
+runs-on = "arc-hpc-pet-vsphere-prod"
+container = "eccr.ecmwf.int/private-playground-ci/ubuntu24.04-internal-tools:latest"
+site = "hpc-batch"
+platform = "atos-hpc-gnu"
+
+[matrix.build-hpc]
+execution = "hpc"
+container-credentials = true
+job-script = "./.ci/hpc/build.sh"
+triggers = ["upstream-change", "rebuild-request"]
+forwarded-deps-outputs = ["cmake-prefix-path"]
+needs = ["ecbuild/build-hpc", "stack-deps/build-hpc"]
+
+# --- downstream CI fan-out ---------------------------------------------------
+# eccodes consumes eckit only on its ENABLE_ECKIT_GEO leg; that scoping lives in
+# eccodes' own manifest, via a `when` predicate on its [[deps]] entry for us.
+# ROLLOUT NOTE: pinned to the sync branch on purpose, and TEMPORARY.
+# `ref` is what the orchestrator pins its `uses:` to, and `uses:` cannot take an
+# expression, so it selects which WORKFLOW DEFINITION runs. Pointing it at the
+# sync branch is what lets the full downstream CI be exercised before the
+# rollout merges: the orchestrator lives on the default branch (workflow_run
+# only ever runs the default-branch copy) while the consumer logic it calls
+# comes from the sync branch. Source checkout and artifact refs are handled
+# independently at runtime by pick-ref and resolve_deps' sync-branch override.
+# FLIP TO develop AND REGENERATE WHEN THE ROLLOUT MERGES.
+[[trigger-downstream]]
+repo = "ecmwf/eccodes"
+ref = "sync-branch-ci-rollout"

--- a/.github/workflows/cross-repo-trigger-hpc.yml
+++ b/.github/workflows/cross-repo-trigger-hpc.yml
@@ -1,0 +1,206 @@
+# GENERATED FILE - DO NOT EDIT.
+# Regenerate via the ci-infrastructure-generate CLI.
+# Source of truth: each repo's .ci/manifest.toml.
+name: Cross-repo trigger (eckit)
+run-name: Cross-repo trigger (${{ inputs.from-repo }}@${{ inputs.from-sha }}) [${{ inputs.dispatch-id }}]
+on:
+  workflow_call:
+    inputs:
+      from-repo:
+        description: owner/repo of the dispatcher (upstream producer or downstream consumer)
+        required: true
+        type: string
+      from-sha:
+        description: SHA of the dispatcher commit
+        required: true
+        type: string
+      from-jobs:
+        description: JSON array of package/kinds that triggered us (e.g. '["fortmath/build","fortmath/build-hpc"]') for upstream-change dispatches. '[]' when rebuild-request is true.
+        required: false
+        default: '[]'
+        type: string
+      rebuild-request:
+        description: True when a downstream consumer dispatches us because our artifact was missing. Mutually exclusive with from-jobs.
+        required: false
+        default: false
+        type: boolean
+      branch:
+        description: Dispatcher branch name; we attempt branch-matching against it
+        required: true
+        type: string
+      fallback-ref:
+        description: Ref to check out if branch does not exist in this repo
+        required: false
+        type: string
+        default: main
+  workflow_dispatch:
+    inputs:
+      dispatch-id:
+        description: Correlation id stamped into run-name so the dispatcher can find this run
+        required: false
+        default: ''
+        type: string
+      from-repo:
+        description: owner/repo of the dispatcher (upstream producer or downstream consumer)
+        required: true
+        type: string
+      from-sha:
+        description: SHA of the dispatcher commit
+        required: true
+        type: string
+      from-jobs:
+        description: JSON array of package/kinds that triggered us (e.g. '["fortmath/build","fortmath/build-hpc"]') for upstream-change dispatches. '[]' when rebuild-request is true.
+        required: false
+        default: '[]'
+        type: string
+      rebuild-request:
+        description: True when a downstream consumer dispatches us because our artifact was missing. Mutually exclusive with from-jobs.
+        required: false
+        default: false
+        type: boolean
+      branch:
+        description: Dispatcher branch name; we attempt branch-matching against it
+        required: true
+        type: string
+      fallback-ref:
+        description: Ref to check out if branch does not exist in this repo
+        required: false
+        type: string
+        default: main
+concurrency:
+  group: cross-repo-trigger-hpc-eckit-${{ github.ref }}
+  cancel-in-progress: false
+env:
+  ARTIFACT_POLL_INTERVAL: ${{ vars.ARTIFACT_POLL_INTERVAL || '60' }}
+  ARTIFACT_S3_ENDPOINT: ${{ secrets.ARTIFACT_S3_ENDPOINT }}
+  ARTIFACT_S3_BUCKET: ${{ secrets.ARTIFACT_S3_BUCKET }}
+  SCCACHE_BUCKET: ${{ secrets.SCCACHE_BUCKET }}
+  AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+  AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+jobs:
+  resolve:
+    if: contains(fromJSON(inputs.from-jobs), 'ecbuild/build-hpc') || contains(fromJSON(inputs.from-jobs), 'stack-deps/build-hpc') || inputs.rebuild-request
+    runs-on: ubuntu-slim
+    outputs:
+      ref: ${{ steps.pick.outputs.ref }}
+      matrix-build-hpc: ${{ steps.r.outputs.matrix-build-hpc }}
+    steps:
+    - id: mint
+      uses: actions/create-github-app-token@v3
+      with:
+        client-id: ${{ secrets.CI_PERMISSIONS_APP_CLIENT_ID }}
+        private-key: ${{ secrets.CI_PERMISSIONS_APP_PRIVATE_KEY }}
+        owner: ${{ github.repository_owner }}
+    - id: pick
+      uses: ecmwf/ci-infrastructure/actions/pick-ref@main
+      with:
+        repo: ecmwf/eckit
+        try-branch: ${{ inputs.branch }}
+        fallback-ref: ${{ inputs.fallback-ref }}
+        token: ${{ steps.mint.outputs.token }}
+    - uses: actions/checkout@v6
+      with:
+        repository: ecmwf/eckit
+        ref: ${{ steps.pick.outputs.ref }}
+        token: ${{ steps.mint.outputs.token }}
+    - id: r
+      uses: ecmwf/ci-infrastructure/actions/resolve-deps@main
+      with:
+        current-branch: ${{ steps.pick.outputs.ref }}
+        matrix: build-hpc
+        token: ${{ steps.mint.outputs.token }}
+        client-id: ${{ secrets.CI_PERMISSIONS_APP_CLIENT_ID }}
+        app-private-key: ${{ secrets.CI_PERMISSIONS_APP_PRIVATE_KEY }}
+  eckit__build_hpc:
+    needs:
+    - resolve
+    if: contains(fromJSON(inputs.from-jobs), 'ecbuild/build-hpc') || contains(fromJSON(inputs.from-jobs), 'stack-deps/build-hpc') || inputs.rebuild-request
+    name: eckit/build-hpc (${{ matrix['build-type'] }}, ${{ matrix.platform }})
+    runs-on: ${{ matrix['runs-on'] }}
+    container:
+      image: ${{ matrix.container || '' }}
+      credentials:
+        username: ${{ secrets.ECCR_PULL_ROBOT_NAME }}
+        password: ${{ secrets.ECCR_PULL_ROBOT_TOKEN }}
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.resolve.outputs.matrix-build-hpc) }}
+    steps:
+    - id: mint
+      uses: actions/create-github-app-token@v3
+      with:
+        client-id: ${{ secrets.CI_PERMISSIONS_APP_CLIENT_ID }}
+        private-key: ${{ secrets.CI_PERMISSIONS_APP_PRIVATE_KEY }}
+        owner: ${{ github.repository_owner }}
+    - id: check_start
+      if: ${{ github.event_name == 'workflow_dispatch' && inputs.from-jobs != '[]' }}
+      uses: ecmwf/ci-infrastructure/actions/report-check-run@main
+      with:
+        token: ${{ steps.mint.outputs.token }}
+        head-repo: ${{ inputs.from-repo }}
+        head-sha: ${{ inputs.from-sha }}
+        name: eckit/build-hpc (${{ matrix['build-type'] }}, ${{ matrix.platform }})
+        details-url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        phase: start
+    - uses: actions/checkout@v6
+      with:
+        repository: ecmwf/eckit
+        ref: ${{ needs.resolve.outputs.ref }}
+        token: ${{ steps.mint.outputs.token }}
+    - name: Decode matrix-leg
+      id: m
+      shell: bash
+      run: |
+        set -euo pipefail
+        shopt -s inherit_errexit 2>/dev/null || true
+        command -v jq >/dev/null || {
+          echo "::error::jq is required but not installed in this runner/image." >&2
+          exit 1
+        }
+        leg='${{ toJSON(matrix) }}'
+        require() {
+          local val
+          val=$(jq -r "$1" <<<"$leg")
+          if [ -z "$val" ] || [ "$val" = "null" ]; then
+            echo "::error::matrix-leg field '$2' empty or null (jq -r '$1' returned '$val')." >&2
+            exit 1
+          fi
+          printf '%s' "$val"
+        }
+        deps_json=$(require '._resolved.deps | tojson' '_resolved.deps')
+        own_artifact_name=$(require '._resolved."own-artifact-name"' '_resolved.own-artifact-name')
+        {
+          echo "deps-json=${deps_json}"
+          echo "own-artifact-name=${own_artifact_name}"
+        } >> "$GITHUB_OUTPUT"
+    - name: Fetch resolved deps
+      id: deps
+      uses: ecmwf/ci-infrastructure/actions/fetch-and-publish@main
+      with:
+        mode: download-only
+        deps-json: ${{ steps.m.outputs.deps-json }}
+        token: ${{ steps.mint.outputs.token }}
+        install-python-deps: 'false'
+    - name: Build on HPC
+      id: build
+      uses: ecmwf/ci-infrastructure/actions/build-on-hpc@main
+      with:
+        site: ${{ matrix.site }}
+        job-script: ${{ matrix.job-script || './.ci/hpc/build.sh' }}
+        artifact-name: ${{ steps.m.outputs.own-artifact-name }}
+        cmake-prefix-path: ${{ steps.deps.outputs.cmake-prefix-path }}
+        work-dir: ${{ vars.HPC_CI_WORK_DIR }}
+        remote-work-dir: ${{ vars.HPC_CI_REMOTE_WORK_DIR }}
+        troika-user: ${{ secrets.HPC_CI_SSH_USER }}
+    - name: Report check-run conclusion
+      if: ${{ always() && github.event_name == 'workflow_dispatch' && inputs.from-jobs != '[]' }}
+      uses: ecmwf/ci-infrastructure/actions/report-check-run@main
+      with:
+        token: ${{ steps.mint.outputs.token }}
+        head-repo: ${{ inputs.from-repo }}
+        head-sha: ${{ inputs.from-sha }}
+        name: eckit/build-hpc (${{ matrix['build-type'] }}, ${{ matrix.platform }})
+        details-url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        phase: finish
+        conclusion: ${{ job.status }}
+        check-run-id: ${{ steps.check_start.outputs.check-run-id }}

--- a/.github/workflows/cross-repo-trigger.yml
+++ b/.github/workflows/cross-repo-trigger.yml
@@ -1,0 +1,208 @@
+# GENERATED FILE - DO NOT EDIT.
+# Regenerate via the ci-infrastructure-generate CLI.
+# Source of truth: each repo's .ci/manifest.toml.
+name: Cross-repo trigger (eckit)
+run-name: Cross-repo trigger (${{ inputs.from-repo }}@${{ inputs.from-sha }}) [${{ inputs.dispatch-id }}]
+on:
+  workflow_call:
+    inputs:
+      from-repo:
+        description: owner/repo of the dispatcher (upstream producer or downstream consumer)
+        required: true
+        type: string
+      from-sha:
+        description: SHA of the dispatcher commit
+        required: true
+        type: string
+      from-jobs:
+        description: JSON array of package/kinds that triggered us (e.g. '["fortmath/build","fortmath/build-hpc"]') for upstream-change dispatches. '[]' when rebuild-request is true.
+        required: false
+        default: '[]'
+        type: string
+      rebuild-request:
+        description: True when a downstream consumer dispatches us because our artifact was missing. Mutually exclusive with from-jobs.
+        required: false
+        default: false
+        type: boolean
+      branch:
+        description: Dispatcher branch name; we attempt branch-matching against it
+        required: true
+        type: string
+      fallback-ref:
+        description: Ref to check out if branch does not exist in this repo
+        required: false
+        type: string
+        default: main
+  workflow_dispatch:
+    inputs:
+      dispatch-id:
+        description: Correlation id stamped into run-name so the dispatcher can find this run
+        required: false
+        default: ''
+        type: string
+      from-repo:
+        description: owner/repo of the dispatcher (upstream producer or downstream consumer)
+        required: true
+        type: string
+      from-sha:
+        description: SHA of the dispatcher commit
+        required: true
+        type: string
+      from-jobs:
+        description: JSON array of package/kinds that triggered us (e.g. '["fortmath/build","fortmath/build-hpc"]') for upstream-change dispatches. '[]' when rebuild-request is true.
+        required: false
+        default: '[]'
+        type: string
+      rebuild-request:
+        description: True when a downstream consumer dispatches us because our artifact was missing. Mutually exclusive with from-jobs.
+        required: false
+        default: false
+        type: boolean
+      branch:
+        description: Dispatcher branch name; we attempt branch-matching against it
+        required: true
+        type: string
+      fallback-ref:
+        description: Ref to check out if branch does not exist in this repo
+        required: false
+        type: string
+        default: main
+concurrency:
+  group: cross-repo-trigger-runner-eckit-${{ github.ref }}
+  cancel-in-progress: false
+env:
+  ARTIFACT_POLL_INTERVAL: ${{ vars.ARTIFACT_POLL_INTERVAL || '60' }}
+  ARTIFACT_S3_ENDPOINT: ${{ secrets.ARTIFACT_S3_ENDPOINT }}
+  ARTIFACT_S3_BUCKET: ${{ secrets.ARTIFACT_S3_BUCKET }}
+  SCCACHE_BUCKET: ${{ secrets.SCCACHE_BUCKET }}
+  AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+  AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+jobs:
+  resolve:
+    if: contains(fromJSON(inputs.from-jobs), 'ecbuild/build') || contains(fromJSON(inputs.from-jobs), 'stack-deps/build') || inputs.rebuild-request
+    runs-on: ubuntu-slim
+    outputs:
+      ref: ${{ steps.pick.outputs.ref }}
+      matrix-build: ${{ steps.r.outputs.matrix-build }}
+    steps:
+    - id: mint
+      uses: actions/create-github-app-token@v3
+      with:
+        client-id: ${{ secrets.CI_PERMISSIONS_APP_CLIENT_ID }}
+        private-key: ${{ secrets.CI_PERMISSIONS_APP_PRIVATE_KEY }}
+        owner: ${{ github.repository_owner }}
+    - id: pick
+      uses: ecmwf/ci-infrastructure/actions/pick-ref@main
+      with:
+        repo: ecmwf/eckit
+        try-branch: ${{ inputs.branch }}
+        fallback-ref: ${{ inputs.fallback-ref }}
+        token: ${{ steps.mint.outputs.token }}
+    - uses: actions/checkout@v6
+      with:
+        repository: ecmwf/eckit
+        ref: ${{ steps.pick.outputs.ref }}
+        token: ${{ steps.mint.outputs.token }}
+    - id: r
+      uses: ecmwf/ci-infrastructure/actions/resolve-deps@main
+      with:
+        current-branch: ${{ steps.pick.outputs.ref }}
+        matrix: build
+        token: ${{ steps.mint.outputs.token }}
+        client-id: ${{ secrets.CI_PERMISSIONS_APP_CLIENT_ID }}
+        app-private-key: ${{ secrets.CI_PERMISSIONS_APP_PRIVATE_KEY }}
+  eckit__build:
+    needs:
+    - resolve
+    if: contains(fromJSON(inputs.from-jobs), 'ecbuild/build') || contains(fromJSON(inputs.from-jobs), 'stack-deps/build') || inputs.rebuild-request
+    name: eckit/build (${{ matrix['cxx-compiler'] }}, ${{ matrix.platform }})
+    runs-on: ${{ matrix['runs-on'] }}
+    container:
+      image: ${{ matrix.container || '' }}
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.resolve.outputs.matrix-build) }}
+    steps:
+    - id: mint
+      uses: actions/create-github-app-token@v3
+      with:
+        client-id: ${{ secrets.CI_PERMISSIONS_APP_CLIENT_ID }}
+        private-key: ${{ secrets.CI_PERMISSIONS_APP_PRIVATE_KEY }}
+        owner: ${{ github.repository_owner }}
+    - id: check_start
+      if: ${{ github.event_name == 'workflow_dispatch' && inputs.from-jobs != '[]' }}
+      uses: ecmwf/ci-infrastructure/actions/report-check-run@main
+      with:
+        token: ${{ steps.mint.outputs.token }}
+        head-repo: ${{ inputs.from-repo }}
+        head-sha: ${{ inputs.from-sha }}
+        name: eckit/build (${{ matrix['cxx-compiler'] }}, ${{ matrix.platform }})
+        details-url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        phase: start
+    - uses: actions/checkout@v6
+      with:
+        repository: ecmwf/eckit
+        ref: ${{ needs.resolve.outputs.ref }}
+        token: ${{ steps.mint.outputs.token }}
+    - name: Decode matrix-leg
+      id: m
+      shell: bash
+      run: |
+        set -euo pipefail
+        shopt -s inherit_errexit 2>/dev/null || true
+        command -v jq >/dev/null || {
+          echo "::error::jq is required but not installed in this runner/image." >&2
+          exit 1
+        }
+        leg='${{ toJSON(matrix) }}'
+        require() {
+          local val
+          val=$(jq -r "$1" <<<"$leg")
+          if [ -z "$val" ] || [ "$val" = "null" ]; then
+            echo "::error::matrix-leg field '$2' empty or null (jq -r '$1' returned '$val')." >&2
+            exit 1
+          fi
+          printf '%s' "$val"
+        }
+        cxx_compiler=$(require '."cxx-compiler"' cxx-compiler)
+        build_type=$(require '."build-type"' build-type)
+        deps_json=$(require '._resolved.deps | tojson' '_resolved.deps')
+        own_artifact_name=$(require '._resolved."own-artifact-name"' '_resolved.own-artifact-name')
+        {
+          echo "cxx-compiler=${cxx_compiler}"
+          echo "build-type=${build_type}"
+          echo "deps-json=${deps_json}"
+          echo "own-artifact-name=${own_artifact_name}"
+        } >> "$GITHUB_OUTPUT"
+    - name: Fetch resolved deps
+      id: deps
+      uses: ecmwf/ci-infrastructure/actions/fetch-and-publish@main
+      with:
+        mode: download-only
+        deps-json: ${{ steps.m.outputs.deps-json }}
+        token: ${{ steps.mint.outputs.token }}
+    - name: Build
+      id: build
+      uses: ./.github/actions/build-eckit
+      with:
+        cmake-prefix-path: ${{ steps.deps.outputs.cmake-prefix-path }}
+        cxx-compiler: ${{ steps.m.outputs.cxx-compiler }}
+        build-type: ${{ steps.m.outputs.build-type }}
+    - name: Publish
+      uses: ecmwf/ci-infrastructure/actions/fetch-and-publish@main
+      with:
+        mode: publish
+        install-path: ${{ steps.build.outputs.install-path }}
+        artifact-name: ${{ steps.m.outputs.own-artifact-name }}
+    - name: Report check-run conclusion
+      if: ${{ always() && github.event_name == 'workflow_dispatch' && inputs.from-jobs != '[]' }}
+      uses: ecmwf/ci-infrastructure/actions/report-check-run@main
+      with:
+        token: ${{ steps.mint.outputs.token }}
+        head-repo: ${{ inputs.from-repo }}
+        head-sha: ${{ inputs.from-sha }}
+        name: eckit/build (${{ matrix['cxx-compiler'] }}, ${{ matrix.platform }})
+        details-url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        phase: finish
+        conclusion: ${{ job.status }}
+        check-run-id: ${{ steps.check_start.outputs.check-run-id }}

--- a/.github/workflows/trigger-downstream-hpc.yml
+++ b/.github/workflows/trigger-downstream-hpc.yml
@@ -1,0 +1,112 @@
+# GENERATED FILE - DO NOT EDIT.
+# Regenerate via the ci-infrastructure-generate CLI.
+# Source of truth: each repo's .ci/manifest.toml.
+name: Downstream HPC (eckit)
+on:
+  workflow_run:
+    workflows:
+    - CI
+    types:
+    - completed
+concurrency:
+  group: trigger-downstream-hpc-${{ github.event.workflow_run.head_sha }}
+  cancel-in-progress: true
+jobs:
+  validate:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-slim
+    steps:
+    - id: mint
+      uses: actions/create-github-app-token@v3
+      with:
+        client-id: ${{ secrets.CI_PERMISSIONS_APP_CLIENT_ID }}
+        private-key: ${{ secrets.CI_PERMISSIONS_APP_PRIVATE_KEY }}
+        owner: ${{ github.repository_owner }}
+    - uses: actions/checkout@v6
+      with:
+        ref: ${{ github.event.workflow_run.head_sha }}
+        token: ${{ steps.mint.outputs.token }}
+    - uses: ecmwf/ci-infrastructure/actions/validate-generated-workflows@main
+      with:
+        token: ${{ steps.mint.outputs.token }}
+  report-start:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-slim
+    steps:
+    - id: mint
+      uses: actions/create-github-app-token@v3
+      with:
+        client-id: ${{ secrets.CI_PERMISSIONS_APP_CLIENT_ID }}
+        private-key: ${{ secrets.CI_PERMISSIONS_APP_PRIVATE_KEY }}
+        owner: ${{ github.repository_owner }}
+    - name: Post pending downstream status
+      env:
+        GH_TOKEN: ${{ steps.mint.outputs.token }}
+      run: |
+        gh api -X POST \
+          "/repos/${{ github.repository }}/statuses/${{ github.event.workflow_run.head_sha }}" \
+          -f state=pending \
+          -f context='downstream/hpc' \
+          -f target_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+          -f description='Downstream HPC tests running'
+  report-ci-failure:
+    if: ${{ github.event.workflow_run.conclusion != 'success' }}
+    runs-on: ubuntu-slim
+    steps:
+    - id: mint
+      uses: actions/create-github-app-token@v3
+      with:
+        client-id: ${{ secrets.CI_PERMISSIONS_APP_CLIENT_ID }}
+        private-key: ${{ secrets.CI_PERMISSIONS_APP_PRIVATE_KEY }}
+        owner: ${{ github.repository_owner }}
+    - name: Post downstream failure status
+      env:
+        GH_TOKEN: ${{ steps.mint.outputs.token }}
+      run: |
+        gh api -X POST \
+          "/repos/${{ github.repository }}/statuses/${{ github.event.workflow_run.head_sha }}" \
+          -f state=failure \
+          -f context='downstream/hpc' \
+          -f target_url="${{ github.event.workflow_run.html_url }}" \
+          -f description='Upstream CI failed; downstream HPC not run'
+  eccodes:
+    name: eccodes
+    needs:
+    - validate
+    uses: ecmwf/eccodes/.github/workflows/cross-repo-trigger-hpc.yml@sync-branch-ci-rollout
+    with:
+      from-repo: ${{ github.repository }}
+      from-sha: ${{ github.event.workflow_run.head_sha }}
+      from-jobs: '["eckit/build-hpc"]'
+      branch: ${{ github.event.workflow_run.head_branch }}
+      fallback-ref: sync-branch-ci-rollout
+    secrets: inherit
+  report-result:
+    needs:
+    - validate
+    - eccodes
+    if: ${{ always() && github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-slim
+    steps:
+    - id: mint
+      uses: actions/create-github-app-token@v3
+      with:
+        client-id: ${{ secrets.CI_PERMISSIONS_APP_CLIENT_ID }}
+        private-key: ${{ secrets.CI_PERMISSIONS_APP_PRIVATE_KEY }}
+        owner: ${{ github.repository_owner }}
+    - name: Post final downstream status
+      env:
+        GH_TOKEN: ${{ steps.mint.outputs.token }}
+      run: |
+        state=success
+        for r in ${{ needs.validate.result }} ${{ needs.eccodes.result }}; do
+          if [ "$r" = failure ] || [ "$r" = cancelled ]; then
+            state=failure
+          fi
+        done
+        gh api -X POST \
+          "/repos/${{ github.repository }}/statuses/${{ github.event.workflow_run.head_sha }}" \
+          -f state="$state" \
+          -f context='downstream/hpc' \
+          -f target_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+          -f description="Downstream HPC tests $state"

--- a/.github/workflows/trigger-downstream.yml
+++ b/.github/workflows/trigger-downstream.yml
@@ -1,0 +1,112 @@
+# GENERATED FILE - DO NOT EDIT.
+# Regenerate via the ci-infrastructure-generate CLI.
+# Source of truth: each repo's .ci/manifest.toml.
+name: Downstream runner (eckit)
+on:
+  workflow_run:
+    workflows:
+    - CI
+    types:
+    - completed
+concurrency:
+  group: trigger-downstream-runner-${{ github.event.workflow_run.head_sha }}
+  cancel-in-progress: true
+jobs:
+  validate:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-slim
+    steps:
+    - id: mint
+      uses: actions/create-github-app-token@v3
+      with:
+        client-id: ${{ secrets.CI_PERMISSIONS_APP_CLIENT_ID }}
+        private-key: ${{ secrets.CI_PERMISSIONS_APP_PRIVATE_KEY }}
+        owner: ${{ github.repository_owner }}
+    - uses: actions/checkout@v6
+      with:
+        ref: ${{ github.event.workflow_run.head_sha }}
+        token: ${{ steps.mint.outputs.token }}
+    - uses: ecmwf/ci-infrastructure/actions/validate-generated-workflows@main
+      with:
+        token: ${{ steps.mint.outputs.token }}
+  report-start:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-slim
+    steps:
+    - id: mint
+      uses: actions/create-github-app-token@v3
+      with:
+        client-id: ${{ secrets.CI_PERMISSIONS_APP_CLIENT_ID }}
+        private-key: ${{ secrets.CI_PERMISSIONS_APP_PRIVATE_KEY }}
+        owner: ${{ github.repository_owner }}
+    - name: Post pending downstream status
+      env:
+        GH_TOKEN: ${{ steps.mint.outputs.token }}
+      run: |
+        gh api -X POST \
+          "/repos/${{ github.repository }}/statuses/${{ github.event.workflow_run.head_sha }}" \
+          -f state=pending \
+          -f context='downstream/runner' \
+          -f target_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+          -f description='Downstream runner tests running'
+  report-ci-failure:
+    if: ${{ github.event.workflow_run.conclusion != 'success' }}
+    runs-on: ubuntu-slim
+    steps:
+    - id: mint
+      uses: actions/create-github-app-token@v3
+      with:
+        client-id: ${{ secrets.CI_PERMISSIONS_APP_CLIENT_ID }}
+        private-key: ${{ secrets.CI_PERMISSIONS_APP_PRIVATE_KEY }}
+        owner: ${{ github.repository_owner }}
+    - name: Post downstream failure status
+      env:
+        GH_TOKEN: ${{ steps.mint.outputs.token }}
+      run: |
+        gh api -X POST \
+          "/repos/${{ github.repository }}/statuses/${{ github.event.workflow_run.head_sha }}" \
+          -f state=failure \
+          -f context='downstream/runner' \
+          -f target_url="${{ github.event.workflow_run.html_url }}" \
+          -f description='Upstream CI failed; downstream runner not run'
+  eccodes:
+    name: eccodes
+    needs:
+    - validate
+    uses: ecmwf/eccodes/.github/workflows/cross-repo-trigger.yml@sync-branch-ci-rollout
+    with:
+      from-repo: ${{ github.repository }}
+      from-sha: ${{ github.event.workflow_run.head_sha }}
+      from-jobs: '["eckit/build"]'
+      branch: ${{ github.event.workflow_run.head_branch }}
+      fallback-ref: sync-branch-ci-rollout
+    secrets: inherit
+  report-result:
+    needs:
+    - validate
+    - eccodes
+    if: ${{ always() && github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-slim
+    steps:
+    - id: mint
+      uses: actions/create-github-app-token@v3
+      with:
+        client-id: ${{ secrets.CI_PERMISSIONS_APP_CLIENT_ID }}
+        private-key: ${{ secrets.CI_PERMISSIONS_APP_PRIVATE_KEY }}
+        owner: ${{ github.repository_owner }}
+    - name: Post final downstream status
+      env:
+        GH_TOKEN: ${{ steps.mint.outputs.token }}
+      run: |
+        state=success
+        for r in ${{ needs.validate.result }} ${{ needs.eccodes.result }}; do
+          if [ "$r" = failure ] || [ "$r" = cancelled ]; then
+            state=failure
+          fi
+        done
+        gh api -X POST \
+          "/repos/${{ github.repository }}/statuses/${{ github.event.workflow_run.head_sha }}" \
+          -f state="$state" \
+          -f context='downstream/runner' \
+          -f target_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+          -f description="Downstream runner tests $state"


### PR DESCRIPTION
## CI: land the cross-repo orchestration

  Adds `.ci/manifest.toml` — declaring this package, its dependencies and its
  consumers — plus the generated workflows that let other repos trigger this one.

  These only work **on the default branch**: `on: workflow_run` always runs the
  default branch's copy, so a fan-out on a feature branch is inert. Landing it
  first is what makes the downstream CI observable before the rollout merges.

  No build definitions — `ci.yml`, the build actions and the HPC recipes stay on
  `sync-branch-ci-rollout`.

  ⚠️ `[[trigger-downstream]].ref` is temporarily pinned to
  `sync-branch-ci-rollout`; flip to `develop` and regenerate when the rollout
  merges (see the `ROLLOUT NOTE` in the manifest).

  `cross-repo-trigger*.yml` / `trigger-downstream*.yml` are generated by
  `ci-infrastructure-generate` — don't hand-edit.

### Description


### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 


<!-- PREVIEW-URL_BEGIN -->
🌦️ >> Documentation << 🌦️
https://sites.ecmwf.int/docs/dev-section/eckit/pull-requests/PR-328
<!-- PREVIEW-URL_END -->