### PR TITLE
regenerate CI workflows for the single-use approval label

### DIFF
--- a/.github/ci-approval-allowlist.yml
+++ b/.github/ci-approval-allowlist.yml
@@ -1,0 +1,8 @@
+---
+exempt:
+  - workflow: contributor-declaration.yml
+  - workflow: label-public-pr.yml
+  - workflow: notify-pull-request.yml
+  - workflow: pr-label-downstream-ci.yml
+  - workflow: old_CI.yml
+    reason: "legacy, retiring; gates downstream-ci with an if: rather than needs:"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [develop, master]
   pull_request:
-    types: [opened, reopened, synchronize, labeled, unlabeled]
+    types: [opened, reopened, synchronize, labeled]
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/contributor-declaration.yml
+++ b/.github/workflows/contributor-declaration.yml
@@ -1,11 +1,15 @@
 name: Contributor Declaration
 
 on:
-  # pull_request_target runs the BASE branch's copy of this file, so a pull
-  # request cannot edit the gate that judges it. Safe here because nothing from
-  # the pull request is ever checked out or executed and no write token is used.
-  pull_request_target:
-    types: [opened, edited, reopened, synchronize]
+  # Parked: run it by hand only, until the declaration check comes back. To
+  # restore, put back the trigger below -- pull_request_target runs the BASE
+  # branch's copy of this file, so a pull request cannot edit the gate that
+  # judges it, and it is safe here because nothing from the pull request is ever
+  # checked out or executed and no write token is used.
+  #
+  #  pull_request_target:
+  #    types: [opened, edited, reopened, synchronize]
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/trigger-downstream-hpc.yml
+++ b/.github/workflows/trigger-downstream-hpc.yml
@@ -8,24 +8,14 @@ on:
     - CI
     types:
     - completed
-  pull_request_target:
-    types:
-    - labeled
 concurrency:
-  group: trigger-downstream-hpc-${{ github.event.workflow_run.head_sha || github.event.pull_request.head.sha }}
+  group: trigger-downstream-hpc-${{ github.event.workflow_run.head_sha }}
   cancel-in-progress: true
 jobs:
-  ci-approval:
-    if: ${{ github.event_name != 'pull_request_target' || github.event.label.name == 'run-downstream-CI' }}
+  context:
     runs-on: ubuntu-slim
     permissions:
-      pull-requests: write
-    steps:
-    - uses: ecmwf/ci-infrastructure/actions/require-ci-approval@main
-  context:
-    needs:
-    - ci-approval
-    runs-on: ubuntu-slim
+      actions: read
     outputs:
       head-sha: ${{ steps.ctx.outputs.head-sha }}
       head-branch: ${{ steps.ctx.outputs.head-branch }}
@@ -33,37 +23,23 @@ jobs:
       ci-url: ${{ steps.ctx.outputs.ci-url }}
       ci-summary: ${{ steps.ctx.outputs.ci-summary }}
     steps:
-    - id: mint
-      uses: actions/create-github-app-token@v3
-      with:
-        client-id: ${{ secrets.CI_PERMISSIONS_APP_CLIENT_ID }}
-        private-key: ${{ secrets.CI_PERMISSIONS_APP_PRIVATE_KEY }}
-        owner: ${{ github.repository_owner }}
     - name: Resolve the commit under test
       id: ctx
       uses: ecmwf/ci-infrastructure/actions/resolve-dispatch-context@main
-      with:
-        token: ${{ steps.mint.outputs.token }}
   label-gate:
     runs-on: ubuntu-slim
+    permissions:
+      pull-requests: read
     outputs:
       run: ${{ steps.gate.outputs.run }}
     steps:
-    - id: mint
-      uses: actions/create-github-app-token@v3
-      with:
-        client-id: ${{ secrets.CI_PERMISSIONS_APP_CLIENT_ID }}
-        private-key: ${{ secrets.CI_PERMISSIONS_APP_PRIVATE_KEY }}
-        owner: ${{ github.repository_owner }}
     - name: Check the downstream-CI label
       id: gate
       uses: ecmwf/ci-infrastructure/actions/check-pr-label@main
       with:
         label: run-downstream-CI
         sha: ${{ needs.context.outputs.head-sha }}
-        token: ${{ steps.mint.outputs.token }}
     needs:
-    - ci-approval
     - context
   validate:
     if: ${{ (needs.context.outputs.ci-conclusion == 'success') && needs['label-gate'].outputs.run == 'true' }}
@@ -83,22 +59,17 @@ jobs:
       with:
         token: ${{ steps.mint.outputs.token }}
     needs:
-    - ci-approval
     - context
     - label-gate
   report-start:
     if: ${{ (needs.context.outputs.ci-conclusion == 'success') && needs['label-gate'].outputs.run == 'true' }}
     runs-on: ubuntu-slim
+    permissions:
+      statuses: write
     steps:
-    - id: mint
-      uses: actions/create-github-app-token@v3
-      with:
-        client-id: ${{ secrets.CI_PERMISSIONS_APP_CLIENT_ID }}
-        private-key: ${{ secrets.CI_PERMISSIONS_APP_PRIVATE_KEY }}
-        owner: ${{ github.repository_owner }}
     - name: Post pending downstream status
       env:
-        GH_TOKEN: ${{ steps.mint.outputs.token }}
+        GH_TOKEN: ${{ github.token }}
       run: |
         gh api -X POST \
           "/repos/${{ github.repository }}/statuses/${{ needs.context.outputs.head-sha }}" \
@@ -107,22 +78,17 @@ jobs:
           -f target_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
           -f description='Downstream HPC tests running'
     needs:
-    - ci-approval
     - context
     - label-gate
   report-ci-failure:
     if: ${{ (needs.context.outputs.ci-conclusion != 'success') && needs['label-gate'].outputs.run == 'true' }}
     runs-on: ubuntu-slim
+    permissions:
+      statuses: write
     steps:
-    - id: mint
-      uses: actions/create-github-app-token@v3
-      with:
-        client-id: ${{ secrets.CI_PERMISSIONS_APP_CLIENT_ID }}
-        private-key: ${{ secrets.CI_PERMISSIONS_APP_PRIVATE_KEY }}
-        owner: ${{ github.repository_owner }}
     - name: Post downstream failure status
       env:
-        GH_TOKEN: ${{ steps.mint.outputs.token }}
+        GH_TOKEN: ${{ github.token }}
       run: |
         gh api -X POST \
           "/repos/${{ github.repository }}/statuses/${{ needs.context.outputs.head-sha }}" \
@@ -131,13 +97,11 @@ jobs:
           -f target_url="${{ needs.context.outputs.ci-url }}" \
           -f description="${{ needs.context.outputs.ci-summary }}; downstream HPC not run"
     needs:
-    - ci-approval
     - context
     - label-gate
   eccodes:
     name: eccodes
     needs:
-    - ci-approval
     - context
     - label-gate
     - validate
@@ -152,23 +116,18 @@ jobs:
     if: ${{ needs['label-gate'].outputs.run == 'true' }}
   report-result:
     needs:
-    - ci-approval
     - context
     - label-gate
     - validate
     - eccodes
     if: ${{ (always() && needs.context.outputs.ci-conclusion == 'success') && needs['label-gate'].outputs.run == 'true' }}
     runs-on: ubuntu-slim
+    permissions:
+      statuses: write
     steps:
-    - id: mint
-      uses: actions/create-github-app-token@v3
-      with:
-        client-id: ${{ secrets.CI_PERMISSIONS_APP_CLIENT_ID }}
-        private-key: ${{ secrets.CI_PERMISSIONS_APP_PRIVATE_KEY }}
-        owner: ${{ github.repository_owner }}
     - name: Post final downstream status
       env:
-        GH_TOKEN: ${{ steps.mint.outputs.token }}
+        GH_TOKEN: ${{ github.token }}
       run: |
         state=success
         for r in ${{ needs.validate.result }} ${{ needs.eccodes.result }}; do

--- a/.github/workflows/trigger-downstream.yml
+++ b/.github/workflows/trigger-downstream.yml
@@ -8,24 +8,14 @@ on:
     - CI
     types:
     - completed
-  pull_request_target:
-    types:
-    - labeled
 concurrency:
-  group: trigger-downstream-runner-${{ github.event.workflow_run.head_sha || github.event.pull_request.head.sha }}
+  group: trigger-downstream-runner-${{ github.event.workflow_run.head_sha }}
   cancel-in-progress: true
 jobs:
-  ci-approval:
-    if: ${{ github.event_name != 'pull_request_target' || github.event.label.name == 'run-downstream-CI' }}
+  context:
     runs-on: ubuntu-slim
     permissions:
-      pull-requests: write
-    steps:
-    - uses: ecmwf/ci-infrastructure/actions/require-ci-approval@main
-  context:
-    needs:
-    - ci-approval
-    runs-on: ubuntu-slim
+      actions: read
     outputs:
       head-sha: ${{ steps.ctx.outputs.head-sha }}
       head-branch: ${{ steps.ctx.outputs.head-branch }}
@@ -33,37 +23,23 @@ jobs:
       ci-url: ${{ steps.ctx.outputs.ci-url }}
       ci-summary: ${{ steps.ctx.outputs.ci-summary }}
     steps:
-    - id: mint
-      uses: actions/create-github-app-token@v3
-      with:
-        client-id: ${{ secrets.CI_PERMISSIONS_APP_CLIENT_ID }}
-        private-key: ${{ secrets.CI_PERMISSIONS_APP_PRIVATE_KEY }}
-        owner: ${{ github.repository_owner }}
     - name: Resolve the commit under test
       id: ctx
       uses: ecmwf/ci-infrastructure/actions/resolve-dispatch-context@main
-      with:
-        token: ${{ steps.mint.outputs.token }}
   label-gate:
     runs-on: ubuntu-slim
+    permissions:
+      pull-requests: read
     outputs:
       run: ${{ steps.gate.outputs.run }}
     steps:
-    - id: mint
-      uses: actions/create-github-app-token@v3
-      with:
-        client-id: ${{ secrets.CI_PERMISSIONS_APP_CLIENT_ID }}
-        private-key: ${{ secrets.CI_PERMISSIONS_APP_PRIVATE_KEY }}
-        owner: ${{ github.repository_owner }}
     - name: Check the downstream-CI label
       id: gate
       uses: ecmwf/ci-infrastructure/actions/check-pr-label@main
       with:
         label: run-downstream-CI
         sha: ${{ needs.context.outputs.head-sha }}
-        token: ${{ steps.mint.outputs.token }}
     needs:
-    - ci-approval
     - context
   validate:
     if: ${{ (needs.context.outputs.ci-conclusion == 'success') && needs['label-gate'].outputs.run == 'true' }}
@@ -83,22 +59,17 @@ jobs:
       with:
         token: ${{ steps.mint.outputs.token }}
     needs:
-    - ci-approval
     - context
     - label-gate
   report-start:
     if: ${{ (needs.context.outputs.ci-conclusion == 'success') && needs['label-gate'].outputs.run == 'true' }}
     runs-on: ubuntu-slim
+    permissions:
+      statuses: write
     steps:
-    - id: mint
-      uses: actions/create-github-app-token@v3
-      with:
-        client-id: ${{ secrets.CI_PERMISSIONS_APP_CLIENT_ID }}
-        private-key: ${{ secrets.CI_PERMISSIONS_APP_PRIVATE_KEY }}
-        owner: ${{ github.repository_owner }}
     - name: Post pending downstream status
       env:
-        GH_TOKEN: ${{ steps.mint.outputs.token }}
+        GH_TOKEN: ${{ github.token }}
       run: |
         gh api -X POST \
           "/repos/${{ github.repository }}/statuses/${{ needs.context.outputs.head-sha }}" \
@@ -107,22 +78,17 @@ jobs:
           -f target_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
           -f description='Downstream runner tests running'
     needs:
-    - ci-approval
     - context
     - label-gate
   report-ci-failure:
     if: ${{ (needs.context.outputs.ci-conclusion != 'success') && needs['label-gate'].outputs.run == 'true' }}
     runs-on: ubuntu-slim
+    permissions:
+      statuses: write
     steps:
-    - id: mint
-      uses: actions/create-github-app-token@v3
-      with:
-        client-id: ${{ secrets.CI_PERMISSIONS_APP_CLIENT_ID }}
-        private-key: ${{ secrets.CI_PERMISSIONS_APP_PRIVATE_KEY }}
-        owner: ${{ github.repository_owner }}
     - name: Post downstream failure status
       env:
-        GH_TOKEN: ${{ steps.mint.outputs.token }}
+        GH_TOKEN: ${{ github.token }}
       run: |
         gh api -X POST \
           "/repos/${{ github.repository }}/statuses/${{ needs.context.outputs.head-sha }}" \
@@ -131,13 +97,11 @@ jobs:
           -f target_url="${{ needs.context.outputs.ci-url }}" \
           -f description="${{ needs.context.outputs.ci-summary }}; downstream runner not run"
     needs:
-    - ci-approval
     - context
     - label-gate
   eccodes:
     name: eccodes
     needs:
-    - ci-approval
     - context
     - label-gate
     - validate
@@ -152,23 +116,18 @@ jobs:
     if: ${{ needs['label-gate'].outputs.run == 'true' }}
   report-result:
     needs:
-    - ci-approval
     - context
     - label-gate
     - validate
     - eccodes
     if: ${{ (always() && needs.context.outputs.ci-conclusion == 'success') && needs['label-gate'].outputs.run == 'true' }}
     runs-on: ubuntu-slim
+    permissions:
+      statuses: write
     steps:
-    - id: mint
-      uses: actions/create-github-app-token@v3
-      with:
-        client-id: ${{ secrets.CI_PERMISSIONS_APP_CLIENT_ID }}
-        private-key: ${{ secrets.CI_PERMISSIONS_APP_PRIVATE_KEY }}
-        owner: ${{ github.repository_owner }}
     - name: Post final downstream status
       env:
-        GH_TOKEN: ${{ steps.mint.outputs.token }}
+        GH_TOKEN: ${{ github.token }}
       run: |
         state=success
         for r in ${{ needs.validate.result }} ${{ needs.eccodes.result }}; do

--- a/python/eckit/src/_eckit/eckit_geo.pxd
+++ b/python/eckit/src/_eckit/eckit_geo.pxd
@@ -21,18 +21,18 @@ cdef extern from "eckit/geo/LibEcKitGeo.h" namespace "eckit":
         LibEcKitGeo& instance()
 
         @staticmethod
-        void purgeCacheDir()
+        void purgeCacheDir() except +
 
         @staticmethod
-        bool projdb_is_available()
+        bool projdb_is_available() except +
 
         @staticmethod
         void projdb_set_search_paths(
             const string& db_path, const vector[string]& search_paths
-        )
+        ) except +
 
-        string version()
-        string gitsha1(unsigned int n)  # n=40 for full sha1
+        string version() except +
+        string gitsha1(unsigned int n) except +  # n=40 for full sha1
 
 
 cdef extern from "eckit/geo/Area.h" namespace "eckit::geo":

--- a/python/eckitlib/pre-compile.sh
+++ b/python/eckitlib/pre-compile.sh
@@ -22,6 +22,10 @@ source python/eckitlib/buildconfig
 mkdir -p python/eckitlib/src/copying
 mkdir -p /tmp/eckit/target/eckit/lib64/
 
+# TODO this PROJ_ROOT discovery is suboptimally hardcoded, leaving it prone
+# to break when there is a change in the docker image / macos build script.
+# It would be better to dynamically search for PROJ like cmake does, relying
+# on the cmake prefix path etc
 if [ "$(uname)" != "Darwin" ] ; then
     echo "no deps installation for platform $(uname)"
     # echo "installing deps for platform $(uname)"
@@ -32,7 +36,7 @@ if [ "$(uname)" != "Darwin" ] ; then
     PROJ_ROOT="${PROJ_ROOT:-/cxx-deps}"
 else
     echo "no deps installation for platform $(uname)"
-    PROJ_ROOT="${PROJ_ROOT:-/tmp/cxx-deps}"
+    PROJ_ROOT="${PROJ_ROOT:-/opt/ecmwf/stack-deps}"
 fi
 
 

--- a/src/eckit/geo/projection/PROJ.cc
+++ b/src/eckit/geo/projection/PROJ.cc
@@ -291,14 +291,11 @@ bool PROJ::projdb_is_available() {
         const PJ_LOG_LEVEL previous_;
     } mute_log;
 
-    try {
-        pj_t crs(proj_create_from_database(ctx(), "EPSG", "4326", PJ_CATEGORY_CRS, false, nullptr));
-        return static_cast<bool>(crs);
-    }
-    catch (...) {
-    }
+    // Note: not using pj_t, which throws on failure (failure is a possible outcome)
+    std::unique_ptr<pj_t::element_type, pj_t::deleter_type> crs(
+        proj_create_from_database(ctx(), "EPSG", "4326", PJ_CATEGORY_CRS, false, nullptr), &proj_destroy);
 
-    return false;
+    return static_cast<bool>(crs);
 }
 
 


### PR DESCRIPTION
### Description

Purely trigger the downstream CI from the CI itself. 
This means it's automatically gated behind the CI approval of the CI.

Get rid of the contributor declaration test.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.

<!-- PREVIEW-URL_BEGIN -->
🌦️ >> Documentation << 🌦️
https://sites.ecmwf.int/docs/dev-section/eckit/pull-requests/PR-338
<!-- PREVIEW-URL_END -->