### PR TITLE
Add support for boolean lists in Parametrisation, Configuration and related classes.

### DIFF
--- a/src/eckit/config/Configuration.cc
+++ b/src/eckit/config/Configuration.cc
@@ -193,6 +193,22 @@ bool Configuration::get(const std::string& name, double& value) const {
     return found;
 }
 
+bool Configuration::get(const std::string& name, std::vector<bool>& value) const {
+    bool found           = false;
+    const eckit::Value v = lookUp(name, found);
+    if (found) {
+        ASSERT(v.isList());
+        value.clear();
+        int i = 0;
+        while (v.contains(i)) {
+            bool result(v[i]);
+            value.push_back(static_cast<bool>(result));
+            i++;
+        }
+    }
+    return found;
+}
+
 bool Configuration::get(const std::string& name, std::vector<int>& value) const {
     bool found           = false;
     const eckit::Value v = lookUp(name, found);
@@ -394,6 +410,11 @@ std::string Configuration::getString(const std::string& name) const {
     return result;
 }
 
+std::vector<bool> Configuration::getBoolVector(const std::string& name) const {
+    std::vector<bool> result;
+    _get(name, result);
+    return result;
+}
 
 std::vector<int> Configuration::getIntVector(const std::string& name) const {
     std::vector<int> result;
@@ -634,6 +655,12 @@ double Configuration::getDouble(const std::string& name, const double& defaultVa
 std::string Configuration::getString(const std::string& name, const std::string& defaultVal) const {
     std::string result;
     _getWithDefault(name, result, defaultVal);
+    return result;
+}
+
+std::vector<bool> Configuration::getBoolVector(const std::string& name, const std::vector<bool>& defaultValue) const {
+    std::vector<bool> result;
+    _getWithDefault(name, result, defaultValue);
     return result;
 }
 

--- a/src/eckit/config/Configuration.cc
+++ b/src/eckit/config/Configuration.cc
@@ -198,12 +198,12 @@ bool Configuration::get(const std::string& name, std::vector<bool>& value) const
     const eckit::Value v = lookUp(name, found);
     if (found) {
         ASSERT(v.isList());
+        if (v.size() != 0 && !v[0].isBool()) {
+            return false;
+        }
         value.clear();
-        int i = 0;
-        while (v.contains(i)) {
-            bool result(v[i]);
-            value.push_back(static_cast<bool>(result));
-            i++;
+        for (int i = 0; v.contains(i); ++i) {
+            value.push_back(static_cast<bool>(v[i]));
         }
     }
     return found;

--- a/src/eckit/config/Configuration.h
+++ b/src/eckit/config/Configuration.h
@@ -54,6 +54,7 @@ public:  // methods
     double getDouble(const std::string& name) const;
     std::string getString(const std::string& name) const;
 
+    std::vector<bool> getBoolVector(const std::string& name) const;
     std::vector<int> getIntVector(const std::string& name) const;
     std::vector<long> getLongVector(const std::string& name) const;
     std::vector<std::size_t> getUnsignedVector(const std::string& name) const;
@@ -75,6 +76,7 @@ public:  // methods
     double getDouble(const std::string& name, const double& defaultValue) const;
     std::string getString(const std::string& name, const std::string& defaultValue) const;
 
+    std::vector<bool> getBoolVector(const std::string& name, const std::vector<bool>& defaultValue) const;
     std::vector<int> getIntVector(const std::string& name, const std::vector<int>& defaultValue) const;
     std::vector<long> getLongVector(const std::string& name, const std::vector<long>& defaultValue) const;
     std::vector<std::size_t> getUnsignedVector(const std::string& name,
@@ -115,6 +117,7 @@ public:  // methods
     bool get(const std::string& name, float& value) const override;
     bool get(const std::string& name, double& value) const override;
 
+    bool get(const std::string& name, std::vector<bool>& value) const override;
     bool get(const std::string& name, std::vector<int>& value) const override;
     bool get(const std::string& name, std::vector<long>& value) const override;
     bool get(const std::string& name, std::vector<long long>& value) const override;
@@ -174,6 +177,9 @@ public:  // methods
             using _V = std::decay_t<typename _T::value_type>;
             if constexpr (std::is_base_of_v<LocalConfiguration, _V>) {
                 return isSubConfigurationList(name);
+            }
+            else if constexpr (std::is_same_v<_V, bool>) {
+                return isBooleanList(name);
             }
             else if constexpr (std::is_same_v<_V, int> || std::is_same_v<_V, long> || std::is_same_v<_V, long long> ||
                                std::is_same_v<_V, std::size_t>) {

--- a/src/eckit/config/Configured.cc
+++ b/src/eckit/config/Configured.cc
@@ -25,4 +25,20 @@ Configured::Configured() {}
 
 Configured::~Configured() {}
 
+Configured& Configured::set(const std::string& name, long long value) {
+    NOTIMP;
+    return *this;
+}
+
+Configured& Configured::set(const std::string& name, const std::vector<long long>& value) {
+    NOTIMP;
+    return *this;
+}
+
+Configured& Configured::set(const std::string& name, const std::vector<bool>& value) {
+    NOTIMP;
+    return *this;
+}
+
+
 }  // namespace eckit

--- a/src/eckit/config/Configured.h
+++ b/src/eckit/config/Configured.h
@@ -52,13 +52,14 @@ public:
     virtual Configured& set(const std::string& name, double value)             = 0;
     virtual Configured& set(const std::string& name, int value)                = 0;
     virtual Configured& set(const std::string& name, long value)               = 0;
-    // virtual Configured& set(const std::string &name, long long value) = 0;
+    virtual Configured& set(const std::string& name, long long value);
     virtual Configured& set(const std::string& name, bool value)   = 0;
     virtual Configured& set(const std::string& name, size_t value) = 0;
 
+    virtual Configured& set(const std::string& name, const std::vector<bool>& value);
     virtual Configured& set(const std::string& name, const std::vector<int>& value)  = 0;
     virtual Configured& set(const std::string& name, const std::vector<long>& value) = 0;
-    // virtual Configured& set(const std::string& name, const std::vector<long long>& value) = 0;
+    virtual Configured& set(const std::string& name, const std::vector<long long>& value);
     virtual Configured& set(const std::string& name, const std::vector<size_t>& value)      = 0;
     virtual Configured& set(const std::string& name, const std::vector<float>& value)       = 0;
     virtual Configured& set(const std::string& name, const std::vector<double>& value)      = 0;

--- a/src/eckit/config/LocalConfiguration.cc
+++ b/src/eckit/config/LocalConfiguration.cc
@@ -117,6 +117,15 @@ LocalConfiguration& LocalConfiguration::set(const std::string& s, size_t value) 
     return *this;
 }
 
+LocalConfiguration& LocalConfiguration::set(const std::string& s, const std::vector<bool>& value) {
+    ValueList values;
+    for (std::vector<bool>::const_iterator v = value.begin(); v != value.end(); ++v) {
+        values.push_back(eckit::Value(*v));
+    }
+    setValue(s, values);
+    return *this;
+}
+
 LocalConfiguration& LocalConfiguration::set(const std::string& s, const std::vector<int>& value) {
     ValueList values;
     for (std::vector<int>::const_iterator v = value.begin(); v != value.end(); ++v) {

--- a/src/eckit/config/LocalConfiguration.h
+++ b/src/eckit/config/LocalConfiguration.h
@@ -52,14 +52,15 @@ public:  // methods
     LocalConfiguration& set(const std::string& name, bool value) override;
     LocalConfiguration& set(const std::string& name, int value) override;
     LocalConfiguration& set(const std::string& name, long value) override;
-    LocalConfiguration& set(const std::string& name, long long value);
+    LocalConfiguration& set(const std::string& name, long long value) override;
     LocalConfiguration& set(const std::string& name, size_t value) override;
     LocalConfiguration& set(const std::string& name, float value) override;
     LocalConfiguration& set(const std::string& name, double value) override;
 
+    LocalConfiguration& set(const std::string& name, const std::vector<bool>& value) override;
     LocalConfiguration& set(const std::string& name, const std::vector<int>& value) override;
     LocalConfiguration& set(const std::string& name, const std::vector<long>& value) override;
-    LocalConfiguration& set(const std::string& name, const std::vector<long long>& value);
+    LocalConfiguration& set(const std::string& name, const std::vector<long long>& value) override;
     LocalConfiguration& set(const std::string& name, const std::vector<size_t>& value) override;
     LocalConfiguration& set(const std::string& name, const std::vector<float>& value) override;
     LocalConfiguration& set(const std::string& name, const std::vector<double>& value) override;

--- a/src/eckit/config/Parametrisation.cc
+++ b/src/eckit/config/Parametrisation.cc
@@ -27,5 +27,8 @@ bool Parametrisation::get(const std::string& name, std::vector<long long>& value
     NOTIMP;
 }
 
+bool Parametrisation::get(const std::string& name, std::vector<bool>& value) const {
+    NOTIMP;
+}
 
 }  // namespace eckit

--- a/src/eckit/config/Parametrisation.h
+++ b/src/eckit/config/Parametrisation.h
@@ -40,6 +40,7 @@ public:  // methods
     virtual bool get(const std::string& name, float& value) const  = 0;
     virtual bool get(const std::string& name, double& value) const = 0;
 
+    virtual bool get(const std::string& name, std::vector<bool>& value) const;
     virtual bool get(const std::string& name, std::vector<int>& value) const  = 0;
     virtual bool get(const std::string& name, std::vector<long>& value) const = 0;
     virtual bool get(const std::string& name, std::vector<long long>& value) const;

--- a/src/eckit/spec/Custom.cc
+++ b/src/eckit/spec/Custom.cc
@@ -131,6 +131,16 @@ bool get_t_v_real(const Custom::container_type& map, const std::string& name, To
 }
 
 
+template <typename To>
+bool get_t_v_boolean(const Custom::container_type& map, const std::string& name, To& value) {
+    if (auto it = map.find(name); it != map.cend()) {
+        const auto& v = it->second;
+        return std::holds_alternative<std::vector<bool>>(v) ? get_t_v(std::get<std::vector<bool>>(v), value) : false;
+    }
+    return false;
+}
+
+
 template <typename T>
 Custom::value_type from_value_t(const Value& value) {
     T to;
@@ -192,6 +202,10 @@ Custom* Custom::make_from_value(const Value& value) {
         const auto list(value.as<ValueList>());
         ASSERT(!list.empty());
 
+        if (std::all_of(list.begin(), list.end(), [](const auto& v) { return v.isBool(); })) {
+            return std::vector<bool>(list.begin(), list.end());
+        }
+
         if (std::all_of(list.begin(), list.end(), [](const auto& v) { return v.isNumber(); })) {
             return std::vector<int>(list.begin(), list.end());
         }
@@ -235,6 +249,7 @@ bool Custom::operator==(const Custom& other) const {
         const auto& name = _a.first;
         auto _b          = other.map_.find(name);
         return _b != other.map_.end() && (custom_value_equal(*this, other, name, long{}) ||
+                                          custom_value_equal(*this, other, name, std::vector<bool>{}) ||
                                           custom_value_equal(*this, other, name, std::vector<long>{}) ||
                                           custom_value_equal(*this, other, name, double{}) ||
                                           custom_value_equal(*this, other, name, std::vector<double>{}) ||
@@ -284,6 +299,11 @@ void Custom::set(const std::string& name, double value) {
 }
 
 
+void Custom::set(const std::string& name, const std::vector<bool>& value) {
+    map_[name] = value;
+}
+
+
 void Custom::set(const std::string& name, const std::vector<int>& value) {
     map_[name] = value;
 }
@@ -324,7 +344,9 @@ void Custom::set(const std::string& name, const Value& value) {
 
     auto list_of = [](const ValueList& list, auto pred) { return std::all_of(list.begin(), list.end(), pred); };
 
-    auto val = value.isList() && list_of(value, [](const Value& v) { return v.isDouble(); })
+    auto val = value.isList() && list_of(value, [](const Value& v) { return v.isBool(); })
+                   ? from_value_t<std::vector<bool>>(value)
+               : value.isList() && list_of(value, [](const Value& v) { return v.isDouble(); })
                    ? from_value_t<std::vector<double>>(value)
                : value.isList() && list_of(value, [](const Value& v) { return v.isNumber(); })
                    ? from_value_t<std::vector<number_type>>(value)
@@ -454,6 +476,11 @@ bool Custom::get(const std::string& name, float& value) const {
 
 bool Custom::get(const std::string& name, double& value) const {
     return get_t_s_real(map_, name, value);
+}
+
+
+bool Custom::get(const std::string& name, std::vector<bool>& value) const {
+    return get_t_v_boolean(map_, name, value);
 }
 
 

--- a/src/eckit/spec/Custom.h
+++ b/src/eckit/spec/Custom.h
@@ -41,9 +41,9 @@ public:
         key_type(const char* s) : key_type(std::string{s}) {}
     };
 
-    using value_type = std::variant<std::string, bool, int, long, long long, size_t, float, double, std::vector<int>,
-                                    std::vector<long>, std::vector<long long>, std::vector<size_t>, std::vector<float>,
-                                    std::vector<double>, std::vector<std::string>, custom_ptr,
+    using value_type = std::variant<std::string, bool, int, long, long long, size_t, float, double, std::vector<bool>,
+                                    std::vector<int>, std::vector<long>, std::vector<long long>, std::vector<size_t>,
+                                    std::vector<float>, std::vector<double>, std::vector<std::string>, custom_ptr,
                                     const char* /* converted to std::string */>;
 
     using container_type = std::map<key_type, value_type>;
@@ -84,6 +84,7 @@ public:
     void set(const std::string& name, size_t);
     void set(const std::string& name, float);
     void set(const std::string& name, double);
+    void set(const std::string& name, const std::vector<bool>&);
     void set(const std::string& name, const std::vector<int>&);
     void set(const std::string& name, const std::vector<long>&);
     void set(const std::string& name, const std::vector<long long>&);
@@ -109,6 +110,7 @@ public:
     bool get(const std::string& name, size_t&) const override;
     bool get(const std::string& name, float&) const override;
     bool get(const std::string& name, double&) const override;
+    bool get(const std::string& name, std::vector<bool>&) const override;
     bool get(const std::string& name, std::vector<int>&) const override;
     bool get(const std::string& name, std::vector<long>&) const override;
     bool get(const std::string& name, std::vector<long long>&) const override;

--- a/src/eckit/spec/Layered.h
+++ b/src/eckit/spec/Layered.h
@@ -55,6 +55,7 @@ public:
     bool get(const std::string& name, size_t& value) const override { return get_t(name, value); }
     bool get(const std::string& name, float& value) const override { return get_t(name, value); }
     bool get(const std::string& name, double& value) const override { return get_t(name, value); }
+    bool get(const std::string& name, std::vector<bool>& value) const override { return get_t(name, value); }
     bool get(const std::string& name, std::vector<int>& value) const override { return get_t(name, value); }
     bool get(const std::string& name, std::vector<long>& value) const override { return get_t(name, value); }
     bool get(const std::string& name, std::vector<long long>& value) const override { return get_t(name, value); }

--- a/tests/config/test_configuration.cc
+++ b/tests/config/test_configuration.cc
@@ -30,6 +30,7 @@ CASE("test_configuration_interface") {
     float value_float                          = 1.234567;
     double value_double                        = 1.2345678912345789123456789;
     std::string value_string                   = "string";
+    std::vector<bool> value_arr_bool           = {true, false, true};
     std::vector<int> value_arr_int             = {1, 2, 3};
     std::vector<long> value_arr_long           = {4, 5};
     std::vector<long long> value_arr_long_long = {4, 5};
@@ -50,6 +51,7 @@ CASE("test_configuration_interface") {
     float result_float         = 0;
     double result_double       = 0;
     std::string result_string;
+    std::vector<bool> result_arr_bool;
     std::vector<int> result_arr_int;
     std::vector<long> result_arr_long;
     std::vector<long long> result_arr_long_long;
@@ -72,6 +74,7 @@ CASE("test_configuration_interface") {
         local.set("float", value_float);
         local.set("double", value_double);
         local.set("string", value_string);
+        local.set("arr_bool", value_arr_bool);
         local.set("arr_int", value_arr_int);
         local.set("arr_long", value_arr_long);
         local.set("arr_long_long", value_arr_long_long);
@@ -94,6 +97,7 @@ CASE("test_configuration_interface") {
     EXPECT(!conf.get("missing", result_float));
     EXPECT(!conf.get("missing", result_double));
     EXPECT(!conf.get("missing", result_string));
+    EXPECT(!conf.get("missing", result_arr_bool));
     EXPECT(!conf.get("missing", result_arr_int));
     EXPECT(!conf.get("missing", result_arr_long));
     EXPECT(!conf.get("missing", result_arr_long_long));
@@ -114,6 +118,7 @@ CASE("test_configuration_interface") {
     EXPECT(conf.get("float", result_float));
     EXPECT(conf.get("double", result_double));
     EXPECT(conf.get("string", result_string));
+    EXPECT(conf.get("arr_bool", result_arr_bool));
     EXPECT(conf.get("arr_int", result_arr_int));
     EXPECT(conf.get("arr_long", result_arr_long));
     EXPECT(conf.get("arr_long_long", result_arr_long_long));
@@ -134,6 +139,7 @@ CASE("test_configuration_interface") {
     EXPECT(result_float == value_float);
     EXPECT(result_double == value_double);
     EXPECT(result_string == value_string);
+    EXPECT(result_arr_bool == value_arr_bool);
     EXPECT(result_arr_int == value_arr_int);
     EXPECT(result_arr_long_long == value_arr_long_long);
     EXPECT(result_arr_size_t == value_arr_size_t);
@@ -150,6 +156,13 @@ CASE("test_configuration_interface") {
     EXPECT(conf.getFloat("float") == value_float);
     EXPECT(conf.getDouble("double") == value_double);
     EXPECT(conf.getString("string") == value_string);
+    EXPECT(conf.getBoolVector("arr_bool") == value_arr_bool);
+    EXPECT(conf.isBooleanList("arr_bool"));
+    EXPECT(!conf.isBooleanList("arr_int"));
+    EXPECT(!conf.isBooleanList("arr_string"));
+    EXPECT(conf.isConvertible<std::vector<bool>>("arr_bool"));
+    EXPECT(!conf.isConvertible<std::vector<bool>>("arr_int"));
+    EXPECT(!conf.isConvertible<std::vector<bool>>("arr_string"));
     EXPECT(conf.getIntVector("arr_int") == value_arr_int);
     EXPECT(conf.getLongVector("arr_long") == value_arr_long);
     EXPECT(conf.getUnsignedVector("arr_size_t") == value_arr_size_t);
@@ -170,6 +183,7 @@ CASE("test_configuration_interface") {
     EXPECT_THROWS_AS(conf.getFloat("missing"), eckit::Exception);
     EXPECT_THROWS_AS(conf.getDouble("missing"), eckit::Exception);
     EXPECT_THROWS_AS(conf.getString("missing"), eckit::Exception);
+    EXPECT_THROWS_AS(conf.getBoolVector("missing"), eckit::Exception);
     EXPECT_THROWS_AS(conf.getIntVector("missing"), eckit::Exception);
     EXPECT_THROWS_AS(conf.getLongVector("missing"), eckit::Exception);
     EXPECT_THROWS_AS(conf.getUnsignedVector("missing"), eckit::Exception);
@@ -190,6 +204,7 @@ CASE("test_configuration_interface") {
     EXPECT(conf.getFloat("missing", value_float) == value_float);
     EXPECT(conf.getDouble("missing", value_double) == value_double);
     EXPECT(conf.getString("missing", value_string) == value_string);
+    EXPECT(conf.getBoolVector("missing", value_arr_bool) == value_arr_bool);
     EXPECT(conf.getIntVector("missing", value_arr_int) == value_arr_int);
     EXPECT(conf.getLongVector("missing", value_arr_long) == value_arr_long);
     EXPECT(conf.getUnsignedVector("missing", value_arr_size_t) == value_arr_size_t);

--- a/tests/spec/custom.cc
+++ b/tests/spec/custom.cc
@@ -47,6 +47,10 @@ void test_t() {
         a = b = {"1", "2", "3"};
         c     = {"7", "8", "9", "10"};
     }
+    else if constexpr (std::is_same_v<T, std::vector<bool>>) {
+        a = b = {false, false, true};
+        c     = {true, false, true};
+    }
     else if constexpr (std::is_same_v<T, std::string>) {
         a = b = "1";
         c     = "7";
@@ -85,6 +89,7 @@ CASE("Custom::value_type") {
     test_t<size_t>();
     test_t<float>();
     test_t<double>();
+    test_t<std::vector<bool>>();
     test_t<std::vector<int>>();
     test_t<std::vector<long>>();
     test_t<std::vector<long long>>();
@@ -168,6 +173,13 @@ CASE("Custom::operator==") {
     EXPECT(d != a);
     EXPECT_NOT(a != d);
     EXPECT_NOT(d == a);
+
+    Custom e({{"mask", std::vector<bool>{true, false, true}}});
+    Custom f({{"mask", std::vector<bool>{true, false, true}}});
+    Custom g({{"mask", std::vector<bool>{false, true, false}}});
+
+    EXPECT(e == f);
+    EXPECT(e != g);
 }
 
 
@@ -324,7 +336,12 @@ CASE("Spec <- Custom") {
 
     SECTION("conversion (5)") {
         std::unique_ptr<Spec> custom(
-            Custom::make_from_value(YAMLParser::decodeString("{long_list: [1, 2, 3], double_list: [1, 2.1, 3]}")));
+            Custom::make_from_value(YAMLParser::decodeString("{bool_list: [true, false, true], long_list: [1, 2, 3], double_list: [1, 2.1, 3]}")));
+
+        const std::vector<bool> expected_bool_list{true, false, true};
+        std::vector<bool> bool_list;
+        EXPECT(custom->get("bool_list", bool_list));
+        EXPECT(bool_list == expected_bool_list);
 
         const std::vector<long> expected_long_list{1, 2, 3};
         auto long_list = custom->get_double_vector("long_list");
@@ -338,6 +355,22 @@ CASE("Spec <- Custom") {
         EXPECT(double_list.size() == expected_double_list.size());
         EXPECT(std::equal(double_list.begin(), double_list.end(), expected_double_list.begin(),
                           [](const auto& a, const auto& b) { return types::is_approximately_equal(a, b); }));
+    }
+
+
+    SECTION("conversion (6)") {
+        const std::vector<bool> expected_bool_list{true, false, true};
+
+        Custom custom;
+        custom.set("bool_list", expected_bool_list);
+
+        const Spec& spec = custom;
+        std::vector<bool> bool_list;
+        EXPECT(spec.get("bool_list", bool_list));
+        EXPECT(bool_list == expected_bool_list);
+
+        std::vector<int> int_list;
+        EXPECT(!spec.get("bool_list", int_list));
     }
 
 
@@ -358,6 +391,7 @@ CASE("Spec <- Custom") {
                                             {"size_t", static_cast<std::size_t>(4)},
                                             {"float", static_cast<float>(5)},
                                             {"double", static_cast<double>(6)},
+                                            {"vector<bool>", std::vector<bool>{true, false}},
                                             {"vector<int>", std::vector<int>{1, 1}},
                                             {"vector<long>", std::vector<long>{2, 2}},
                                             {"vector<long long>", std::vector<long long>{3, 3}},
@@ -368,7 +402,7 @@ CASE("Spec <- Custom") {
 
         const std::string b_str = b->str();
         const std::string b_ref =
-            R"({"bool":true,"double":6,"float":5,"int":1,"long":2,"long long":3,"size_t":4,"string":"string","vector<double>":[6,6],"vector<float>":[5,5],"vector<int>":[1,1],"vector<long long>":[3,3],"vector<long>":[2,2],"vector<size_t>":[4,4],"vector<string>":["string","string"]})";
+            R"({"bool":true,"double":6,"float":5,"int":1,"long":2,"long long":3,"size_t":4,"string":"string","vector<bool>":[true,false],"vector<double>":[6,6],"vector<float>":[5,5],"vector<int>":[1,1],"vector<long long>":[3,3],"vector<long>":[2,2],"vector<size_t>":[4,4],"vector<string>":["string","string"]})";
         EXPECT_EQUAL(b_str, b_ref);
     }
 }

--- a/tests/spec/custom.cc
+++ b/tests/spec/custom.cc
@@ -335,8 +335,8 @@ CASE("Spec <- Custom") {
 
 
     SECTION("conversion (5)") {
-        std::unique_ptr<Spec> custom(
-            Custom::make_from_value(YAMLParser::decodeString("{bool_list: [true, false, true], long_list: [1, 2, 3], double_list: [1, 2.1, 3]}")));
+        std::unique_ptr<Spec> custom(Custom::make_from_value(YAMLParser::decodeString(
+            "{bool_list: [true, false, true], long_list: [1, 2, 3], double_list: [1, 2.1, 3]}")));
 
         const std::vector<bool> expected_bool_list{true, false, true};
         std::vector<bool> bool_list;

--- a/tests/spec/layered.cc
+++ b/tests/spec/layered.cc
@@ -20,12 +20,14 @@ namespace eckit::spec::test {
 
 
 CASE("Spec <- Layered") {
-    int one    = 1;
-    double two = 2.;
+    int one                              = 1;
+    double two                           = 2.;
+    std::vector<bool> expected_bool_list = {true, false, true};
 
-    spec::Custom a({{"foo", one}, {"bar", two}});
+    spec::Custom a({{"foo", one}, {"bar", two}, {"bool_list", expected_bool_list}});
     ASSERT(a.has("foo"));
     ASSERT(a.has("bar"));
+    ASSERT(a.has("bool_list"));
 
     spec::Layered b(a);
 
@@ -42,6 +44,13 @@ CASE("Spec <- Layered") {
 
     auto value = b.get_int("foo");
     EXPECT(value == one);
+
+    std::vector<bool> bool_list;
+    EXPECT(b.get("bool_list", bool_list));
+    EXPECT(bool_list == expected_bool_list);
+
+    b.hide("bool_list");
+    EXPECT_NOT(b.get("bool_list", bool_list));
 }
 
 


### PR DESCRIPTION
### Description

This pull request adds support for handling vectors of boolean values (`std::vector<bool>`) in the configuration and spec classes. This includes the ability to set, get, and compare boolean vectors in configuration objects, as well as updating the interface and tests to cover these new capabilities.

The most important changes are:

**Configuration and Parametrisation Enhancements:**

* Added support for retrieving boolean vectors with new methods `getBoolVector` (with and without default values) and the corresponding `get(const std::string&, std::vector<bool>&)` overload in `Configuration`, `Parametrisation`, and their subclasses. The new virtual functions are not pure abstract, but throw NOTIMP such that downstream packages can stay compatible, and can adapt when desired. Subclasses within eckit have all been adapted as if the functions were pure abstract.

* Updated the type checking logic in `Configuration` to recognize boolean lists for template-based getters.

**Setting Boolean Vectors:**

* Implemented `set(const std::string&, const std::vector<bool>&)` in `Configured`, `LocalConfiguration`, and `Custom`, allowing boolean vectors to be stored in configuration objects.

**Spec and Variant Support:**

* Extended the `Custom` spec class to support storing and retrieving `std::vector<bool>` as a variant type, including construction from values, equality checks, and variant conversion logic.

**Testing:**

* Added and updated tests in `test_configuration.cc` to verify correct setting and retrieval of boolean vectors, as well as handling of missing boolean vector keys.


### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 


<!-- PREVIEW-URL_BEGIN -->
🌦️ >> Documentation << 🌦️
https://sites.ecmwf.int/docs/dev-section/eckit/pull-requests/PR-330
<!-- PREVIEW-URL_END -->