### PR TITLE
Single-use CI approval label, and job names from _resolved

### DIFF
--- a/.github/ci-approval-allowlist.yml
+++ b/.github/ci-approval-allowlist.yml
@@ -1,0 +1,8 @@
+---
+exempt:
+  - workflow: contributor-declaration.yml
+  - workflow: label-public-pr.yml
+  - workflow: notify-pull-request.yml
+  - workflow: pr-label-downstream-ci.yml
+  - workflow: old_CI.yml
+    reason: "legacy, retiring; gates downstream-ci with an if: rather than needs:"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,16 +109,7 @@ jobs:
         if: always()
         uses: ecmwf/ci-infrastructure/actions/print-dep-table@main
         with:
-          deps-json: ${{ toJSON(matrix._resolved.deps) }}
-          own-name: eckit
-          own-sha: ${{ matrix._resolved.own-sha }}
-          own-ref: ${{ matrix._resolved.own-ref }}
-          own-artifact-name: ${{ matrix._resolved.own-artifact-name }}
-          own-platform: ${{ matrix._resolved.own-platform }}
-          own-compiler: ${{ matrix._resolved.own-compiler }}
-          own-python: ${{ matrix._resolved.own-python }}
-          own-build-type: ${{ matrix._resolved.own-build-type }}
-          own-deps-hash: ${{ matrix._resolved.own-deps-hash }}
+          resolved: ${{ toJSON(matrix._resolved) }}
 
   build-hpc:
     needs: [ci-approval, resolve]
@@ -154,6 +145,7 @@ jobs:
           install-python-deps: 'false'
 
       - name: Build eckit on HPC
+        id: build
         uses: ecmwf/ci-infrastructure/actions/build-on-hpc@main
         with:
           site: ${{ matrix.site }}
@@ -170,13 +162,5 @@ jobs:
         if: always()
         uses: ecmwf/ci-infrastructure/actions/print-dep-table@main
         with:
-          deps-json: ${{ toJSON(matrix._resolved.deps) }}
-          own-name: eckit
-          own-sha: ${{ matrix._resolved.own-sha }}
-          own-ref: ${{ matrix._resolved.own-ref }}
-          own-artifact-name: ${{ matrix._resolved.own-artifact-name }}
-          own-platform: ${{ matrix._resolved.own-platform }}
-          own-compiler: ${{ matrix._resolved.own-compiler }}
-          own-python: ${{ matrix._resolved.own-python }}
-          own-build-type: ${{ matrix._resolved.own-build-type }}
-          own-deps-hash: ${{ matrix._resolved.own-deps-hash }}
+          resolved: ${{ toJSON(matrix._resolved) }}
+          own-source: ${{ steps.build.outputs.cache-hit == 'true' && 'artifact' || 'built' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,9 +47,7 @@ jobs:
           client-id: ${{ secrets.CI_PERMISSIONS_APP_CLIENT_ID }}
           private-key: ${{ secrets.CI_PERMISSIONS_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
-      - uses: actions/checkout@v6
-        with:
-          ref: ${{ github.event.pull_request.number && format('refs/pull/{0}/merge', github.event.pull_request.number) || '' }}
+      - uses: ecmwf/ci-infrastructure/actions/checkout-under-test@main
       - id: r
         uses: ecmwf/ci-infrastructure/actions/resolve-deps@main
         with:
@@ -77,9 +75,7 @@ jobs:
           client-id: ${{ secrets.CI_PERMISSIONS_APP_CLIENT_ID }}
           private-key: ${{ secrets.CI_PERMISSIONS_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
-      - uses: actions/checkout@v6
-        with:
-          ref: ${{ github.event.pull_request.number && format('refs/pull/{0}/merge', github.event.pull_request.number) || '' }}
+      - uses: ecmwf/ci-infrastructure/actions/checkout-under-test@main
 
       - name: Fetch resolved deps
         id: deps
@@ -96,11 +92,6 @@ jobs:
           cxx-compiler: ${{ matrix.cxx-compiler }}
           build-type: ${{ matrix.build-type }}
 
-      - name: Print dependency table
-        uses: ecmwf/ci-infrastructure/actions/print-dep-table@main
-        with:
-          resolved-json: ${{ toJSON(matrix._resolved) }}
-
       # Invocation comes from .ci/manifest.toml's [matrix.build], the same place
       # the generated cross-repo-trigger.yml renders its Test step from. Spelling
       # it out again here is how the two lanes drift apart.
@@ -113,6 +104,21 @@ jobs:
         with:
           install-path: ${{ steps.build.outputs.install-path }}
           artifact-name: ${{ matrix._resolved.own-artifact-name }}
+
+      - name: Print dependency table
+        if: always()
+        uses: ecmwf/ci-infrastructure/actions/print-dep-table@main
+        with:
+          deps-json: ${{ toJSON(matrix._resolved.deps) }}
+          own-name: eckit
+          own-sha: ${{ matrix._resolved.own-sha }}
+          own-ref: ${{ matrix._resolved.own-ref }}
+          own-artifact-name: ${{ matrix._resolved.own-artifact-name }}
+          own-platform: ${{ matrix._resolved.own-platform }}
+          own-compiler: ${{ matrix._resolved.own-compiler }}
+          own-python: ${{ matrix._resolved.own-python }}
+          own-build-type: ${{ matrix._resolved.own-build-type }}
+          own-deps-hash: ${{ matrix._resolved.own-deps-hash }}
 
   build-hpc:
     needs: [ci-approval, resolve]
@@ -135,9 +141,7 @@ jobs:
           client-id: ${{ secrets.CI_PERMISSIONS_APP_CLIENT_ID }}
           private-key: ${{ secrets.CI_PERMISSIONS_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
-      - uses: actions/checkout@v6
-        with:
-          ref: ${{ github.event.pull_request.number && format('refs/pull/{0}/merge', github.event.pull_request.number) || '' }}
+      - uses: ecmwf/ci-infrastructure/actions/checkout-under-test@main
 
       - name: Fetch resolved deps
         id: deps
@@ -161,3 +165,18 @@ jobs:
           work-dir: ${{ vars.HPC_CI_WORK_DIR }}
           remote-work-dir: ${{ vars.HPC_CI_REMOTE_WORK_DIR }}
           troika-user: ${{ secrets.HPC_CI_SSH_USER }}
+
+      - name: Print dependency table
+        if: always()
+        uses: ecmwf/ci-infrastructure/actions/print-dep-table@main
+        with:
+          deps-json: ${{ toJSON(matrix._resolved.deps) }}
+          own-name: eckit
+          own-sha: ${{ matrix._resolved.own-sha }}
+          own-ref: ${{ matrix._resolved.own-ref }}
+          own-artifact-name: ${{ matrix._resolved.own-artifact-name }}
+          own-platform: ${{ matrix._resolved.own-platform }}
+          own-compiler: ${{ matrix._resolved.own-compiler }}
+          own-python: ${{ matrix._resolved.own-python }}
+          own-build-type: ${{ matrix._resolved.own-build-type }}
+          own-deps-hash: ${{ matrix._resolved.own-deps-hash }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [develop, master]
   pull_request:
-    types: [opened, reopened, synchronize, labeled, unlabeled]
+    types: [opened, reopened, synchronize, labeled]
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
 
   build:
     needs: [ci-approval, resolve]
-    name: build+test (${{ matrix.platform }}, ${{ matrix.cxx-compiler }})
+    name: build+test (${{ matrix._resolved['job-name'] }})
     runs-on: ${{ matrix['runs-on'] }}
     container:
       image: ${{ matrix.container || '' }}
@@ -116,7 +116,7 @@ jobs:
 
   build-hpc:
     needs: [ci-approval, resolve]
-    name: build-hpc (${{ matrix.platform }})
+    name: build-hpc (${{ matrix._resolved['job-name'] }})
     runs-on: ${{ matrix['runs-on'] }}
     container:
       image: ${{ matrix.container }}

--- a/.github/workflows/contributor-declaration.yml
+++ b/.github/workflows/contributor-declaration.yml
@@ -1,11 +1,15 @@
 name: Contributor Declaration
 
 on:
-  # pull_request_target runs the BASE branch's copy of this file, so a pull
-  # request cannot edit the gate that judges it. Safe here because nothing from
-  # the pull request is ever checked out or executed and no write token is used.
-  pull_request_target:
-    types: [opened, edited, reopened, synchronize]
+  # Parked: run it by hand only, until the declaration check comes back. To
+  # restore, put back the trigger below -- pull_request_target runs the BASE
+  # branch's copy of this file, so a pull request cannot edit the gate that
+  # judges it, and it is safe here because nothing from the pull request is ever
+  # checked out or executed and no write token is used.
+  #
+  #  pull_request_target:
+  #    types: [opened, edited, reopened, synchronize]
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/cross-repo-trigger-hpc.yml
+++ b/.github/workflows/cross-repo-trigger-hpc.yml
@@ -115,7 +115,7 @@ jobs:
     needs:
     - resolve
     if: contains(fromJSON(inputs.from-jobs), 'ecbuild/build-hpc') || contains(fromJSON(inputs.from-jobs), 'stack-deps/build-hpc') || inputs.rebuild-request
-    name: eckit/build-hpc (${{ matrix.platform }}, ${{ matrix['cxx-compiler'] }})
+    name: eckit/build-hpc (${{ matrix._resolved['job-name'] }})
     runs-on: ${{ matrix['runs-on'] }}
     container:
       image: ${{ matrix.container || '' }}
@@ -139,7 +139,7 @@ jobs:
         token: ${{ steps.mint.outputs.token }}
         head-repo: ${{ inputs.from-repo }}
         head-sha: ${{ inputs.from-sha }}
-        name: eckit/build-hpc (${{ matrix.platform }}, ${{ matrix['cxx-compiler'] }})
+        name: eckit/build-hpc (${{ matrix._resolved['job-name'] }})
         details-url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         phase: start
     - name: Announce image
@@ -203,7 +203,7 @@ jobs:
         token: ${{ steps.mint.outputs.token }}
         head-repo: ${{ inputs.from-repo }}
         head-sha: ${{ inputs.from-sha }}
-        name: eckit/build-hpc (${{ matrix.platform }}, ${{ matrix['cxx-compiler'] }})
+        name: eckit/build-hpc (${{ matrix._resolved['job-name'] }})
         details-url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         phase: finish
         conclusion: ${{ job.status }}

--- a/.github/workflows/cross-repo-trigger.yml
+++ b/.github/workflows/cross-repo-trigger.yml
@@ -115,7 +115,7 @@ jobs:
     needs:
     - resolve
     if: contains(fromJSON(inputs.from-jobs), 'ecbuild/build') || contains(fromJSON(inputs.from-jobs), 'stack-deps/build') || inputs.rebuild-request
-    name: eckit/build (${{ matrix.platform }}, ${{ matrix['cxx-compiler'] }})
+    name: eckit/build (${{ matrix._resolved['job-name'] }})
     runs-on: ${{ matrix['runs-on'] }}
     container:
       image: ${{ matrix.container || '' }}
@@ -136,7 +136,7 @@ jobs:
         token: ${{ steps.mint.outputs.token }}
         head-repo: ${{ inputs.from-repo }}
         head-sha: ${{ inputs.from-sha }}
-        name: eckit/build (${{ matrix.platform }}, ${{ matrix['cxx-compiler'] }})
+        name: eckit/build (${{ matrix._resolved['job-name'] }})
         details-url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         phase: start
     - name: Announce image
@@ -205,7 +205,7 @@ jobs:
         token: ${{ steps.mint.outputs.token }}
         head-repo: ${{ inputs.from-repo }}
         head-sha: ${{ inputs.from-sha }}
-        name: eckit/build (${{ matrix.platform }}, ${{ matrix['cxx-compiler'] }})
+        name: eckit/build (${{ matrix._resolved['job-name'] }})
         details-url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         phase: finish
         conclusion: ${{ job.status }}

--- a/.github/workflows/trigger-downstream-hpc.yml
+++ b/.github/workflows/trigger-downstream-hpc.yml
@@ -8,24 +8,14 @@ on:
     - CI
     types:
     - completed
-  pull_request_target:
-    types:
-    - labeled
 concurrency:
-  group: trigger-downstream-hpc-${{ github.event.workflow_run.head_sha || github.event.pull_request.head.sha }}
+  group: trigger-downstream-hpc-${{ github.event.workflow_run.head_sha }}
   cancel-in-progress: true
 jobs:
-  ci-approval:
-    if: ${{ github.event_name != 'pull_request_target' || github.event.label.name == 'run-downstream-CI' }}
+  context:
     runs-on: ubuntu-slim
     permissions:
-      pull-requests: write
-    steps:
-    - uses: ecmwf/ci-infrastructure/actions/require-ci-approval@main
-  context:
-    needs:
-    - ci-approval
-    runs-on: ubuntu-slim
+      actions: read
     outputs:
       head-sha: ${{ steps.ctx.outputs.head-sha }}
       head-branch: ${{ steps.ctx.outputs.head-branch }}
@@ -33,37 +23,23 @@ jobs:
       ci-url: ${{ steps.ctx.outputs.ci-url }}
       ci-summary: ${{ steps.ctx.outputs.ci-summary }}
     steps:
-    - id: mint
-      uses: actions/create-github-app-token@v3
-      with:
-        client-id: ${{ secrets.CI_PERMISSIONS_APP_CLIENT_ID }}
-        private-key: ${{ secrets.CI_PERMISSIONS_APP_PRIVATE_KEY }}
-        owner: ${{ github.repository_owner }}
     - name: Resolve the commit under test
       id: ctx
       uses: ecmwf/ci-infrastructure/actions/resolve-dispatch-context@main
-      with:
-        token: ${{ steps.mint.outputs.token }}
   label-gate:
     runs-on: ubuntu-slim
+    permissions:
+      pull-requests: read
     outputs:
       run: ${{ steps.gate.outputs.run }}
     steps:
-    - id: mint
-      uses: actions/create-github-app-token@v3
-      with:
-        client-id: ${{ secrets.CI_PERMISSIONS_APP_CLIENT_ID }}
-        private-key: ${{ secrets.CI_PERMISSIONS_APP_PRIVATE_KEY }}
-        owner: ${{ github.repository_owner }}
     - name: Check the downstream-CI label
       id: gate
       uses: ecmwf/ci-infrastructure/actions/check-pr-label@main
       with:
         label: run-downstream-CI
         sha: ${{ needs.context.outputs.head-sha }}
-        token: ${{ steps.mint.outputs.token }}
     needs:
-    - ci-approval
     - context
   validate:
     if: ${{ (needs.context.outputs.ci-conclusion == 'success') && needs['label-gate'].outputs.run == 'true' }}
@@ -83,22 +59,17 @@ jobs:
       with:
         token: ${{ steps.mint.outputs.token }}
     needs:
-    - ci-approval
     - context
     - label-gate
   report-start:
     if: ${{ (needs.context.outputs.ci-conclusion == 'success') && needs['label-gate'].outputs.run == 'true' }}
     runs-on: ubuntu-slim
+    permissions:
+      statuses: write
     steps:
-    - id: mint
-      uses: actions/create-github-app-token@v3
-      with:
-        client-id: ${{ secrets.CI_PERMISSIONS_APP_CLIENT_ID }}
-        private-key: ${{ secrets.CI_PERMISSIONS_APP_PRIVATE_KEY }}
-        owner: ${{ github.repository_owner }}
     - name: Post pending downstream status
       env:
-        GH_TOKEN: ${{ steps.mint.outputs.token }}
+        GH_TOKEN: ${{ github.token }}
       run: |
         gh api -X POST \
           "/repos/${{ github.repository }}/statuses/${{ needs.context.outputs.head-sha }}" \
@@ -107,22 +78,17 @@ jobs:
           -f target_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
           -f description='Downstream HPC tests running'
     needs:
-    - ci-approval
     - context
     - label-gate
   report-ci-failure:
     if: ${{ (needs.context.outputs.ci-conclusion != 'success') && needs['label-gate'].outputs.run == 'true' }}
     runs-on: ubuntu-slim
+    permissions:
+      statuses: write
     steps:
-    - id: mint
-      uses: actions/create-github-app-token@v3
-      with:
-        client-id: ${{ secrets.CI_PERMISSIONS_APP_CLIENT_ID }}
-        private-key: ${{ secrets.CI_PERMISSIONS_APP_PRIVATE_KEY }}
-        owner: ${{ github.repository_owner }}
     - name: Post downstream failure status
       env:
-        GH_TOKEN: ${{ steps.mint.outputs.token }}
+        GH_TOKEN: ${{ github.token }}
       run: |
         gh api -X POST \
           "/repos/${{ github.repository }}/statuses/${{ needs.context.outputs.head-sha }}" \
@@ -131,13 +97,11 @@ jobs:
           -f target_url="${{ needs.context.outputs.ci-url }}" \
           -f description="${{ needs.context.outputs.ci-summary }}; downstream HPC not run"
     needs:
-    - ci-approval
     - context
     - label-gate
   eccodes:
     name: eccodes
     needs:
-    - ci-approval
     - context
     - label-gate
     - validate
@@ -152,23 +116,18 @@ jobs:
     if: ${{ needs['label-gate'].outputs.run == 'true' }}
   report-result:
     needs:
-    - ci-approval
     - context
     - label-gate
     - validate
     - eccodes
     if: ${{ (always() && needs.context.outputs.ci-conclusion == 'success') && needs['label-gate'].outputs.run == 'true' }}
     runs-on: ubuntu-slim
+    permissions:
+      statuses: write
     steps:
-    - id: mint
-      uses: actions/create-github-app-token@v3
-      with:
-        client-id: ${{ secrets.CI_PERMISSIONS_APP_CLIENT_ID }}
-        private-key: ${{ secrets.CI_PERMISSIONS_APP_PRIVATE_KEY }}
-        owner: ${{ github.repository_owner }}
     - name: Post final downstream status
       env:
-        GH_TOKEN: ${{ steps.mint.outputs.token }}
+        GH_TOKEN: ${{ github.token }}
       run: |
         state=success
         for r in ${{ needs.validate.result }} ${{ needs.eccodes.result }}; do

--- a/.github/workflows/trigger-downstream-hpc.yml
+++ b/.github/workflows/trigger-downstream-hpc.yml
@@ -55,6 +55,7 @@ jobs:
       with:
         ref: ${{ needs.context.outputs.head-sha }}
         token: ${{ steps.mint.outputs.token }}
+        allow-unsafe-pr-checkout: true
     - uses: ecmwf/ci-infrastructure/actions/validate-generated-workflows@main
       with:
         token: ${{ steps.mint.outputs.token }}

--- a/.github/workflows/trigger-downstream-hpc.yml
+++ b/.github/workflows/trigger-downstream-hpc.yml
@@ -8,10 +8,42 @@ on:
     - CI
     types:
     - completed
+  pull_request_target:
+    types:
+    - labeled
 concurrency:
-  group: trigger-downstream-hpc-${{ github.event.workflow_run.head_sha }}
+  group: trigger-downstream-hpc-${{ github.event.workflow_run.head_sha || github.event.pull_request.head.sha }}
   cancel-in-progress: true
 jobs:
+  ci-approval:
+    if: ${{ github.event_name != 'pull_request_target' || github.event.label.name == 'run-downstream-CI' }}
+    runs-on: ubuntu-slim
+    permissions:
+      pull-requests: write
+    steps:
+    - uses: ecmwf/ci-infrastructure/actions/require-ci-approval@main
+  context:
+    needs:
+    - ci-approval
+    runs-on: ubuntu-slim
+    outputs:
+      head-sha: ${{ steps.ctx.outputs.head-sha }}
+      head-branch: ${{ steps.ctx.outputs.head-branch }}
+      ci-conclusion: ${{ steps.ctx.outputs.ci-conclusion }}
+      ci-url: ${{ steps.ctx.outputs.ci-url }}
+      ci-summary: ${{ steps.ctx.outputs.ci-summary }}
+    steps:
+    - id: mint
+      uses: actions/create-github-app-token@v3
+      with:
+        client-id: ${{ secrets.CI_PERMISSIONS_APP_CLIENT_ID }}
+        private-key: ${{ secrets.CI_PERMISSIONS_APP_PRIVATE_KEY }}
+        owner: ${{ github.repository_owner }}
+    - name: Resolve the commit under test
+      id: ctx
+      uses: ecmwf/ci-infrastructure/actions/resolve-dispatch-context@main
+      with:
+        token: ${{ steps.mint.outputs.token }}
   label-gate:
     runs-on: ubuntu-slim
     outputs:
@@ -28,10 +60,13 @@ jobs:
       uses: ecmwf/ci-infrastructure/actions/check-pr-label@main
       with:
         label: run-downstream-CI
-        sha: ${{ github.event.workflow_run.head_sha }}
+        sha: ${{ needs.context.outputs.head-sha }}
         token: ${{ steps.mint.outputs.token }}
+    needs:
+    - ci-approval
+    - context
   validate:
-    if: ${{ (github.event.workflow_run.conclusion == 'success') && needs['label-gate'].outputs.run == 'true' }}
+    if: ${{ (needs.context.outputs.ci-conclusion == 'success') && needs['label-gate'].outputs.run == 'true' }}
     runs-on: ubuntu-slim
     steps:
     - id: mint
@@ -42,15 +77,17 @@ jobs:
         owner: ${{ github.repository_owner }}
     - uses: actions/checkout@v6
       with:
-        ref: ${{ github.event.workflow_run.head_sha }}
+        ref: ${{ needs.context.outputs.head-sha }}
         token: ${{ steps.mint.outputs.token }}
     - uses: ecmwf/ci-infrastructure/actions/validate-generated-workflows@main
       with:
         token: ${{ steps.mint.outputs.token }}
     needs:
+    - ci-approval
+    - context
     - label-gate
   report-start:
-    if: ${{ (github.event.workflow_run.conclusion == 'success') && needs['label-gate'].outputs.run == 'true' }}
+    if: ${{ (needs.context.outputs.ci-conclusion == 'success') && needs['label-gate'].outputs.run == 'true' }}
     runs-on: ubuntu-slim
     steps:
     - id: mint
@@ -64,15 +101,17 @@ jobs:
         GH_TOKEN: ${{ steps.mint.outputs.token }}
       run: |
         gh api -X POST \
-          "/repos/${{ github.repository }}/statuses/${{ github.event.workflow_run.head_sha }}" \
+          "/repos/${{ github.repository }}/statuses/${{ needs.context.outputs.head-sha }}" \
           -f state=pending \
           -f context='downstream/hpc' \
           -f target_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
           -f description='Downstream HPC tests running'
     needs:
+    - ci-approval
+    - context
     - label-gate
   report-ci-failure:
-    if: ${{ (github.event.workflow_run.conclusion != 'success') && needs['label-gate'].outputs.run == 'true' }}
+    if: ${{ (needs.context.outputs.ci-conclusion != 'success') && needs['label-gate'].outputs.run == 'true' }}
     runs-on: ubuntu-slim
     steps:
     - id: mint
@@ -86,33 +125,39 @@ jobs:
         GH_TOKEN: ${{ steps.mint.outputs.token }}
       run: |
         gh api -X POST \
-          "/repos/${{ github.repository }}/statuses/${{ github.event.workflow_run.head_sha }}" \
+          "/repos/${{ github.repository }}/statuses/${{ needs.context.outputs.head-sha }}" \
           -f state=failure \
           -f context='downstream/hpc' \
-          -f target_url="${{ github.event.workflow_run.html_url }}" \
-          -f description='Upstream CI failed; downstream HPC not run'
+          -f target_url="${{ needs.context.outputs.ci-url }}" \
+          -f description="${{ needs.context.outputs.ci-summary }}; downstream HPC not run"
     needs:
+    - ci-approval
+    - context
     - label-gate
   eccodes:
     name: eccodes
     needs:
+    - ci-approval
+    - context
     - label-gate
     - validate
     uses: ecmwf/eccodes/.github/workflows/cross-repo-trigger-hpc.yml@develop
     with:
       from-repo: ${{ github.repository }}
-      from-sha: ${{ github.event.workflow_run.head_sha }}
+      from-sha: ${{ needs.context.outputs.head-sha }}
       from-jobs: '["eckit/build-hpc"]'
-      branch: ${{ github.event.workflow_run.head_branch }}
+      branch: ${{ needs.context.outputs.head-branch }}
       fallback-ref: develop
     secrets: inherit
     if: ${{ needs['label-gate'].outputs.run == 'true' }}
   report-result:
     needs:
+    - ci-approval
+    - context
     - label-gate
     - validate
     - eccodes
-    if: ${{ (always() && github.event.workflow_run.conclusion == 'success') && needs['label-gate'].outputs.run == 'true' }}
+    if: ${{ (always() && needs.context.outputs.ci-conclusion == 'success') && needs['label-gate'].outputs.run == 'true' }}
     runs-on: ubuntu-slim
     steps:
     - id: mint
@@ -132,7 +177,7 @@ jobs:
           fi
         done
         gh api -X POST \
-          "/repos/${{ github.repository }}/statuses/${{ github.event.workflow_run.head_sha }}" \
+          "/repos/${{ github.repository }}/statuses/${{ needs.context.outputs.head-sha }}" \
           -f state="$state" \
           -f context='downstream/hpc' \
           -f target_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \

--- a/.github/workflows/trigger-downstream.yml
+++ b/.github/workflows/trigger-downstream.yml
@@ -8,10 +8,42 @@ on:
     - CI
     types:
     - completed
+  pull_request_target:
+    types:
+    - labeled
 concurrency:
-  group: trigger-downstream-runner-${{ github.event.workflow_run.head_sha }}
+  group: trigger-downstream-runner-${{ github.event.workflow_run.head_sha || github.event.pull_request.head.sha }}
   cancel-in-progress: true
 jobs:
+  ci-approval:
+    if: ${{ github.event_name != 'pull_request_target' || github.event.label.name == 'run-downstream-CI' }}
+    runs-on: ubuntu-slim
+    permissions:
+      pull-requests: write
+    steps:
+    - uses: ecmwf/ci-infrastructure/actions/require-ci-approval@main
+  context:
+    needs:
+    - ci-approval
+    runs-on: ubuntu-slim
+    outputs:
+      head-sha: ${{ steps.ctx.outputs.head-sha }}
+      head-branch: ${{ steps.ctx.outputs.head-branch }}
+      ci-conclusion: ${{ steps.ctx.outputs.ci-conclusion }}
+      ci-url: ${{ steps.ctx.outputs.ci-url }}
+      ci-summary: ${{ steps.ctx.outputs.ci-summary }}
+    steps:
+    - id: mint
+      uses: actions/create-github-app-token@v3
+      with:
+        client-id: ${{ secrets.CI_PERMISSIONS_APP_CLIENT_ID }}
+        private-key: ${{ secrets.CI_PERMISSIONS_APP_PRIVATE_KEY }}
+        owner: ${{ github.repository_owner }}
+    - name: Resolve the commit under test
+      id: ctx
+      uses: ecmwf/ci-infrastructure/actions/resolve-dispatch-context@main
+      with:
+        token: ${{ steps.mint.outputs.token }}
   label-gate:
     runs-on: ubuntu-slim
     outputs:
@@ -28,10 +60,13 @@ jobs:
       uses: ecmwf/ci-infrastructure/actions/check-pr-label@main
       with:
         label: run-downstream-CI
-        sha: ${{ github.event.workflow_run.head_sha }}
+        sha: ${{ needs.context.outputs.head-sha }}
         token: ${{ steps.mint.outputs.token }}
+    needs:
+    - ci-approval
+    - context
   validate:
-    if: ${{ (github.event.workflow_run.conclusion == 'success') && needs['label-gate'].outputs.run == 'true' }}
+    if: ${{ (needs.context.outputs.ci-conclusion == 'success') && needs['label-gate'].outputs.run == 'true' }}
     runs-on: ubuntu-slim
     steps:
     - id: mint
@@ -42,15 +77,17 @@ jobs:
         owner: ${{ github.repository_owner }}
     - uses: actions/checkout@v6
       with:
-        ref: ${{ github.event.workflow_run.head_sha }}
+        ref: ${{ needs.context.outputs.head-sha }}
         token: ${{ steps.mint.outputs.token }}
     - uses: ecmwf/ci-infrastructure/actions/validate-generated-workflows@main
       with:
         token: ${{ steps.mint.outputs.token }}
     needs:
+    - ci-approval
+    - context
     - label-gate
   report-start:
-    if: ${{ (github.event.workflow_run.conclusion == 'success') && needs['label-gate'].outputs.run == 'true' }}
+    if: ${{ (needs.context.outputs.ci-conclusion == 'success') && needs['label-gate'].outputs.run == 'true' }}
     runs-on: ubuntu-slim
     steps:
     - id: mint
@@ -64,15 +101,17 @@ jobs:
         GH_TOKEN: ${{ steps.mint.outputs.token }}
       run: |
         gh api -X POST \
-          "/repos/${{ github.repository }}/statuses/${{ github.event.workflow_run.head_sha }}" \
+          "/repos/${{ github.repository }}/statuses/${{ needs.context.outputs.head-sha }}" \
           -f state=pending \
           -f context='downstream/runner' \
           -f target_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
           -f description='Downstream runner tests running'
     needs:
+    - ci-approval
+    - context
     - label-gate
   report-ci-failure:
-    if: ${{ (github.event.workflow_run.conclusion != 'success') && needs['label-gate'].outputs.run == 'true' }}
+    if: ${{ (needs.context.outputs.ci-conclusion != 'success') && needs['label-gate'].outputs.run == 'true' }}
     runs-on: ubuntu-slim
     steps:
     - id: mint
@@ -86,33 +125,39 @@ jobs:
         GH_TOKEN: ${{ steps.mint.outputs.token }}
       run: |
         gh api -X POST \
-          "/repos/${{ github.repository }}/statuses/${{ github.event.workflow_run.head_sha }}" \
+          "/repos/${{ github.repository }}/statuses/${{ needs.context.outputs.head-sha }}" \
           -f state=failure \
           -f context='downstream/runner' \
-          -f target_url="${{ github.event.workflow_run.html_url }}" \
-          -f description='Upstream CI failed; downstream runner not run'
+          -f target_url="${{ needs.context.outputs.ci-url }}" \
+          -f description="${{ needs.context.outputs.ci-summary }}; downstream runner not run"
     needs:
+    - ci-approval
+    - context
     - label-gate
   eccodes:
     name: eccodes
     needs:
+    - ci-approval
+    - context
     - label-gate
     - validate
     uses: ecmwf/eccodes/.github/workflows/cross-repo-trigger.yml@develop
     with:
       from-repo: ${{ github.repository }}
-      from-sha: ${{ github.event.workflow_run.head_sha }}
+      from-sha: ${{ needs.context.outputs.head-sha }}
       from-jobs: '["eckit/build"]'
-      branch: ${{ github.event.workflow_run.head_branch }}
+      branch: ${{ needs.context.outputs.head-branch }}
       fallback-ref: develop
     secrets: inherit
     if: ${{ needs['label-gate'].outputs.run == 'true' }}
   report-result:
     needs:
+    - ci-approval
+    - context
     - label-gate
     - validate
     - eccodes
-    if: ${{ (always() && github.event.workflow_run.conclusion == 'success') && needs['label-gate'].outputs.run == 'true' }}
+    if: ${{ (always() && needs.context.outputs.ci-conclusion == 'success') && needs['label-gate'].outputs.run == 'true' }}
     runs-on: ubuntu-slim
     steps:
     - id: mint
@@ -132,7 +177,7 @@ jobs:
           fi
         done
         gh api -X POST \
-          "/repos/${{ github.repository }}/statuses/${{ github.event.workflow_run.head_sha }}" \
+          "/repos/${{ github.repository }}/statuses/${{ needs.context.outputs.head-sha }}" \
           -f state="$state" \
           -f context='downstream/runner' \
           -f target_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \

--- a/.github/workflows/trigger-downstream.yml
+++ b/.github/workflows/trigger-downstream.yml
@@ -55,6 +55,7 @@ jobs:
       with:
         ref: ${{ needs.context.outputs.head-sha }}
         token: ${{ steps.mint.outputs.token }}
+        allow-unsafe-pr-checkout: true
     - uses: ecmwf/ci-infrastructure/actions/validate-generated-workflows@main
       with:
         token: ${{ steps.mint.outputs.token }}

--- a/.github/workflows/trigger-downstream.yml
+++ b/.github/workflows/trigger-downstream.yml
@@ -8,24 +8,14 @@ on:
     - CI
     types:
     - completed
-  pull_request_target:
-    types:
-    - labeled
 concurrency:
-  group: trigger-downstream-runner-${{ github.event.workflow_run.head_sha || github.event.pull_request.head.sha }}
+  group: trigger-downstream-runner-${{ github.event.workflow_run.head_sha }}
   cancel-in-progress: true
 jobs:
-  ci-approval:
-    if: ${{ github.event_name != 'pull_request_target' || github.event.label.name == 'run-downstream-CI' }}
+  context:
     runs-on: ubuntu-slim
     permissions:
-      pull-requests: write
-    steps:
-    - uses: ecmwf/ci-infrastructure/actions/require-ci-approval@main
-  context:
-    needs:
-    - ci-approval
-    runs-on: ubuntu-slim
+      actions: read
     outputs:
       head-sha: ${{ steps.ctx.outputs.head-sha }}
       head-branch: ${{ steps.ctx.outputs.head-branch }}
@@ -33,37 +23,23 @@ jobs:
       ci-url: ${{ steps.ctx.outputs.ci-url }}
       ci-summary: ${{ steps.ctx.outputs.ci-summary }}
     steps:
-    - id: mint
-      uses: actions/create-github-app-token@v3
-      with:
-        client-id: ${{ secrets.CI_PERMISSIONS_APP_CLIENT_ID }}
-        private-key: ${{ secrets.CI_PERMISSIONS_APP_PRIVATE_KEY }}
-        owner: ${{ github.repository_owner }}
     - name: Resolve the commit under test
       id: ctx
       uses: ecmwf/ci-infrastructure/actions/resolve-dispatch-context@main
-      with:
-        token: ${{ steps.mint.outputs.token }}
   label-gate:
     runs-on: ubuntu-slim
+    permissions:
+      pull-requests: read
     outputs:
       run: ${{ steps.gate.outputs.run }}
     steps:
-    - id: mint
-      uses: actions/create-github-app-token@v3
-      with:
-        client-id: ${{ secrets.CI_PERMISSIONS_APP_CLIENT_ID }}
-        private-key: ${{ secrets.CI_PERMISSIONS_APP_PRIVATE_KEY }}
-        owner: ${{ github.repository_owner }}
     - name: Check the downstream-CI label
       id: gate
       uses: ecmwf/ci-infrastructure/actions/check-pr-label@main
       with:
         label: run-downstream-CI
         sha: ${{ needs.context.outputs.head-sha }}
-        token: ${{ steps.mint.outputs.token }}
     needs:
-    - ci-approval
     - context
   validate:
     if: ${{ (needs.context.outputs.ci-conclusion == 'success') && needs['label-gate'].outputs.run == 'true' }}
@@ -83,22 +59,17 @@ jobs:
       with:
         token: ${{ steps.mint.outputs.token }}
     needs:
-    - ci-approval
     - context
     - label-gate
   report-start:
     if: ${{ (needs.context.outputs.ci-conclusion == 'success') && needs['label-gate'].outputs.run == 'true' }}
     runs-on: ubuntu-slim
+    permissions:
+      statuses: write
     steps:
-    - id: mint
-      uses: actions/create-github-app-token@v3
-      with:
-        client-id: ${{ secrets.CI_PERMISSIONS_APP_CLIENT_ID }}
-        private-key: ${{ secrets.CI_PERMISSIONS_APP_PRIVATE_KEY }}
-        owner: ${{ github.repository_owner }}
     - name: Post pending downstream status
       env:
-        GH_TOKEN: ${{ steps.mint.outputs.token }}
+        GH_TOKEN: ${{ github.token }}
       run: |
         gh api -X POST \
           "/repos/${{ github.repository }}/statuses/${{ needs.context.outputs.head-sha }}" \
@@ -107,22 +78,17 @@ jobs:
           -f target_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
           -f description='Downstream runner tests running'
     needs:
-    - ci-approval
     - context
     - label-gate
   report-ci-failure:
     if: ${{ (needs.context.outputs.ci-conclusion != 'success') && needs['label-gate'].outputs.run == 'true' }}
     runs-on: ubuntu-slim
+    permissions:
+      statuses: write
     steps:
-    - id: mint
-      uses: actions/create-github-app-token@v3
-      with:
-        client-id: ${{ secrets.CI_PERMISSIONS_APP_CLIENT_ID }}
-        private-key: ${{ secrets.CI_PERMISSIONS_APP_PRIVATE_KEY }}
-        owner: ${{ github.repository_owner }}
     - name: Post downstream failure status
       env:
-        GH_TOKEN: ${{ steps.mint.outputs.token }}
+        GH_TOKEN: ${{ github.token }}
       run: |
         gh api -X POST \
           "/repos/${{ github.repository }}/statuses/${{ needs.context.outputs.head-sha }}" \
@@ -131,13 +97,11 @@ jobs:
           -f target_url="${{ needs.context.outputs.ci-url }}" \
           -f description="${{ needs.context.outputs.ci-summary }}; downstream runner not run"
     needs:
-    - ci-approval
     - context
     - label-gate
   eccodes:
     name: eccodes
     needs:
-    - ci-approval
     - context
     - label-gate
     - validate
@@ -152,23 +116,18 @@ jobs:
     if: ${{ needs['label-gate'].outputs.run == 'true' }}
   report-result:
     needs:
-    - ci-approval
     - context
     - label-gate
     - validate
     - eccodes
     if: ${{ (always() && needs.context.outputs.ci-conclusion == 'success') && needs['label-gate'].outputs.run == 'true' }}
     runs-on: ubuntu-slim
+    permissions:
+      statuses: write
     steps:
-    - id: mint
-      uses: actions/create-github-app-token@v3
-      with:
-        client-id: ${{ secrets.CI_PERMISSIONS_APP_CLIENT_ID }}
-        private-key: ${{ secrets.CI_PERMISSIONS_APP_PRIVATE_KEY }}
-        owner: ${{ github.repository_owner }}
     - name: Post final downstream status
       env:
-        GH_TOKEN: ${{ steps.mint.outputs.token }}
+        GH_TOKEN: ${{ github.token }}
       run: |
         state=success
         for r in ${{ needs.validate.result }} ${{ needs.eccodes.result }}; do

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,3 +45,8 @@ repos:
       - id: clang-format
         types_or: [c, c++]
         exclude: 'src/_eckit/_.*\.(h|cpp)'
+
+  - repo: https://github.com/ecmwf/ci-infrastructure
+    rev: 83c6ffdefe118a75d76e6802bf0b8cf27185eaf7
+    hooks:
+      - id: check-ci-approval


### PR DESCRIPTION
Everything the CI rollout has open for this repo, as one pull request instead of a
two-deep stack. Supersedes #337 and #338 — same branch, same commits, no rebase;
GitHub simply refuses to retarget a PR that is part of a stack.

Two changes:

- **Job names come from `_resolved.job-name`.** One name, computed once by
  `resolve-deps`, instead of each workflow spelling out its own
  `${{ matrix.platform }}, ${{ matrix['cxx-compiler'] }}` — which is how the CI
  and cross-repo lanes drift apart.
- **The `approved-for-ci` label is single-use.** `require-ci-approval` now spends
  the label the moment it is honoured, so one approval buys one run and a
  contributor cannot earn approval on a harmless diff and replay it. Adds
  `.github/ci-approval-allowlist.yml` for the legacy workflows that are exempt.

The regenerated `trigger-downstream{,-hpc}.yml` are what actually make downstream
CI green again: the orchestrator now resolves the commit under test through a
`context` job, and `label-gate` uses `github.token` with an explicit
`permissions:` block rather than a minted App token.

### Why downstream CI is red without this

`ci-infrastructure@main` is at `eab560cc`, which changed the rendered orchestrator.
This repo's `develop` still carries the previous render, so the orchestrator's
`validate` job fails, every consumer job is skipped, and `downstream/runner` flips
to failure. Verified by re-running the generator's `--check` against `develop`
(stale) and against this branch (clean).

Merged `develop` in; it touched no CI files, and regenerating produces no delta.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015RsLA9yt5sthqAuLFjBHdm


<!-- PREVIEW-URL_BEGIN -->
🌦️ >> Documentation << 🌦️
https://sites.ecmwf.int/docs/dev-section/eckit/pull-requests/PR-340
<!-- PREVIEW-URL_END -->

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.

