### PR TITLE
Name jobs from _resolved.job-name

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
 
   build:
     needs: [ci-approval, resolve]
-    name: build+test (${{ matrix.platform }}, ${{ matrix.cxx-compiler }})
+    name: build+test (${{ matrix._resolved['job-name'] }})
     runs-on: ${{ matrix['runs-on'] }}
     container:
       image: ${{ matrix.container || '' }}
@@ -116,7 +116,7 @@ jobs:
 
   build-hpc:
     needs: [ci-approval, resolve]
-    name: build-hpc (${{ matrix.platform }})
+    name: build-hpc (${{ matrix._resolved['job-name'] }})
     runs-on: ${{ matrix['runs-on'] }}
     container:
       image: ${{ matrix.container }}

--- a/.github/workflows/cross-repo-trigger-hpc.yml
+++ b/.github/workflows/cross-repo-trigger-hpc.yml
@@ -115,7 +115,7 @@ jobs:
     needs:
     - resolve
     if: contains(fromJSON(inputs.from-jobs), 'ecbuild/build-hpc') || contains(fromJSON(inputs.from-jobs), 'stack-deps/build-hpc') || inputs.rebuild-request
-    name: eckit/build-hpc (${{ matrix.platform }}, ${{ matrix['cxx-compiler'] }})
+    name: eckit/build-hpc (${{ matrix._resolved['job-name'] }})
     runs-on: ${{ matrix['runs-on'] }}
     container:
       image: ${{ matrix.container || '' }}
@@ -139,7 +139,7 @@ jobs:
         token: ${{ steps.mint.outputs.token }}
         head-repo: ${{ inputs.from-repo }}
         head-sha: ${{ inputs.from-sha }}
-        name: eckit/build-hpc (${{ matrix.platform }}, ${{ matrix['cxx-compiler'] }})
+        name: eckit/build-hpc (${{ matrix._resolved['job-name'] }})
         details-url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         phase: start
     - name: Announce image
@@ -203,7 +203,7 @@ jobs:
         token: ${{ steps.mint.outputs.token }}
         head-repo: ${{ inputs.from-repo }}
         head-sha: ${{ inputs.from-sha }}
-        name: eckit/build-hpc (${{ matrix.platform }}, ${{ matrix['cxx-compiler'] }})
+        name: eckit/build-hpc (${{ matrix._resolved['job-name'] }})
         details-url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         phase: finish
         conclusion: ${{ job.status }}

--- a/.github/workflows/cross-repo-trigger.yml
+++ b/.github/workflows/cross-repo-trigger.yml
@@ -115,7 +115,7 @@ jobs:
     needs:
     - resolve
     if: contains(fromJSON(inputs.from-jobs), 'ecbuild/build') || contains(fromJSON(inputs.from-jobs), 'stack-deps/build') || inputs.rebuild-request
-    name: eckit/build (${{ matrix.platform }}, ${{ matrix['cxx-compiler'] }})
+    name: eckit/build (${{ matrix._resolved['job-name'] }})
     runs-on: ${{ matrix['runs-on'] }}
     container:
       image: ${{ matrix.container || '' }}
@@ -136,7 +136,7 @@ jobs:
         token: ${{ steps.mint.outputs.token }}
         head-repo: ${{ inputs.from-repo }}
         head-sha: ${{ inputs.from-sha }}
-        name: eckit/build (${{ matrix.platform }}, ${{ matrix['cxx-compiler'] }})
+        name: eckit/build (${{ matrix._resolved['job-name'] }})
         details-url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         phase: start
     - name: Announce image
@@ -205,7 +205,7 @@ jobs:
         token: ${{ steps.mint.outputs.token }}
         head-repo: ${{ inputs.from-repo }}
         head-sha: ${{ inputs.from-sha }}
-        name: eckit/build (${{ matrix.platform }}, ${{ matrix['cxx-compiler'] }})
+        name: eckit/build (${{ matrix._resolved['job-name'] }})
         details-url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         phase: finish
         conclusion: ${{ job.status }}

--- a/.github/workflows/trigger-downstream-hpc.yml
+++ b/.github/workflows/trigger-downstream-hpc.yml
@@ -8,10 +8,42 @@ on:
     - CI
     types:
     - completed
+  pull_request_target:
+    types:
+    - labeled
 concurrency:
-  group: trigger-downstream-hpc-${{ github.event.workflow_run.head_sha }}
+  group: trigger-downstream-hpc-${{ github.event.workflow_run.head_sha || github.event.pull_request.head.sha }}
   cancel-in-progress: true
 jobs:
+  ci-approval:
+    if: ${{ github.event_name != 'pull_request_target' || github.event.label.name == 'run-downstream-CI' }}
+    runs-on: ubuntu-slim
+    permissions:
+      pull-requests: write
+    steps:
+    - uses: ecmwf/ci-infrastructure/actions/require-ci-approval@main
+  context:
+    needs:
+    - ci-approval
+    runs-on: ubuntu-slim
+    outputs:
+      head-sha: ${{ steps.ctx.outputs.head-sha }}
+      head-branch: ${{ steps.ctx.outputs.head-branch }}
+      ci-conclusion: ${{ steps.ctx.outputs.ci-conclusion }}
+      ci-url: ${{ steps.ctx.outputs.ci-url }}
+      ci-summary: ${{ steps.ctx.outputs.ci-summary }}
+    steps:
+    - id: mint
+      uses: actions/create-github-app-token@v3
+      with:
+        client-id: ${{ secrets.CI_PERMISSIONS_APP_CLIENT_ID }}
+        private-key: ${{ secrets.CI_PERMISSIONS_APP_PRIVATE_KEY }}
+        owner: ${{ github.repository_owner }}
+    - name: Resolve the commit under test
+      id: ctx
+      uses: ecmwf/ci-infrastructure/actions/resolve-dispatch-context@main
+      with:
+        token: ${{ steps.mint.outputs.token }}
   label-gate:
     runs-on: ubuntu-slim
     outputs:
@@ -28,10 +60,13 @@ jobs:
       uses: ecmwf/ci-infrastructure/actions/check-pr-label@main
       with:
         label: run-downstream-CI
-        sha: ${{ github.event.workflow_run.head_sha }}
+        sha: ${{ needs.context.outputs.head-sha }}
         token: ${{ steps.mint.outputs.token }}
+    needs:
+    - ci-approval
+    - context
   validate:
-    if: ${{ (github.event.workflow_run.conclusion == 'success') && needs['label-gate'].outputs.run == 'true' }}
+    if: ${{ (needs.context.outputs.ci-conclusion == 'success') && needs['label-gate'].outputs.run == 'true' }}
     runs-on: ubuntu-slim
     steps:
     - id: mint
@@ -42,15 +77,17 @@ jobs:
         owner: ${{ github.repository_owner }}
     - uses: actions/checkout@v6
       with:
-        ref: ${{ github.event.workflow_run.head_sha }}
+        ref: ${{ needs.context.outputs.head-sha }}
         token: ${{ steps.mint.outputs.token }}
     - uses: ecmwf/ci-infrastructure/actions/validate-generated-workflows@main
       with:
         token: ${{ steps.mint.outputs.token }}
     needs:
+    - ci-approval
+    - context
     - label-gate
   report-start:
-    if: ${{ (github.event.workflow_run.conclusion == 'success') && needs['label-gate'].outputs.run == 'true' }}
+    if: ${{ (needs.context.outputs.ci-conclusion == 'success') && needs['label-gate'].outputs.run == 'true' }}
     runs-on: ubuntu-slim
     steps:
     - id: mint
@@ -64,15 +101,17 @@ jobs:
         GH_TOKEN: ${{ steps.mint.outputs.token }}
       run: |
         gh api -X POST \
-          "/repos/${{ github.repository }}/statuses/${{ github.event.workflow_run.head_sha }}" \
+          "/repos/${{ github.repository }}/statuses/${{ needs.context.outputs.head-sha }}" \
           -f state=pending \
           -f context='downstream/hpc' \
           -f target_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
           -f description='Downstream HPC tests running'
     needs:
+    - ci-approval
+    - context
     - label-gate
   report-ci-failure:
-    if: ${{ (github.event.workflow_run.conclusion != 'success') && needs['label-gate'].outputs.run == 'true' }}
+    if: ${{ (needs.context.outputs.ci-conclusion != 'success') && needs['label-gate'].outputs.run == 'true' }}
     runs-on: ubuntu-slim
     steps:
     - id: mint
@@ -86,33 +125,39 @@ jobs:
         GH_TOKEN: ${{ steps.mint.outputs.token }}
       run: |
         gh api -X POST \
-          "/repos/${{ github.repository }}/statuses/${{ github.event.workflow_run.head_sha }}" \
+          "/repos/${{ github.repository }}/statuses/${{ needs.context.outputs.head-sha }}" \
           -f state=failure \
           -f context='downstream/hpc' \
-          -f target_url="${{ github.event.workflow_run.html_url }}" \
-          -f description='Upstream CI failed; downstream HPC not run'
+          -f target_url="${{ needs.context.outputs.ci-url }}" \
+          -f description="${{ needs.context.outputs.ci-summary }}; downstream HPC not run"
     needs:
+    - ci-approval
+    - context
     - label-gate
   eccodes:
     name: eccodes
     needs:
+    - ci-approval
+    - context
     - label-gate
     - validate
     uses: ecmwf/eccodes/.github/workflows/cross-repo-trigger-hpc.yml@develop
     with:
       from-repo: ${{ github.repository }}
-      from-sha: ${{ github.event.workflow_run.head_sha }}
+      from-sha: ${{ needs.context.outputs.head-sha }}
       from-jobs: '["eckit/build-hpc"]'
-      branch: ${{ github.event.workflow_run.head_branch }}
+      branch: ${{ needs.context.outputs.head-branch }}
       fallback-ref: develop
     secrets: inherit
     if: ${{ needs['label-gate'].outputs.run == 'true' }}
   report-result:
     needs:
+    - ci-approval
+    - context
     - label-gate
     - validate
     - eccodes
-    if: ${{ (always() && github.event.workflow_run.conclusion == 'success') && needs['label-gate'].outputs.run == 'true' }}
+    if: ${{ (always() && needs.context.outputs.ci-conclusion == 'success') && needs['label-gate'].outputs.run == 'true' }}
     runs-on: ubuntu-slim
     steps:
     - id: mint
@@ -132,7 +177,7 @@ jobs:
           fi
         done
         gh api -X POST \
-          "/repos/${{ github.repository }}/statuses/${{ github.event.workflow_run.head_sha }}" \
+          "/repos/${{ github.repository }}/statuses/${{ needs.context.outputs.head-sha }}" \
           -f state="$state" \
           -f context='downstream/hpc' \
           -f target_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \

--- a/.github/workflows/trigger-downstream.yml
+++ b/.github/workflows/trigger-downstream.yml
@@ -8,10 +8,42 @@ on:
     - CI
     types:
     - completed
+  pull_request_target:
+    types:
+    - labeled
 concurrency:
-  group: trigger-downstream-runner-${{ github.event.workflow_run.head_sha }}
+  group: trigger-downstream-runner-${{ github.event.workflow_run.head_sha || github.event.pull_request.head.sha }}
   cancel-in-progress: true
 jobs:
+  ci-approval:
+    if: ${{ github.event_name != 'pull_request_target' || github.event.label.name == 'run-downstream-CI' }}
+    runs-on: ubuntu-slim
+    permissions:
+      pull-requests: write
+    steps:
+    - uses: ecmwf/ci-infrastructure/actions/require-ci-approval@main
+  context:
+    needs:
+    - ci-approval
+    runs-on: ubuntu-slim
+    outputs:
+      head-sha: ${{ steps.ctx.outputs.head-sha }}
+      head-branch: ${{ steps.ctx.outputs.head-branch }}
+      ci-conclusion: ${{ steps.ctx.outputs.ci-conclusion }}
+      ci-url: ${{ steps.ctx.outputs.ci-url }}
+      ci-summary: ${{ steps.ctx.outputs.ci-summary }}
+    steps:
+    - id: mint
+      uses: actions/create-github-app-token@v3
+      with:
+        client-id: ${{ secrets.CI_PERMISSIONS_APP_CLIENT_ID }}
+        private-key: ${{ secrets.CI_PERMISSIONS_APP_PRIVATE_KEY }}
+        owner: ${{ github.repository_owner }}
+    - name: Resolve the commit under test
+      id: ctx
+      uses: ecmwf/ci-infrastructure/actions/resolve-dispatch-context@main
+      with:
+        token: ${{ steps.mint.outputs.token }}
   label-gate:
     runs-on: ubuntu-slim
     outputs:
@@ -28,10 +60,13 @@ jobs:
       uses: ecmwf/ci-infrastructure/actions/check-pr-label@main
       with:
         label: run-downstream-CI
-        sha: ${{ github.event.workflow_run.head_sha }}
+        sha: ${{ needs.context.outputs.head-sha }}
         token: ${{ steps.mint.outputs.token }}
+    needs:
+    - ci-approval
+    - context
   validate:
-    if: ${{ (github.event.workflow_run.conclusion == 'success') && needs['label-gate'].outputs.run == 'true' }}
+    if: ${{ (needs.context.outputs.ci-conclusion == 'success') && needs['label-gate'].outputs.run == 'true' }}
     runs-on: ubuntu-slim
     steps:
     - id: mint
@@ -42,15 +77,17 @@ jobs:
         owner: ${{ github.repository_owner }}
     - uses: actions/checkout@v6
       with:
-        ref: ${{ github.event.workflow_run.head_sha }}
+        ref: ${{ needs.context.outputs.head-sha }}
         token: ${{ steps.mint.outputs.token }}
     - uses: ecmwf/ci-infrastructure/actions/validate-generated-workflows@main
       with:
         token: ${{ steps.mint.outputs.token }}
     needs:
+    - ci-approval
+    - context
     - label-gate
   report-start:
-    if: ${{ (github.event.workflow_run.conclusion == 'success') && needs['label-gate'].outputs.run == 'true' }}
+    if: ${{ (needs.context.outputs.ci-conclusion == 'success') && needs['label-gate'].outputs.run == 'true' }}
     runs-on: ubuntu-slim
     steps:
     - id: mint
@@ -64,15 +101,17 @@ jobs:
         GH_TOKEN: ${{ steps.mint.outputs.token }}
       run: |
         gh api -X POST \
-          "/repos/${{ github.repository }}/statuses/${{ github.event.workflow_run.head_sha }}" \
+          "/repos/${{ github.repository }}/statuses/${{ needs.context.outputs.head-sha }}" \
           -f state=pending \
           -f context='downstream/runner' \
           -f target_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
           -f description='Downstream runner tests running'
     needs:
+    - ci-approval
+    - context
     - label-gate
   report-ci-failure:
-    if: ${{ (github.event.workflow_run.conclusion != 'success') && needs['label-gate'].outputs.run == 'true' }}
+    if: ${{ (needs.context.outputs.ci-conclusion != 'success') && needs['label-gate'].outputs.run == 'true' }}
     runs-on: ubuntu-slim
     steps:
     - id: mint
@@ -86,33 +125,39 @@ jobs:
         GH_TOKEN: ${{ steps.mint.outputs.token }}
       run: |
         gh api -X POST \
-          "/repos/${{ github.repository }}/statuses/${{ github.event.workflow_run.head_sha }}" \
+          "/repos/${{ github.repository }}/statuses/${{ needs.context.outputs.head-sha }}" \
           -f state=failure \
           -f context='downstream/runner' \
-          -f target_url="${{ github.event.workflow_run.html_url }}" \
-          -f description='Upstream CI failed; downstream runner not run'
+          -f target_url="${{ needs.context.outputs.ci-url }}" \
+          -f description="${{ needs.context.outputs.ci-summary }}; downstream runner not run"
     needs:
+    - ci-approval
+    - context
     - label-gate
   eccodes:
     name: eccodes
     needs:
+    - ci-approval
+    - context
     - label-gate
     - validate
     uses: ecmwf/eccodes/.github/workflows/cross-repo-trigger.yml@develop
     with:
       from-repo: ${{ github.repository }}
-      from-sha: ${{ github.event.workflow_run.head_sha }}
+      from-sha: ${{ needs.context.outputs.head-sha }}
       from-jobs: '["eckit/build"]'
-      branch: ${{ github.event.workflow_run.head_branch }}
+      branch: ${{ needs.context.outputs.head-branch }}
       fallback-ref: develop
     secrets: inherit
     if: ${{ needs['label-gate'].outputs.run == 'true' }}
   report-result:
     needs:
+    - ci-approval
+    - context
     - label-gate
     - validate
     - eccodes
-    if: ${{ (always() && github.event.workflow_run.conclusion == 'success') && needs['label-gate'].outputs.run == 'true' }}
+    if: ${{ (always() && needs.context.outputs.ci-conclusion == 'success') && needs['label-gate'].outputs.run == 'true' }}
     runs-on: ubuntu-slim
     steps:
     - id: mint
@@ -132,7 +177,7 @@ jobs:
           fi
         done
         gh api -X POST \
-          "/repos/${{ github.repository }}/statuses/${{ github.event.workflow_run.head_sha }}" \
+          "/repos/${{ github.repository }}/statuses/${{ needs.context.outputs.head-sha }}" \
           -f state="$state" \
           -f context='downstream/runner' \
           -f target_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \


### PR DESCRIPTION
### Why

Improve the job name printing in the CI.

The hand-written `ci.yml` and the generated `cross-repo-trigger*.yml` had drifted:
`build-hpc` showed no toolchain at all in `ci.yml` while the generated lane
appended it, and `ci.yml` wrote `${{ matrix.cxx-compiler }}` where the generated
lane wrote `${{ matrix['cxx-compiler'] }}`.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.