### PR TITLE
eckit::utils: safe casts (1) corrected handling of converting to/from…

### DIFF
--- a/src/eckit/utils/SafeCasts.h
+++ b/src/eckit/utils/SafeCasts.h
@@ -9,7 +9,7 @@
  */
 
 /**
- * Place functions to allow for save type casting in this file
+ * Safe type casting between integer types, preserving the value across changes of width and signedness.
  */
 #pragma once
 #include <limits>
@@ -22,10 +22,9 @@ namespace eckit {
 
 namespace detail {
 
-/// Tag defaulting the first template parameter of 'into_signed'/'into_unsigned', so that supplying an
-/// explicit template argument (which would name the *source* type) is rejected instead of silently
-/// converting the argument before the check is applied.
-struct deduce_source_type {};
+/// Tag defaulting the target type of 'into_signed'/'into_unsigned' to the same width as the source, so that an
+/// explicit template argument names the target rather than being silently converted to before being checked.
+struct deduce_target_type {};
 
 /**
  *  Tells whether a value is representable by the target type, checking it against both the minimum and the
@@ -36,41 +35,24 @@ struct deduce_source_type {};
  */
 template <typename T, typename S, std::enable_if_t<std::is_integral_v<T> && std::is_integral_v<S>, int> = 0>
 [[nodiscard]] constexpr bool fits(S value) {
+    using L = std::numeric_limits<T>;
+
     if constexpr (std::is_signed_v<S> == std::is_signed_v<T>) {
-        // same signedness: a target at least as wide represents every value exactly
-        if constexpr (sizeof(T) >= sizeof(S)) {
-            return true;
-        }
-        else if constexpr (std::is_signed_v<S>) {
-            return value >= static_cast<S>(std::numeric_limits<T>::min()) &&
-                   value <= static_cast<S>(std::numeric_limits<T>::max());
+        // sharing a signedness, the wider type represents both bounds and the value exactly
+        using C = std::conditional_t<(sizeof(T) > sizeof(S)), T, S>;
+        if constexpr (std::is_signed_v<C>) {
+            return static_cast<C>(value) >= static_cast<C>(L::min()) &&
+                   static_cast<C>(value) <= static_cast<C>(L::max());
         }
         else {
-            // the minimum (0) is shared by both types, so only the maximum can be exceeded
-            return value <= static_cast<S>(std::numeric_limits<T>::max());
+            return static_cast<C>(value) <= static_cast<C>(L::max());  // both start at zero
         }
     }
     else if constexpr (std::is_signed_v<S>) {
-        // signed into unsigned: the minimum check rejects every negative value
-        if (value < 0) {
-            return false;
-        }
-        if constexpr (sizeof(T) >= sizeof(S)) {
-            return true;
-        }
-        else {
-            using US = std::make_unsigned_t<S>;
-            return static_cast<US>(value) <= static_cast<US>(std::numeric_limits<T>::max());
-        }
+        return value >= 0 && static_cast<std::make_unsigned_t<S>>(value) <= L::max();
     }
     else {
-        // unsigned into signed: the minimum (0) is always representable, a strictly wider target always fits
-        if constexpr (sizeof(T) > sizeof(S)) {
-            return true;
-        }
-        else {
-            return value <= static_cast<S>(std::numeric_limits<T>::max());
-        }
+        return value <= static_cast<std::make_unsigned_t<T>>(L::max());  // zero is always representable
     }
 }
 
@@ -96,30 +78,38 @@ template <typename T, typename S, std::enable_if_t<std::is_integral_v<T> && std:
  *  Casts signed integer into unsigned.
  *  @param value to cast from.
  *  @return value cast into, same as before but unsigned type.
- *  @throws BadCast if used with a negative value.
+ *  @throws BadCast if the value is negative, or too large for the target type.
  */
-template <typename Deduce = detail::deduce_source_type, typename S,
-          std::enable_if_t<std::is_integral_v<S> && !std::is_same_v<std::remove_cv_t<S>, bool>, int> = 0>
-[[nodiscard]] constexpr auto into_unsigned(S value) -> std::make_unsigned_t<S> {
-    static_assert(std::is_same_v<Deduce, detail::deduce_source_type>,
-                  "eckit::into_unsigned takes no explicit template argument: it would name the source type, "
-                  "converting the argument before it is checked. Use eckit::into<T>(value) to pick a target type.");
-    return into<std::make_unsigned_t<S>>(value);
+template <typename T = detail::deduce_target_type, typename S, std::enable_if_t<std::is_integral_v<S>, int> = 0>
+[[nodiscard]] constexpr auto into_unsigned(S value) {
+    if constexpr (std::is_same_v<T, detail::deduce_target_type>) {
+        return into<std::make_unsigned_t<S>>(value);
+    }
+    else {
+        static_assert(std::is_integral_v<T> && std::is_unsigned_v<T>,
+                      "the explicit template argument of eckit::into_unsigned names the target type, "
+                      "which must be an unsigned integer");
+        return into<T>(value);
+    }
 }
 
 /**
  *  Casts unsigned integer into signed.
  *  @param value to cast from.
  *  @return value cast into, same as before but signed type.
- *  @throws BadCast if used with a value > 2^(bits-1)-1
+ *  @throws BadCast if the value is not representable by the target type.
  */
-template <typename Deduce = detail::deduce_source_type, typename S,
-          std::enable_if_t<std::is_integral_v<S> && !std::is_same_v<std::remove_cv_t<S>, bool>, int> = 0>
-[[nodiscard]] constexpr auto into_signed(S value) -> std::make_signed_t<S> {
-    static_assert(std::is_same_v<Deduce, detail::deduce_source_type>,
-                  "eckit::into_signed takes no explicit template argument: it would name the source type, "
-                  "converting the argument before it is checked. Use eckit::into<T>(value) to pick a target type.");
-    return into<std::make_signed_t<S>>(value);
+template <typename T = detail::deduce_target_type, typename S, std::enable_if_t<std::is_integral_v<S>, int> = 0>
+[[nodiscard]] constexpr auto into_signed(S value) {
+    if constexpr (std::is_same_v<T, detail::deduce_target_type>) {
+        return into<std::make_signed_t<S>>(value);
+    }
+    else {
+        static_assert(std::is_integral_v<T> && std::is_signed_v<T>,
+                      "the explicit template argument of eckit::into_signed names the target type, "
+                      "which must be a signed integer");
+        return into<T>(value);
+    }
 }
 
 }  // namespace eckit

--- a/src/eckit/utils/SafeCasts.h
+++ b/src/eckit/utils/SafeCasts.h
@@ -13,11 +13,84 @@
  */
 #pragma once
 #include <limits>
+#include <string>
 #include <type_traits>
 
 #include "eckit/exception/Exceptions.h"
 
 namespace eckit {
+
+namespace detail {
+
+/// Tag defaulting the first template parameter of 'into_signed'/'into_unsigned', so that supplying an
+/// explicit template argument (which would name the *source* type) is rejected instead of silently
+/// converting the argument before the check is applied.
+struct deduce_source_type {};
+
+/**
+ *  Tells whether a value is representable by the target type, checking it against both the minimum and the
+ *  maximum allowed value. Comparisons are only ever made in a type that represents both operands exactly, so
+ *  that conversions mixing signed and unsigned types are decided correctly.
+ *  @param value to check.
+ *  @return whether the value can be cast to the target type without changing it.
+ */
+template <typename T, typename S, std::enable_if_t<std::is_integral_v<T> && std::is_integral_v<S>, int> = 0>
+[[nodiscard]] constexpr bool fits(S value) {
+    if constexpr (std::is_signed_v<S> == std::is_signed_v<T>) {
+        // same signedness: a target at least as wide represents every value exactly
+        if constexpr (sizeof(T) >= sizeof(S)) {
+            return true;
+        }
+        else if constexpr (std::is_signed_v<S>) {
+            return value >= static_cast<S>(std::numeric_limits<T>::min()) &&
+                   value <= static_cast<S>(std::numeric_limits<T>::max());
+        }
+        else {
+            // the minimum (0) is shared by both types, so only the maximum can be exceeded
+            return value <= static_cast<S>(std::numeric_limits<T>::max());
+        }
+    }
+    else if constexpr (std::is_signed_v<S>) {
+        // signed into unsigned: the minimum check rejects every negative value
+        if (value < 0) {
+            return false;
+        }
+        if constexpr (sizeof(T) >= sizeof(S)) {
+            return true;
+        }
+        else {
+            using US = std::make_unsigned_t<S>;
+            return static_cast<US>(value) <= static_cast<US>(std::numeric_limits<T>::max());
+        }
+    }
+    else {
+        // unsigned into signed: the minimum (0) is always representable, a strictly wider target always fits
+        if constexpr (sizeof(T) > sizeof(S)) {
+            return true;
+        }
+        else {
+            return value <= static_cast<S>(std::numeric_limits<T>::max());
+        }
+    }
+}
+
+}  // namespace detail
+
+/**
+ *  Casts an integer into another integer type, checking that the value is preserved. Both the minimum and the
+ *  maximum allowed value are checked, covering conversions that mix signed and unsigned types as well as
+ *  conversions that narrow (such as 'long long' into 'long', or 'long' into 'int').
+ *  @param value to cast from.
+ *  @return value cast into the requested type.
+ *  @throws BadCast if the value is not representable by the target type.
+ */
+template <typename T, typename S, std::enable_if_t<std::is_integral_v<T> && std::is_integral_v<S>, int> = 0>
+[[nodiscard]] constexpr T into(S value) {
+    if (!detail::fits<T>(value)) {
+        throw eckit::BadCast("Value " + std::to_string(value) + " cannot be cast to the target type", Here());
+    }
+    return static_cast<T>(value);
+}
 
 /**
  *  Casts signed integer into unsigned.
@@ -25,23 +98,13 @@ namespace eckit {
  *  @return value cast into, same as before but unsigned type.
  *  @throws BadCast if used with a negative value.
  */
-template <typename S, std::enable_if_t<std::is_integral_v<S> && std::is_signed_v<S>, int> = 0>
+template <typename Deduce = detail::deduce_source_type, typename S,
+          std::enable_if_t<std::is_integral_v<S> && !std::is_same_v<std::remove_cv_t<S>, bool>, int> = 0>
 [[nodiscard]] constexpr auto into_unsigned(S value) -> std::make_unsigned_t<S> {
-    using U = std::make_unsigned_t<S>;
-    if (value < 0) {
-        throw eckit::BadCast("Negative value cannot be cast to unsigned type", Here());
-    }
-    return static_cast<U>(value);
-}
-
-/**
- * Template specialization that turns unsigned to unsigned conversions with 'into_unsigned' into a NoOp
- * @param value
- * @return value, returned unmodified.
- */
-template <typename S, std::enable_if_t<std::is_integral_v<S> && std::is_unsigned_v<S>, int> = 0>
-[[nodiscard]] constexpr auto into_unsigned(S value) -> std::make_unsigned_t<S> {
-    return value;
+    static_assert(std::is_same_v<Deduce, detail::deduce_source_type>,
+                  "eckit::into_unsigned takes no explicit template argument: it would name the source type, "
+                  "converting the argument before it is checked. Use eckit::into<T>(value) to pick a target type.");
+    return into<std::make_unsigned_t<S>>(value);
 }
 
 /**
@@ -50,23 +113,13 @@ template <typename S, std::enable_if_t<std::is_integral_v<S> && std::is_unsigned
  *  @return value cast into, same as before but signed type.
  *  @throws BadCast if used with a value > 2^(bits-1)-1
  */
-template <typename U, std::enable_if_t<std::is_integral_v<U> && std::is_unsigned_v<U>, int> = 0>
-[[nodiscard]] constexpr auto into_signed(U value) -> std::make_signed_t<U> {
-    using S = std::make_signed_t<U>;
-    if (value > static_cast<U>(std::numeric_limits<S>::max())) {
-        throw eckit::BadCast("Value too large to cast to signed type");
-    }
-    return static_cast<S>(value);
-}
-
-/**
- * Template specialization that turns signed to signed conversions with 'into_signed' into a NoOp
- * @param value
- * @return value, returned unmodified.
- */
-template <typename U, std::enable_if_t<std::is_integral_v<U> && std::is_signed_v<U>, int> = 0>
-[[nodiscard]] constexpr auto into_signed(U value) -> std::make_signed_t<U> {
-    return value;
+template <typename Deduce = detail::deduce_source_type, typename S,
+          std::enable_if_t<std::is_integral_v<S> && !std::is_same_v<std::remove_cv_t<S>, bool>, int> = 0>
+[[nodiscard]] constexpr auto into_signed(S value) -> std::make_signed_t<S> {
+    static_assert(std::is_same_v<Deduce, detail::deduce_source_type>,
+                  "eckit::into_signed takes no explicit template argument: it would name the source type, "
+                  "converting the argument before it is checked. Use eckit::into<T>(value) to pick a target type.");
+    return into<std::make_signed_t<S>>(value);
 }
 
 }  // namespace eckit

--- a/tests/utils/test_safe_casts.cc
+++ b/tests/utils/test_safe_casts.cc
@@ -14,9 +14,55 @@
 
 #include <cstdint>
 #include <limits>
+#include <type_traits>
 
+using eckit::into;
 using eckit::into_signed;
 using eckit::into_unsigned;
+
+namespace {
+
+template <typename T>
+constexpr T min = std::numeric_limits<T>::min();
+
+template <typename T>
+constexpr T max = std::numeric_limits<T>::max();
+
+/// Not a round trip: casting back is self-inverting under modular wrap-around, so it cannot detect that
+/// uint16_t{65408} and int8_t{-128} share a representation but not a value. Sign and magnitude can.
+template <typename T>
+constexpr bool isNegative(T value) {
+    if constexpr (std::is_signed_v<T>) {
+        return value < T{};
+    }
+    else {
+        return false;
+    }
+}
+
+template <typename T, typename S>
+constexpr bool preservesValue(S value) {
+    static_assert(sizeof(S) <= 4, "wider sources would not compare exactly as intmax_t");
+    const auto converted = static_cast<T>(value);
+    return isNegative(converted) == isNegative(value) &&
+           static_cast<intmax_t>(converted) == static_cast<intmax_t>(value);
+}
+
+/// Checks 'fits' against that oracle for every value of the source type. Uses the non-throwing predicate so
+/// the exhaustive sweep stays cheap.
+template <typename T, typename S>
+bool fitsMatchesOracleForEveryValue() {
+    for (auto value = min<S>;; ++value) {
+        if (eckit::detail::fits<T>(value) != preservesValue<T>(value)) {
+            return false;
+        }
+        if (value == max<S>) {
+            return true;
+        }
+    }
+}
+
+}  // namespace
 
 CASE("Can convert positive signed to unsigned") {
     EXPECT_EQUAL(into_unsigned(int8_t{5}), uint8_t{5});
@@ -93,6 +139,96 @@ CASE("No-op if used as signed to signed cast") {
     EXPECT_EQUAL(into_signed(static_cast<int>(-5)), -5);
     EXPECT_EQUAL(into_signed(static_cast<long>(-5)), -5);
     EXPECT_EQUAL(into_signed(static_cast<long long>(-5)), -5);
+}
+
+CASE("Widening always preserves the value") {
+    EXPECT_EQUAL(into<int64_t>(int8_t{-5}), -5);
+    EXPECT_EQUAL(into<int64_t>(min<int32_t>), min<int32_t>);
+    EXPECT_EQUAL(into<int32_t>(uint8_t{200}), 200);
+    EXPECT_EQUAL(into<int32_t>(max<uint16_t>), max<uint16_t>);
+    EXPECT_EQUAL(into<uint64_t>(max<uint32_t>), max<uint32_t>);
+}
+
+CASE("Same type is an identity, including at the limits") {
+    EXPECT_EQUAL(into<int32_t>(min<int32_t>), min<int32_t>);
+    EXPECT_EQUAL(into<int32_t>(max<int32_t>), max<int32_t>);
+    EXPECT_EQUAL(into<uint64_t>(max<uint64_t>), max<uint64_t>);
+}
+
+CASE("Signed narrowing checks both the minimum and the maximum") {
+    EXPECT_EQUAL(into<int32_t>(int64_t{min<int32_t>}), min<int32_t>);
+    EXPECT_EQUAL(into<int32_t>(int64_t{max<int32_t>}), max<int32_t>);
+    EXPECT_THROWS_AS((void)into<int32_t>(int64_t{min<int32_t>} - 1), eckit::BadCast);
+    EXPECT_THROWS_AS((void)into<int32_t>(int64_t{max<int32_t>} + 1), eckit::BadCast);
+    EXPECT_THROWS_AS((void)into<int32_t>(min<int64_t>), eckit::BadCast);
+    EXPECT_THROWS_AS((void)into<int32_t>(max<int64_t>), eckit::BadCast);
+}
+
+CASE("Unsigned narrowing checks the maximum") {
+    EXPECT_EQUAL(into<uint8_t>(uint32_t{max<uint8_t>}), max<uint8_t>);
+    EXPECT_THROWS_AS((void)into<uint8_t>(uint32_t{max<uint8_t>} + 1), eckit::BadCast);
+    EXPECT_THROWS_AS((void)into<uint8_t>(max<uint64_t>), eckit::BadCast);
+}
+
+CASE("Signed to unsigned rejects every negative value, even when widening") {
+    EXPECT_EQUAL(into<uint64_t>(int8_t{0}), uint64_t{0});
+    EXPECT_THROWS_AS((void)into<uint8_t>(int8_t{-1}), eckit::BadCast);
+    EXPECT_THROWS_AS((void)into<uint64_t>(int8_t{-1}), eckit::BadCast);
+    EXPECT_THROWS_AS((void)into<uint64_t>(min<int64_t>), eckit::BadCast);
+}
+
+CASE("Unsigned to signed checks the maximum, the minimum being unreachable") {
+    EXPECT_EQUAL(into<int32_t>(static_cast<uint32_t>(max<int32_t>)), max<int32_t>);
+    EXPECT_EQUAL(into<int32_t>(uint32_t{0}), 0);
+    EXPECT_THROWS_AS((void)into<int32_t>(static_cast<uint32_t>(max<int32_t>) + 1), eckit::BadCast);
+    EXPECT_THROWS_AS((void)into<int64_t>(max<uint64_t>), eckit::BadCast);
+}
+
+CASE("Narrows where into_signed and into_unsigned structurally cannot") {
+    EXPECT_EQUAL(into<long>((long long)7), 7L);
+    EXPECT_EQUAL(into<int>(long{-7}), -7);
+    EXPECT_THROWS_AS((void)into<int>(int64_t{max<int32_t>} + 1), eckit::BadCast);
+}
+
+CASE("into_signed reports rather than wraps the values it cannot represent") {
+    EXPECT_THROWS_AS((void)into_signed(static_cast<uint64_t>(max<int64_t>) + 1), eckit::BadCast);
+    EXPECT_EQUAL(into_signed(static_cast<uint64_t>(max<int64_t>)), max<int64_t>);
+}
+
+CASE("into_signed and into_unsigned preserve the width of their argument") {
+    static_assert(std::is_same_v<decltype(into_signed(uint32_t{0})), int32_t>);
+    static_assert(std::is_same_v<decltype(into_signed(int32_t{0})), int32_t>);
+    static_assert(std::is_same_v<decltype(into_unsigned(int64_t{0})), uint64_t>);
+    static_assert(std::is_same_v<decltype(into_unsigned(uint64_t{0})), uint64_t>);
+    EXPECT(true);
+}
+
+CASE("into_signed and into_unsigned take a deduction guard, not an explicit source type") {
+    using Guard = eckit::detail::deduce_source_type;
+    static_assert(std::is_same_v<decltype(into_signed<Guard>(uint64_t{0})), int64_t>);
+    static_assert(std::is_same_v<decltype(into_unsigned<Guard>(int64_t{0})), uint64_t>);
+    EXPECT(true);
+}
+
+CASE("Usable in constant expressions") {
+    static_assert(into<int32_t>(int64_t{7}) == 7);
+    static_assert(into<uint8_t>(int32_t{255}) == 255);
+    static_assert(eckit::detail::fits<int8_t>(127));
+    static_assert(!eckit::detail::fits<int8_t>(128));
+    static_assert(!eckit::detail::fits<uint32_t>(-1));
+    EXPECT(true);
+}
+
+CASE("Agrees with sign and magnitude for every value of the source type") {
+    EXPECT((fitsMatchesOracleForEveryValue<int8_t, int16_t>()));
+    EXPECT((fitsMatchesOracleForEveryValue<int8_t, uint16_t>()));
+    EXPECT((fitsMatchesOracleForEveryValue<uint8_t, int16_t>()));
+    EXPECT((fitsMatchesOracleForEveryValue<uint8_t, uint16_t>()));
+    EXPECT((fitsMatchesOracleForEveryValue<int16_t, int16_t>()));
+    EXPECT((fitsMatchesOracleForEveryValue<int16_t, uint16_t>()));
+    EXPECT((fitsMatchesOracleForEveryValue<uint16_t, int16_t>()));
+    EXPECT((fitsMatchesOracleForEveryValue<int64_t, int16_t>()));
+    EXPECT((fitsMatchesOracleForEveryValue<uint64_t, int16_t>()));
 }
 
 int main(int argc, char* argv[]) {

--- a/tests/utils/test_safe_casts.cc
+++ b/tests/utils/test_safe_casts.cc
@@ -141,17 +141,11 @@ CASE("No-op if used as signed to signed cast") {
     EXPECT_EQUAL(into_signed(static_cast<long long>(-5)), -5);
 }
 
-CASE("Widening always preserves the value") {
+CASE("Widening and same-type conversions always preserve the value") {
     EXPECT_EQUAL(into<int64_t>(int8_t{-5}), -5);
     EXPECT_EQUAL(into<int64_t>(min<int32_t>), min<int32_t>);
-    EXPECT_EQUAL(into<int32_t>(uint8_t{200}), 200);
     EXPECT_EQUAL(into<int32_t>(max<uint16_t>), max<uint16_t>);
-    EXPECT_EQUAL(into<uint64_t>(max<uint32_t>), max<uint32_t>);
-}
-
-CASE("Same type is an identity, including at the limits") {
     EXPECT_EQUAL(into<int32_t>(min<int32_t>), min<int32_t>);
-    EXPECT_EQUAL(into<int32_t>(max<int32_t>), max<int32_t>);
     EXPECT_EQUAL(into<uint64_t>(max<uint64_t>), max<uint64_t>);
 }
 
@@ -160,8 +154,6 @@ CASE("Signed narrowing checks both the minimum and the maximum") {
     EXPECT_EQUAL(into<int32_t>(int64_t{max<int32_t>}), max<int32_t>);
     EXPECT_THROWS_AS((void)into<int32_t>(int64_t{min<int32_t>} - 1), eckit::BadCast);
     EXPECT_THROWS_AS((void)into<int32_t>(int64_t{max<int32_t>} + 1), eckit::BadCast);
-    EXPECT_THROWS_AS((void)into<int32_t>(min<int64_t>), eckit::BadCast);
-    EXPECT_THROWS_AS((void)into<int32_t>(max<int64_t>), eckit::BadCast);
 }
 
 CASE("Unsigned narrowing checks the maximum") {
@@ -179,7 +171,6 @@ CASE("Signed to unsigned rejects every negative value, even when widening") {
 
 CASE("Unsigned to signed checks the maximum, the minimum being unreachable") {
     EXPECT_EQUAL(into<int32_t>(static_cast<uint32_t>(max<int32_t>)), max<int32_t>);
-    EXPECT_EQUAL(into<int32_t>(uint32_t{0}), 0);
     EXPECT_THROWS_AS((void)into<int32_t>(static_cast<uint32_t>(max<int32_t>) + 1), eckit::BadCast);
     EXPECT_THROWS_AS((void)into<int64_t>(max<uint64_t>), eckit::BadCast);
 }
@@ -190,24 +181,19 @@ CASE("Narrows where into_signed and into_unsigned structurally cannot") {
     EXPECT_THROWS_AS((void)into<int>(int64_t{max<int32_t>} + 1), eckit::BadCast);
 }
 
-CASE("into_signed reports rather than wraps the values it cannot represent") {
-    EXPECT_THROWS_AS((void)into_signed(static_cast<uint64_t>(max<int64_t>) + 1), eckit::BadCast);
-    EXPECT_EQUAL(into_signed(static_cast<uint64_t>(max<int64_t>)), max<int64_t>);
-}
-
-CASE("into_signed and into_unsigned preserve the width of their argument") {
+CASE("The target type defaults to the width of the source") {
     static_assert(std::is_same_v<decltype(into_signed(uint32_t{0})), int32_t>);
-    static_assert(std::is_same_v<decltype(into_signed(int32_t{0})), int32_t>);
     static_assert(std::is_same_v<decltype(into_unsigned(int64_t{0})), uint64_t>);
-    static_assert(std::is_same_v<decltype(into_unsigned(uint64_t{0})), uint64_t>);
-    EXPECT(true);
+    EXPECT_EQUAL(into_signed(static_cast<uint64_t>(max<int64_t>)), max<int64_t>);
+    EXPECT_THROWS_AS((void)into_signed(static_cast<uint64_t>(max<int64_t>) + 1), eckit::BadCast);
 }
 
-CASE("into_signed and into_unsigned take a deduction guard, not an explicit source type") {
-    using Guard = eckit::detail::deduce_source_type;
-    static_assert(std::is_same_v<decltype(into_signed<Guard>(uint64_t{0})), int64_t>);
-    static_assert(std::is_same_v<decltype(into_unsigned<Guard>(int64_t{0})), uint64_t>);
-    EXPECT(true);
+CASE("An explicit template argument names the target type, not the source") {
+    static_assert(std::is_same_v<decltype(into_unsigned<uint64_t>(int32_t{0})), uint64_t>);
+    static_assert(std::is_same_v<decltype(into_signed<int8_t>(uint32_t{0})), int8_t>);
+    EXPECT_EQUAL(into_unsigned<uint64_t>(int32_t{5}), uint64_t{5});
+    EXPECT_THROWS_AS((void)into_unsigned<size_t>(long{-1}), eckit::BadCast);
+    EXPECT_THROWS_AS((void)into_signed<int8_t>(uint32_t{200}), eckit::BadCast);
 }
 
 CASE("Usable in constant expressions") {


### PR DESCRIPTION
### Description

eckit::utils: safe casts:
1. corrected handling of converting to/from unsigned/signed, and
2. checking lower bounds


### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 


<!-- PREVIEW-URL_BEGIN -->
🌦️ >> Documentation << 🌦️
https://sites.ecmwf.int/docs/dev-section/eckit/pull-requests/PR-334
<!-- PREVIEW-URL_END -->